### PR TITLE
docs(getting-started): rename iloom-issue-reviewer to iloom-code-reviewer

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -314,12 +314,12 @@ Get your Gemini API key from [Google AI Studio](https://aistudio.google.com/apik
 
 **Step 2: Configure the Code Review Agent**
 
-Add the `iloom-issue-reviewer` agent configuration to `.iloom/settings.json`:
+Add the `iloom-code-reviewer` agent configuration to `.iloom/settings.json`:
 
 ```json
 {
   "agents": {
-    "iloom-issue-reviewer": {
+    "iloom-code-reviewer": {
       "providers": {
         "gemini": "gemini-3-pro-preview"
       }


### PR DESCRIPTION
## Summary
- Renames `iloom-issue-reviewer` to `iloom-code-reviewer` in the getting started guide
- Aligns documentation with the current agent naming convention

## Test plan
- [x] Verify the agent name is consistent with the actual configuration