### PR TITLE
Include recap context in session summaries

### DIFF
--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -5,30 +5,10 @@
  * Skips config validation for fast startup.
  * Includes filePath in output so extension can set up file watcher.
  */
-import path from 'path'
-import os from 'os'
-import fs from 'fs-extra'
 import type { RecapFile, RecapOutput } from '../mcp/recap-types.js'
 import { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
 import { IdentifierParser } from '../utils/IdentifierParser.js'
-
-const RECAPS_DIR = path.join(os.homedir(), '.config', 'iloom-ai', 'recaps')
-
-/**
- * Reuse MetadataManager.slugifyPath() algorithm
- *
- * Algorithm:
- * 1. Trim trailing slashes
- * 2. Replace all path separators (/ or \) with ___ (triple underscore)
- * 3. Replace any other non-alphanumeric characters (except _ and -) with -
- * 4. Append .json
- */
-function slugifyPath(loomPath: string): string {
-	let slug = loomPath.replace(/[/\\]+$/, '')
-	slug = slug.replace(/[/\\]/g, '___')
-	slug = slug.replace(/[^a-zA-Z0-9_-]/g, '-')
-	return `${slug}.json`
-}
+import { getRecapFilePath, readRecapFile } from '../utils/recap.js'
 
 export interface RecapCommandInput {
 	identifier?: string | undefined // Optional identifier (issue number, PR number, branch name)
@@ -43,19 +23,10 @@ export class RecapCommand {
 	async execute(input: RecapCommandInput): Promise<RecapOutput | void> {
 		// Resolve loom path from identifier or fall back to cwd
 		const loomPath = await this.resolveLoomPath(input.identifier)
-		const filePath = path.join(RECAPS_DIR, slugifyPath(loomPath))
+		const filePath = getRecapFilePath(loomPath)
 
 		// Read recap file (return empty object if not found)
-		let recap: RecapFile = {}
-		try {
-			if (await fs.pathExists(filePath)) {
-				const content = await fs.readFile(filePath, 'utf8')
-				recap = JSON.parse(content) as RecapFile
-			}
-		} catch {
-			// Graceful degradation - return empty recap on read error
-			// This is intentional for fast startup
-		}
+		const recap: RecapFile = (await readRecapFile(loomPath)) ?? {}
 
 		// Build output with filePath for file watching (provide defaults for optional fields)
 		const goal = recap.goal ?? null

--- a/src/lib/PromptTemplateManager.ts
+++ b/src/lib/PromptTemplateManager.ts
@@ -35,6 +35,7 @@ export interface TemplateVariables {
 	BRANCH_NAME?: string      // Branch being finished
 	LOOM_TYPE?: string        // 'issue' or 'pr'
 	COMPACT_SUMMARIES?: string  // Extracted compact summaries from session transcript
+	RECAP_JSON?: string  // JSON recap context for session summary
 	// Draft PR mode variables - mutually exclusive with standard issue mode
 	DRAFT_PR_NUMBER?: number  // PR number for draft PR workflow
 	DRAFT_PR_MODE?: boolean   // True when using github-draft-pr merge mode
@@ -215,6 +216,10 @@ export class PromptTemplateManager {
 			result = result.replace(/COMPACT_SUMMARIES/g, variables.COMPACT_SUMMARIES)
 		}
 
+		if (variables.RECAP_JSON !== undefined) {
+			result = result.replace(/RECAP_JSON/g, variables.RECAP_JSON)
+		}
+
 		// Draft PR mode variable substitution
 		if (variables.DRAFT_PR_NUMBER !== undefined) {
 			result = result.replace(/DRAFT_PR_NUMBER/g, String(variables.DRAFT_PR_NUMBER))
@@ -340,6 +345,17 @@ export class PromptTemplateManager {
 		} else {
 			// Remove the entire conditional block
 			result = result.replace(compactSummariesRegex, '')
+		}
+
+		// Process RECAP_JSON conditionals
+		const recapJsonRegex = /\{\{#IF RECAP_JSON\}\}(.*?)\{\{\/IF RECAP_JSON\}\}/gs
+
+		if (variables.RECAP_JSON !== undefined && variables.RECAP_JSON !== '') {
+			// Include the content, remove the conditional markers
+			result = result.replace(recapJsonRegex, '$1')
+		} else {
+			// Remove the entire conditional block
+			result = result.replace(recapJsonRegex, '')
 		}
 
 		// Process DRAFT_PR_MODE conditionals

--- a/src/lib/SessionSummaryService.test.ts
+++ b/src/lib/SessionSummaryService.test.ts
@@ -15,6 +15,11 @@ vi.mock('../utils/claude-transcript.js', () => ({
 	readSessionContext: vi.fn(),
 }))
 
+// Mock the recap utility
+vi.mock('../utils/recap.js', () => ({
+	readRecapForPrompt: vi.fn(),
+}))
+
 // Mock the IssueManagementProviderFactory
 vi.mock('../mcp/IssueManagementProviderFactory.js', () => ({
 	IssueManagementProviderFactory: {
@@ -30,6 +35,7 @@ vi.mock('../utils/remote.js', () => ({
 // Import mocked modules
 import { launchClaude } from '../utils/claude.js'
 import { readSessionContext } from '../utils/claude-transcript.js'
+import { readRecapForPrompt } from '../utils/recap.js'
 import { IssueManagementProviderFactory } from '../mcp/IssueManagementProviderFactory.js'
 import { hasMultipleRemotes } from '../utils/remote.js'
 
@@ -118,6 +124,9 @@ describe('SessionSummaryService', () => {
 		// Setup transcript mock - returns null by default (no compact summaries)
 		vi.mocked(readSessionContext).mockResolvedValue(null)
 
+		// Setup recap mock - returns empty by default (no recap context)
+		vi.mocked(readRecapForPrompt).mockResolvedValue('')
+
 		// Setup remote mock - defaults to single remote (no fork mode)
 		vi.mocked(hasMultipleRemotes).mockResolvedValue(false)
 
@@ -145,6 +154,7 @@ describe('SessionSummaryService', () => {
 				BRANCH_NAME: 'feat/issue-123__test-feature',
 				LOOM_TYPE: 'issue',
 				COMPACT_SUMMARIES: '',
+				RECAP_JSON: '',
 			})
 
 			// Verify Claude was called
@@ -304,7 +314,29 @@ describe('SessionSummaryService', () => {
 				BRANCH_NAME: 'feat/issue-123__test-feature',
 				LOOM_TYPE: 'issue',
 				COMPACT_SUMMARIES: compactSummary,
+				RECAP_JSON: '',
 			})
+		})
+
+		it('should include recap context in prompt when recap exists', async () => {
+			const recapJson = JSON.stringify(
+				{
+					goal: 'Test goal',
+					entries: [
+						{ id: 'uuid-1', timestamp: '2025-01-01T00:00:00Z', type: 'decision', content: 'Use TypeScript' },
+					],
+				},
+				null,
+				2
+			)
+			vi.mocked(readRecapForPrompt).mockResolvedValue(recapJson)
+
+			await service.generateAndPostSummary(defaultInput)
+
+			expect(readRecapForPrompt).toHaveBeenCalledWith(defaultInput.worktreePath)
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith('session-summary', expect.objectContaining({
+				RECAP_JSON: recapJson,
+			}))
 		})
 
 		it('should work without compact summaries (short sessions)', async () => {

--- a/src/lib/SessionSummaryService.ts
+++ b/src/lib/SessionSummaryService.ts
@@ -11,6 +11,7 @@
 import { logger } from '../utils/logger.js'
 import { launchClaude, generateDeterministicSessionId } from '../utils/claude.js'
 import { readSessionContext } from '../utils/claude-transcript.js'
+import { readRecapForPrompt } from '../utils/recap.js'
 import { PromptTemplateManager } from './PromptTemplateManager.js'
 import { MetadataManager } from './MetadataManager.js'
 import { SettingsManager, type IloomSettings } from './SettingsManager.js'
@@ -92,17 +93,26 @@ export class SessionSummaryService {
 				logger.debug('No compact summaries found in session transcript')
 			}
 
-			// 5. Load and process the session-summary template
+			// 5. Load recap context for summary generation
+			const recapJson = await readRecapForPrompt(input.worktreePath)
+			if (recapJson) {
+				logger.debug(`Found recap context (${recapJson.length} chars)`)
+			} else {
+				logger.debug('No recap context found for this loom')
+			}
+
+			// 6. Load and process the session-summary template
 			const prompt = await this.templateManager.getPrompt('session-summary', {
 				ISSUE_NUMBER: String(input.issueNumber),
 				BRANCH_NAME: input.branchName,
 				LOOM_TYPE: input.loomType,
 				COMPACT_SUMMARIES: compactSummaries ?? '',
+				RECAP_JSON: recapJson,
 			})
 
 			logger.debug('Session summary prompt:\n' + prompt)
 
-			// 6. Invoke Claude headless to generate summary
+			// 7. Invoke Claude headless to generate summary
 			// Use --resume with session ID so Claude knows which conversation to summarize
 			const summaryModel = this.settingsManager.getSummaryModel(settings)
 			const summaryResult = await launchClaude(prompt, {
@@ -118,13 +128,13 @@ export class SessionSummaryService {
 
 			const summary = summaryResult.trim()
 
-			// 7. Skip posting if summary is too short (likely failed generation)
+			// 8. Skip posting if summary is too short (likely failed generation)
 			if (summary.length < 100) {
 				logger.warn('Session summary too short, skipping post')
 				return
 			}
 
-			// 8. Post summary to issue or PR (PR takes priority when prNumber is provided)
+			// 9. Post summary to issue or PR (PR takes priority when prNumber is provided)
 			await this.postSummaryToIssue(input.issueNumber, summary, settings, input.worktreePath, input.prNumber)
 
 			const targetDescription = input.prNumber ? `PR #${input.prNumber}` : 'issue'
@@ -174,17 +184,26 @@ export class SessionSummaryService {
 			logger.debug('No compact summaries found in session transcript')
 		}
 
-		// 4. Load and process the session-summary template
+		// 4. Load recap context for summary generation
+		const recapJson = await readRecapForPrompt(worktreePath)
+		if (recapJson) {
+			logger.debug(`Found recap context (${recapJson.length} chars)`)
+		} else {
+			logger.debug('No recap context found for this loom')
+		}
+
+		// 5. Load and process the session-summary template
 		const prompt = await this.templateManager.getPrompt('session-summary', {
 			ISSUE_NUMBER: issueNumber !== undefined ? String(issueNumber) : '',
 			BRANCH_NAME: branchName,
 			LOOM_TYPE: loomType,
 			COMPACT_SUMMARIES: compactSummaries ?? '',
+			RECAP_JSON: recapJson,
 		})
 
 		logger.debug('Session summary prompt:\n' + prompt)
 
-		// 5. Invoke Claude headless to generate summary
+		// 6. Invoke Claude headless to generate summary
 		const summaryModel = this.settingsManager.getSummaryModel(settings)
 		const summaryResult = await launchClaude(prompt, {
 			headless: true,
@@ -198,7 +217,7 @@ export class SessionSummaryService {
 
 		const summary = summaryResult.trim()
 
-		// 6. Check if summary is too short (likely failed generation)
+		// 7. Check if summary is too short (likely failed generation)
 		if (summary.length < 100) {
 			throw new Error('Session summary too short - generation may have failed')
 		}

--- a/src/utils/recap.ts
+++ b/src/utils/recap.ts
@@ -1,0 +1,77 @@
+import path from 'path'
+import os from 'os'
+import fs from 'fs-extra'
+import type { RecapFile } from '../mcp/recap-types.js'
+import { logger } from './logger.js'
+
+const RECAPS_DIR = path.join(os.homedir(), '.config', 'iloom-ai', 'recaps')
+
+/**
+ * Reuse MetadataManager.slugifyPath() algorithm for recap file naming
+ *
+ * Algorithm:
+ * 1. Trim trailing slashes
+ * 2. Replace all path separators (/ or \) with ___ (triple underscore)
+ * 3. Replace any other non-alphanumeric characters (except _ and -) with -
+ * 4. Append .json
+ */
+export function slugifyRecapPath(loomPath: string): string {
+	let slug = loomPath.replace(/[/\\]+$/, '')
+	slug = slug.replace(/[/\\]/g, '___')
+	slug = slug.replace(/[^a-zA-Z0-9_-]/g, '-')
+	return `${slug}.json`
+}
+
+export function getRecapFilePath(loomPath: string): string {
+	return path.join(RECAPS_DIR, slugifyRecapPath(loomPath))
+}
+
+function hasRecapContent(recap: RecapFile | null): boolean {
+	if (!recap) {
+		return false
+	}
+
+	if (recap.goal) {
+		return true
+	}
+
+	if (recap.complexity) {
+		return true
+	}
+
+	if (recap.entries && recap.entries.length > 0) {
+		return true
+	}
+
+	if (recap.artifacts && recap.artifacts.length > 0) {
+		return true
+	}
+
+	return false
+}
+
+export async function readRecapFile(loomPath: string): Promise<RecapFile | null> {
+	const filePath = getRecapFilePath(loomPath)
+
+	try {
+		if (!(await fs.pathExists(filePath))) {
+			return null
+		}
+
+		const content = await fs.readFile(filePath, 'utf8')
+		return JSON.parse(content) as RecapFile
+	} catch (error) {
+		logger.debug('Failed to read recap file', { filePath, error })
+		return null
+	}
+}
+
+export async function readRecapForPrompt(loomPath: string): Promise<string> {
+	const recap = await readRecapFile(loomPath)
+
+	if (!hasRecapContent(recap)) {
+		return ''
+	}
+
+	return JSON.stringify(recap, null, 2)
+}

--- a/templates/prompts/session-summary-prompt.txt
+++ b/templates/prompts/session-summary-prompt.txt
@@ -22,11 +22,23 @@ COMPACT_SUMMARIES
 ------- END PREVIOUS CONTEXT ------
 {{/IF COMPACT_SUMMARIES}}
 
+{{#IF RECAP_JSON}}
+
+**CRITICAL: How to use the recap below:** The recap is a structured log created during the session (goal, decisions, insights, risks, assumptions). Use it to avoid missing key context. If recap entries conflict with the live conversation or compact summaries, prefer the most recent timestamped information.
+
+## Recap Context - STRUCTURED SESSION LOG
+------- BEGIN RECAP JSON ------
+
+RECAP_JSON
+
+------- END RECAP JSON ------
+{{/IF RECAP_JSON}}
+
 ## Your Task
 
-Reflect on THIS conversation (the one you're currently in){{#IF COMPACT_SUMMARIES}} AND the previous context above (THIS IS VERY IMPORTANT){{/IF COMPACT_SUMMARIES}}, and generate a concise summary focused on:
+Reflect on THIS conversation (the one you're currently in){{#IF COMPACT_SUMMARIES}} AND the previous context above (THIS IS VERY IMPORTANT){{/IF COMPACT_SUMMARIES}}{{#IF RECAP_JSON}} AND the recap context above (THIS IS VERY IMPORTANT){{/IF RECAP_JSON}}, and generate a concise summary focused on:
 
-1. **Key Insights**: What important learnings emerged during implementation{{#IF COMPACT_SUMMARIES}} INCLUDING the previous context above (THIS IS VERY IMPORTANT){{/IF COMPACT_SUMMARIES}}?
+1. **Key Insights**: What important learnings emerged during implementation{{#IF COMPACT_SUMMARIES}} INCLUDING the previous context above (THIS IS VERY IMPORTANT){{/IF COMPACT_SUMMARIES}}{{#IF RECAP_JSON}} AND the recap context above (THIS IS VERY IMPORTANT){{/IF RECAP_JSON}}?
 2. **Decisions Made**: What significant technical decisions were made and why?
 3. **Challenges Encountered**: What obstacles were faced and how were they resolved?
 4. **Mistakes and Corrections**: What mistakes were made and what was learned from them?
@@ -79,4 +91,4 @@ Keep the visible themes section brief (3-5 bullet points, one sentence each). Th
 ## VALIDATION CHECKLIST - FAILING THIS LIST MEANS FAILING THE TASK:
 * Did you ouput ONLY the markdown with no commentary before or after?
 {{#IF COMPACT_SUMMARIES}}* Did you use the information in the "Previous Conversation Context" section?{{/IF COMPACT_SUMMARIES}}
-
+{{#IF RECAP_JSON}}* Did you use the recap context section above?{{/IF RECAP_JSON}}


### PR DESCRIPTION
## Summary
- add recap JSON context to session summary prompts
- share recap file helper between recap command and summary service
- extend summary tests for recap context

## Testing
- corepack pnpm test