### PR TITLE
Move mergeBehavior to shared settings

### DIFF
--- a/.iloom/settings.json
+++ b/.iloom/settings.json
@@ -20,5 +20,8 @@
     "terminal": true,
     "vscode": true
   },
-  "attribution": "on"
+  "attribution": "on",
+  "mergeBehavior": {
+    "mode": "github-draft-pr"
+  }
 }


### PR DESCRIPTION
## Summary
- Moves the `mergeBehavior.mode: "github-draft-pr"` setting from `.iloom/settings.local.json` to `.iloom/settings.json`
- This makes the draft PR workflow a shared team default rather than a personal preference

## Test plan
- [ ] Verify `il start` creates draft PRs as expected
- [ ] Verify settings are correctly loaded from shared config