### PR TITLE
Add il rebase command with Claude-assisted conflict resolution. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ iloom finish
 # AI assisted validation, commit, merge steps, as well as loom cleanup (run this from the loom directory)
 # Alias: dn
 
+iloom rebase
+# Rebase current branch on main with Claude-assisted conflict resolution (run this from a loom directory)
+# Options:
+#   -f, --force    - Skip confirmation prompts
+#   -n, --dry-run  - Preview actions without executing
+
 iloom cleanup [identifier...]
 # Remove a loom without merging (safely, by default)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,6 +213,22 @@ program
   })
 
 program
+  .command('rebase')
+  .description('Rebase current branch on main with Claude-assisted conflict resolution')
+  .option('-f, --force', 'Skip confirmation prompts')
+  .option('-n, --dry-run', 'Preview actions without executing')
+  .action(async (options: { force?: boolean; dryRun?: boolean }) => {
+    try {
+      const { RebaseCommand } = await import('./commands/rebase.js')
+      const command = new RebaseCommand()
+      await command.execute(options)
+    } catch (error) {
+      logger.error(`Failed to rebase: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      process.exit(1)
+    }
+  })
+
+program
   .command('spin')
   .alias('ignite')
   .description('Launch Claude with auto-detected workspace context')

--- a/src/commands/rebase.test.ts
+++ b/src/commands/rebase.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { RebaseCommand, WorktreeValidationError } from './rebase.js'
+import type { MergeManager } from '../lib/MergeManager.js'
+import type { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
+import type { SettingsManager } from '../lib/SettingsManager.js'
+import type { GitWorktree } from '../types/worktree.js'
+
+// Mock dependencies
+vi.mock('../lib/MergeManager.js')
+vi.mock('../lib/GitWorktreeManager.js')
+vi.mock('../lib/SettingsManager.js')
+vi.mock('../utils/git.js', () => ({
+	isValidGitRepo: vi.fn(),
+	getRepoRoot: vi.fn(),
+}))
+
+// Import mocked functions
+import { isValidGitRepo, getRepoRoot } from '../utils/git.js'
+
+describe('RebaseCommand', () => {
+	let command: RebaseCommand
+	let mockMergeManager: MergeManager
+	let mockGitWorktreeManager: GitWorktreeManager
+	let mockSettingsManager: SettingsManager
+	let originalCwd: typeof process.cwd
+
+	// Helper to create mock worktree
+	const createMockWorktree = (overrides: Partial<GitWorktree> = {}): GitWorktree => ({
+		path: '/test/worktree',
+		branch: 'feat/issue-123-test',
+		commit: 'abc123',
+		bare: false,
+		detached: false,
+		locked: false,
+		...overrides,
+	})
+
+	beforeEach(() => {
+		// Save original cwd
+		originalCwd = process.cwd
+
+		// Create mock MergeManager
+		mockMergeManager = {
+			rebaseOnMain: vi.fn().mockResolvedValue(undefined),
+		} as unknown as MergeManager
+
+		// Create mock GitWorktreeManager
+		mockGitWorktreeManager = {
+			listWorktrees: vi.fn(),
+			isMainWorktree: vi.fn(),
+		} as unknown as GitWorktreeManager
+
+		// Create mock SettingsManager
+		mockSettingsManager = {
+			loadSettings: vi.fn().mockResolvedValue({}),
+			getProtectedBranches: vi.fn().mockResolvedValue(['main', 'master', 'develop']),
+		} as unknown as SettingsManager
+
+		// Create command with mocked dependencies
+		command = new RebaseCommand(mockMergeManager, mockGitWorktreeManager, mockSettingsManager)
+	})
+
+	afterEach(() => {
+		process.cwd = originalCwd
+	})
+
+	describe('WorktreeValidationError', () => {
+		it('creates error with message and suggestion', () => {
+			const error = new WorktreeValidationError('Test message', 'Test suggestion')
+			expect(error.message).toBe('Test message')
+			expect(error.suggestion).toBe('Test suggestion')
+			expect(error.name).toBe('WorktreeValidationError')
+		})
+	})
+
+	describe('worktree validation', () => {
+		it('throws error when not in a git repository', async () => {
+			process.cwd = vi.fn().mockReturnValue('/tmp/not-a-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(false)
+
+			await expect(command.execute()).rejects.toThrow(WorktreeValidationError)
+			await expect(command.execute()).rejects.toThrow('Not a git repository.')
+		})
+
+		it('throws error when repo root cannot be determined', async () => {
+			process.cwd = vi.fn().mockReturnValue('/test/worktree')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue(null)
+
+			await expect(command.execute()).rejects.toThrow(WorktreeValidationError)
+			await expect(command.execute()).rejects.toThrow('Could not determine repository root.')
+		})
+
+		it('throws error when directory is not a registered worktree', async () => {
+			process.cwd = vi.fn().mockReturnValue('/test/regular-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/regular-repo')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([
+				createMockWorktree({ path: '/other/worktree' }),
+			])
+
+			await expect(command.execute()).rejects.toThrow(WorktreeValidationError)
+			await expect(command.execute()).rejects.toThrow('This directory is not an iloom worktree.')
+		})
+
+		it('throws error when running from main worktree', async () => {
+			const mainWorktree = createMockWorktree({
+				path: '/test/main-repo',
+				branch: 'main',
+				bare: true,
+			})
+			process.cwd = vi.fn().mockReturnValue('/test/main-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/main-repo')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([mainWorktree])
+			vi.mocked(mockGitWorktreeManager.isMainWorktree).mockResolvedValue(true)
+
+			await expect(command.execute()).rejects.toThrow(WorktreeValidationError)
+			await expect(command.execute()).rejects.toThrow('Cannot rebase from the main worktree.')
+		})
+
+		it('works from subdirectory within valid worktree', async () => {
+			const worktree = createMockWorktree({ path: '/test/worktree' })
+			process.cwd = vi.fn().mockReturnValue('/test/worktree/src/components')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/worktree')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([worktree])
+			vi.mocked(mockGitWorktreeManager.isMainWorktree).mockResolvedValue(false)
+
+			await command.execute()
+
+			// Should use repo root, not the subdirectory
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/worktree', {
+				dryRun: false,
+				force: false,
+			})
+		})
+
+		it('provides helpful suggestion for non-git directory', async () => {
+			process.cwd = vi.fn().mockReturnValue('/tmp/not-a-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(false)
+
+			try {
+				await command.execute()
+				expect.fail('Expected WorktreeValidationError')
+			} catch (error) {
+				expect(error).toBeInstanceOf(WorktreeValidationError)
+				expect((error as WorktreeValidationError).suggestion).toContain("'il start'")
+			}
+		})
+
+		it('provides helpful suggestion for regular git repo', async () => {
+			process.cwd = vi.fn().mockReturnValue('/test/regular-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/regular-repo')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([])
+
+			try {
+				await command.execute()
+				expect.fail('Expected WorktreeValidationError')
+			} catch (error) {
+				expect(error).toBeInstanceOf(WorktreeValidationError)
+				expect((error as WorktreeValidationError).suggestion).toContain("'il list'")
+			}
+		})
+
+		it('provides helpful suggestion for main worktree', async () => {
+			const mainWorktree = createMockWorktree({
+				path: '/test/main-repo',
+				branch: 'main',
+			})
+			process.cwd = vi.fn().mockReturnValue('/test/main-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/main-repo')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([mainWorktree])
+			vi.mocked(mockGitWorktreeManager.isMainWorktree).mockResolvedValue(true)
+
+			try {
+				await command.execute()
+				expect.fail('Expected WorktreeValidationError')
+			} catch (error) {
+				expect(error).toBeInstanceOf(WorktreeValidationError)
+				expect((error as WorktreeValidationError).suggestion).toContain('Navigate to a feature worktree')
+			}
+		})
+	})
+
+	describe('execute with valid worktree', () => {
+		beforeEach(() => {
+			// Setup valid worktree context
+			const worktree = createMockWorktree({ path: '/test/worktree' })
+			process.cwd = vi.fn().mockReturnValue('/test/worktree')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/worktree')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([worktree])
+			vi.mocked(mockGitWorktreeManager.isMainWorktree).mockResolvedValue(false)
+		})
+
+		it('calls rebaseOnMain with worktree path', async () => {
+			await command.execute()
+
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/worktree', {
+				dryRun: false,
+				force: false,
+			})
+		})
+
+		it('succeeds when branch is already up to date', async () => {
+			vi.mocked(mockMergeManager.rebaseOnMain).mockResolvedValue(undefined)
+
+			await expect(command.execute()).resolves.toBeUndefined()
+		})
+
+		it('succeeds when rebase completes without conflicts', async () => {
+			vi.mocked(mockMergeManager.rebaseOnMain).mockResolvedValue(undefined)
+
+			await expect(command.execute()).resolves.toBeUndefined()
+		})
+
+		it('handles rebase conflicts by launching Claude (via MergeManager)', async () => {
+			// MergeManager.rebaseOnMain handles Claude conflict resolution internally
+			// It only throws if conflicts cannot be resolved
+			vi.mocked(mockMergeManager.rebaseOnMain).mockResolvedValue(undefined)
+
+			await expect(command.execute()).resolves.toBeUndefined()
+		})
+
+		it('propagates MergeManager errors', async () => {
+			const mergeError = new Error('Rebase failed: merge conflict')
+			vi.mocked(mockMergeManager.rebaseOnMain).mockRejectedValue(mergeError)
+
+			await expect(command.execute()).rejects.toThrow('Rebase failed: merge conflict')
+		})
+
+		it('handles dry-run mode', async () => {
+			await command.execute({ dryRun: true })
+
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/worktree', {
+				dryRun: true,
+				force: false,
+			})
+		})
+
+		it('handles force mode', async () => {
+			await command.execute({ force: true })
+
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/worktree', {
+				dryRun: false,
+				force: true,
+			})
+		})
+
+		it('handles both dry-run and force mode together', async () => {
+			await command.execute({ dryRun: true, force: true })
+
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/worktree', {
+				dryRun: true,
+				force: true,
+			})
+		})
+	})
+
+	describe('edge cases', () => {
+		it('handles worktree with multiple worktrees registered', async () => {
+			const mainWorktree = createMockWorktree({
+				path: '/test/main',
+				branch: 'main',
+			})
+			const featureWorktree = createMockWorktree({
+				path: '/test/feat-issue-123',
+				branch: 'feat/issue-123-feature',
+			})
+			process.cwd = vi.fn().mockReturnValue('/test/feat-issue-123')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/feat-issue-123')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([
+				mainWorktree,
+				featureWorktree,
+			])
+			vi.mocked(mockGitWorktreeManager.isMainWorktree).mockResolvedValue(false)
+
+			await command.execute()
+
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/feat-issue-123', {
+				dryRun: false,
+				force: false,
+			})
+		})
+
+		it('validates before calling rebaseOnMain', async () => {
+			process.cwd = vi.fn().mockReturnValue('/tmp/not-a-repo')
+			vi.mocked(isValidGitRepo).mockResolvedValue(false)
+
+			await expect(command.execute()).rejects.toThrow(WorktreeValidationError)
+
+			// rebaseOnMain should not be called if validation fails
+			expect(mockMergeManager.rebaseOnMain).not.toHaveBeenCalled()
+		})
+
+		it('handles deeply nested subdirectory within worktree', async () => {
+			const worktree = createMockWorktree({ path: '/test/worktree' })
+			process.cwd = vi.fn().mockReturnValue('/test/worktree/src/lib/utils/deep/nested')
+			vi.mocked(isValidGitRepo).mockResolvedValue(true)
+			vi.mocked(getRepoRoot).mockResolvedValue('/test/worktree')
+			vi.mocked(mockGitWorktreeManager.listWorktrees).mockResolvedValue([worktree])
+			vi.mocked(mockGitWorktreeManager.isMainWorktree).mockResolvedValue(false)
+
+			await command.execute()
+
+			expect(mockMergeManager.rebaseOnMain).toHaveBeenCalledWith('/test/worktree', {
+				dryRun: false,
+				force: false,
+			})
+		})
+	})
+})

--- a/src/commands/rebase.ts
+++ b/src/commands/rebase.ts
@@ -1,0 +1,127 @@
+import { logger } from '../utils/logger.js'
+import { MergeManager } from '../lib/MergeManager.js'
+import { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
+import { SettingsManager } from '../lib/SettingsManager.js'
+import { isValidGitRepo, getRepoRoot } from '../utils/git.js'
+import type { MergeOptions } from '../types/index.js'
+
+export interface RebaseOptions {
+	force?: boolean
+	dryRun?: boolean
+}
+
+/**
+ * Error thrown when the rebase command is run from an invalid location
+ */
+export class WorktreeValidationError extends Error {
+	constructor(
+		message: string,
+		public readonly suggestion: string
+	) {
+		super(message)
+		this.name = 'WorktreeValidationError'
+	}
+}
+
+/**
+ * RebaseCommand: Rebase current branch on main with Claude-assisted conflict resolution
+ *
+ * This command:
+ * 1. Validates the current directory is an iloom-managed worktree
+ * 2. Detects the worktree root (supports running from subdirectories)
+ * 3. Delegates to MergeManager.rebaseOnMain() which handles:
+ *    - Checking main branch exists
+ *    - Detecting uncommitted changes (throws if found)
+ *    - Checking if already up-to-date
+ *    - Executing rebase
+ *    - Claude-assisted conflict resolution
+ * 4. Reports success
+ */
+export class RebaseCommand {
+	private mergeManager: MergeManager
+	private gitWorktreeManager: GitWorktreeManager
+	private settingsManager: SettingsManager
+
+	constructor(mergeManager?: MergeManager, gitWorktreeManager?: GitWorktreeManager, settingsManager?: SettingsManager) {
+		this.mergeManager = mergeManager ?? new MergeManager()
+		this.gitWorktreeManager = gitWorktreeManager ?? new GitWorktreeManager()
+		this.settingsManager = settingsManager ?? new SettingsManager()
+	}
+
+	/**
+	 * Validate that the current directory is within an iloom-managed worktree
+	 * Returns the worktree root path if valid
+	 * @throws WorktreeValidationError if validation fails
+	 */
+	private async validateWorktreeContext(): Promise<string> {
+		const currentDir = process.cwd()
+
+		// Step 1: Check if we're in a git repository at all
+		const isGitRepo = await isValidGitRepo(currentDir)
+		if (!isGitRepo) {
+			throw new WorktreeValidationError(
+				'Not a git repository.',
+				"Run 'il rebase' from within an iloom worktree created by 'il start'."
+			)
+		}
+
+		// Step 2: Get the repository root (handles subdirectories)
+		const repoRoot = await getRepoRoot(currentDir)
+		if (!repoRoot) {
+			throw new WorktreeValidationError(
+				'Could not determine repository root.',
+				"Run 'il rebase' from within an iloom worktree created by 'il start'."
+			)
+		}
+
+		// Step 3: Check if this path is a registered git worktree
+		const worktrees = await this.gitWorktreeManager.listWorktrees()
+		const currentWorktree = worktrees.find(wt => wt.path === repoRoot)
+
+		if (!currentWorktree) {
+			throw new WorktreeValidationError(
+				'This directory is not an iloom worktree.',
+				"Run 'il rebase' from within a worktree created by 'il start <issue>'. Use 'il list' to see available worktrees."
+			)
+		}
+
+		// Step 4: Check if this is the main worktree (we shouldn't rebase from main)
+		const isMain = await this.gitWorktreeManager.isMainWorktree(currentWorktree, this.settingsManager)
+		if (isMain) {
+			throw new WorktreeValidationError(
+				'Cannot rebase from the main worktree.',
+				"Navigate to a feature worktree created by 'il start <issue>' and run 'il rebase' from there."
+			)
+		}
+
+		return repoRoot
+	}
+
+	async execute(options: RebaseOptions = {}): Promise<void> {
+		// Step 1: Validate we're in a valid iloom worktree
+		let worktreePath: string
+		try {
+			worktreePath = await this.validateWorktreeContext()
+		} catch (error) {
+			if (error instanceof WorktreeValidationError) {
+				logger.error(error.message)
+				logger.info(error.suggestion)
+				throw error
+			}
+			throw error
+		}
+
+		const mergeOptions: MergeOptions = {
+			dryRun: options.dryRun ?? false,
+			force: options.force ?? false,
+		}
+
+		// MergeManager.rebaseOnMain() handles:
+		// - Checking main branch exists
+		// - Detecting uncommitted changes (throws if found)
+		// - Checking if already up-to-date
+		// - Executing rebase
+		// - Claude-assisted conflict resolution
+		await this.mergeManager.rebaseOnMain(worktreePath, mergeOptions)
+	}
+}

--- a/src/lib/ResourceCleanup.test.ts
+++ b/src/lib/ResourceCleanup.test.ts
@@ -46,6 +46,7 @@ describe('ResourceCleanup', () => {
 		mockGitWorktree.findWorktreeForIssue = vi.fn()
 		mockGitWorktree.findWorktreeForPR = vi.fn()
 		mockGitWorktree.findWorktreeForBranch = vi.fn()
+		mockGitWorktree.isMainWorktree = vi.fn()
 
 		vi.clearAllMocks()
 	})

--- a/src/lib/ResourceCleanup.ts
+++ b/src/lib/ResourceCleanup.ts
@@ -595,7 +595,7 @@ export class ResourceCleanup {
 		const blockers: string[] = []
 
 		// Check if main worktree
-		const isMain = await this.gitWorktree.isMainWorktree(worktree)
+		const isMain = await this.gitWorktree.isMainWorktree(worktree, this.settingsManager)
 		if (isMain) {
 			blockers.push(`Cannot cleanup main worktree: "${worktree.branch}" @ "${worktree.path}"`)
 		}

--- a/tests/lib/ResourceCleanup-database-prefetch.test.ts
+++ b/tests/lib/ResourceCleanup-database-prefetch.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../src/utils/logger.js', () => ({
 vi.mock('../../src/utils/git.js', () => ({
 	executeGitCommand: vi.fn(),
 	findMainWorktreePath: vi.fn().mockResolvedValue('/test/main'),
+	findMainWorktreePathWithSettings: vi.fn().mockResolvedValue('/test/main'),
 	hasUncommittedChanges: vi.fn().mockResolvedValue(false),
 }))
 


### PR DESCRIPTION
Fixes #209

- New `il rebase` command that rebases current branch on main
- Claude AI automatically invoked to resolve conflicts when they occur
- Supports --force and --dry-run options
- Validates user is in an iloom worktree before rebasing
- Helpful error messages when run from wrong location (non-git, non-worktree, main worktree)
- Works correctly from any subdirectory within a valid worktree

Also fixes isMainWorktree() to use configured main branch from settings instead of relying on Git's arbitrary worktree ordering. Fixes #64