### PR TITLE
feat(review): add IMPLEMENTATION artifact type to artifact reviewer

### DIFF
--- a/templates/agents/iloom-artifact-reviewer.md
+++ b/templates/agents/iloom-artifact-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: iloom-artifact-reviewer
-description: Use this agent to review workflow artifacts (enhancements, analyses, plans) before posting. The agent validates quality and completeness against artifact-specific criteria and provides actionable feedback for improvements.\n\nExamples:\n<example>\nContext: Orchestrator wants to review an enhancement before posting\nuser: "Review this ENHANCEMENT artifact for issue #42: [enhancement content]"\nassistant: "I'll analyze this enhancement against quality criteria and provide feedback."\n<commentary>\nThe orchestrator is requesting artifact review before posting, so use the iloom-artifact-reviewer agent.\n</commentary>\n</example>\n<example>\nContext: Orchestrator wants to review a plan before posting\nuser: "Review this PLAN artifact for issue #78: [plan content]"\nassistant: "I'll evaluate this implementation plan for actionability, specificity, and completeness."\n<commentary>\nThe plan needs quality review before posting, so use the iloom-artifact-reviewer agent.\n</commentary>\n</example>
+description: Use this agent to review workflow artifacts (enhancements, analyses, plans, implementations) before posting. The agent validates quality and completeness against artifact-specific criteria and provides actionable feedback for improvements.\n\nExamples:\n<example>\nContext: Orchestrator wants to review an enhancement before posting\nuser: "Review this ENHANCEMENT artifact for issue #42: [enhancement content]"\nassistant: "I'll analyze this enhancement against quality criteria and provide feedback."\n<commentary>\nThe orchestrator is requesting artifact review before posting, so use the iloom-artifact-reviewer agent.\n</commentary>\n</example>\n<example>\nContext: Orchestrator wants to review a plan before posting\nuser: "Review this PLAN artifact for issue #78: [plan content]"\nassistant: "I'll evaluate this implementation plan for actionability, specificity, and completeness."\n<commentary>\nThe plan needs quality review before posting, so use the iloom-artifact-reviewer agent.\n</commentary>\n</example>\n<example>\nContext: Orchestrator wants to verify implementation matches the plan\nuser: "Review this IMPLEMENTATION artifact for issue #55: [implementer output]"\nassistant: "I'll verify the implementation covers all planned steps and flag any deviations."\n<commentary>\nThe orchestrator wants to check plan-to-implementation alignment, so use the iloom-artifact-reviewer agent.\n</commentary>\n</example>
 model: opus
 color: yellow
 ---
@@ -29,13 +29,15 @@ Codex review configured with model: {{ARTIFACT_REVIEW_CODEX_MODEL}}
 
 ## What to Look For
 
-Identify the artifact type from context (ENHANCEMENT, ANALYSIS, or PLAN) and focus your review accordingly. Be skeptical - flag anything that seems wrong or suspicious.
+Identify the artifact type from context (ENHANCEMENT, ANALYSIS, PLAN, or IMPLEMENTATION) and focus your review accordingly. Be skeptical - flag anything that seems wrong or suspicious.
 
 **Enhancement artifacts:** You are reviewing an enhanced issue specification written by an AI agent. The original issue is provided for context. Evaluate it for: accuracy (does it correctly capture what the user asked for?), completeness (does it cover the full issue scope without inventing requirements?), and any misunderstandings or additions that go beyond the original request.
 
 **Analysis artifacts:** You are reviewing a technical analysis written by an AI agent. The issue it analyzed is provided for context. Evaluate it for: technical accuracy (are file references, code excerpts, and API/library claims correct?), correctness (does the reasoning hold up? are conclusions supported by evidence?), and any risks or flaws (factual errors, logical gaps, important things overlooked).
 
 **Plan artifacts:** You are reviewing an implementation plan written by an AI agent. The issue and any prior analysis are provided for context. Evaluate it for: technical accuracy (are file paths and line numbers plausible?), correctness (will the approach actually work?), completeness (does it cover the full issue scope?), and any risks or flaws (missing steps, architectural problems, things that would cause implementation to fail).
+
+**Implementation artifacts:** You are reviewing the output summary of an implementation agent. The plan it was executing against is provided for context. This is NOT a code review — the code reviewer agent handles code quality, security, and style. Your job is strictly plan-to-implementation alignment: coverage (were all planned steps completed?), deviations (did the implementer skip, alter, or add steps not in the plan?), and completeness (are there planned items that appear unaddressed?). Flag any gaps or unexplained deviations. Do not comment on code quality, naming, patterns, or style.
 
 Do not manufacture issues - if the artifact is good, say so.
 
@@ -78,7 +80,7 @@ Return your review in this exact format:
 
 ### Step 1 - Parse Input
 
-1. Extract the artifact type from the context (ENHANCEMENT, ANALYSIS, or PLAN)
+1. Extract the artifact type from the context (ENHANCEMENT, ANALYSIS, PLAN, or IMPLEMENTATION)
 2. Extract the artifact content to review
 3. Identify the issue number for context
 
@@ -162,7 +164,7 @@ Present your results in the following format:
 
 ### Step 1 - Parse Input
 
-1. Extract the artifact type from the context (ENHANCEMENT, ANALYSIS, or PLAN)
+1. Extract the artifact type from the context (ENHANCEMENT, ANALYSIS, PLAN, or IMPLEMENTATION)
 2. Extract the artifact content to review
 3. Identify the issue number for context
 

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -813,6 +813,31 @@ Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
    - Call `mcp__recap__add_artifact` again with the same `primaryUrl` but updated `description` reflecting the completed state (this replaces the original "in progress" artifact)
 
 5. Mark todo #16 as completed
+{{#if IMPLEMENTER_REVIEW_ENABLED}}
+{{#if ARTIFACT_REVIEW_ENABLED}}
+5.5. Artifact Review (Implementation):
+   - The implementer output should be reviewed for plan alignment before code review
+   - Invoke: @agent-iloom-artifact-reviewer with context: "Review this IMPLEMENTATION artifact for issue #{{ISSUE_NUMBER}}: [IMPLEMENTER_OUTPUT]. The plan it was executing: [PLAN_CONTENT]"
+   - Wait for review results
+   - If review suggests improvements:
+{{#if ONE_SHOT_MODE}}
+     a. If verdict is SUGGEST_IMPROVEMENTS:
+        - Log: "Artifact review suggests improvements: [summary]"
+        - Re-invoke @agent-iloom-issue-implementer with: "Apply these specific improvements to address plan gaps: [REVIEWER_FEEDBACK]"
+        - After update, proceed to next step (do not re-review)
+     b. If verdict is RECOMMEND_REGENERATION:
+        - Log: "Artifact review recommends regeneration: [summary]"
+        - Re-run @agent-iloom-issue-implementer from scratch with the reviewer's feedback
+{{else}}
+     a. Present review findings to user
+     b. Use AskUserQuestion tool: "The artifact reviewer found plan alignment issues. How would you like to proceed?"
+        - Options: "Accept implementation as-is", "Address feedback", "Manually fix"
+     c. If address feedback: Re-run @agent-iloom-issue-implementer with feedback
+     d. If manually fix: Wait for user edits, then proceed
+{{/if}}
+   - If review approves: Proceed to STEP 5 - Review Phase
+{{/if}}
+{{/if}}
 6. After implementation completes, proceed to STEP 5 - Review Phase (do NOT skip to Post-Workflow Help)
 
 If workflow plan determined SKIP_IMPLEMENTATION:

--- a/templates/prompts/regular-prompt.txt
+++ b/templates/prompts/regular-prompt.txt
@@ -672,6 +672,31 @@ Execute combined analyze-and-plan agent:
 2. Display implementation summary to user
    - If implementation revealed unexpected issues or required pivots, use `recap.add_entry` to log them (type: "insight" or "risk")
 3. Mark todo #17 as completed
+{{#if IMPLEMENTER_REVIEW_ENABLED}}
+{{#if ARTIFACT_REVIEW_ENABLED}}
+3.5. Artifact Review (Implementation):
+   - The implementer output should be reviewed for plan alignment before code review
+   - Invoke: @agent-iloom-artifact-reviewer with context: "Review this IMPLEMENTATION artifact: [IMPLEMENTER_OUTPUT]. The plan it was executing: [PLAN_CONTENT]"
+   - Wait for review results
+   - If review suggests improvements:
+{{#if ONE_SHOT_MODE}}
+     a. If verdict is SUGGEST_IMPROVEMENTS:
+        - Log: "Artifact review suggests improvements: [summary]"
+        - Re-invoke @agent-iloom-issue-implementer with: "Apply these specific improvements to address plan gaps: [REVIEWER_FEEDBACK]"
+        - After update, proceed to next step (do not re-review)
+     b. If verdict is RECOMMEND_REGENERATION:
+        - Log: "Artifact review recommends regeneration: [summary]"
+        - Re-run @agent-iloom-issue-implementer from scratch with the reviewer's feedback
+{{else}}
+     a. Present review findings to user
+     b. Use AskUserQuestion tool: "The artifact reviewer found plan alignment issues. How would you like to proceed?"
+        - Options: "Accept implementation as-is", "Address feedback", "Manually fix"
+     c. If address feedback: Re-run @agent-iloom-issue-implementer with feedback
+     d. If manually fix: Wait for user edits, then proceed
+{{/if}}
+   - If review approves: Proceed to STEP 5.5 - Review Phase
+{{/if}}
+{{/if}}
 4. After implementation completes, proceed to STEP 5.5 - Review Phase (do NOT skip to Post-Workflow Help)
 
 ---


### PR DESCRIPTION
## Summary
- Add IMPLEMENTATION as a 4th artifact type in the artifact reviewer agent
- Review criteria is strictly plan-to-implementation alignment (coverage, deviations, completeness) — explicitly not code review
- Add detailed workflow sections (step 5.5 / 3.5) in issue-prompt.txt and regular-prompt.txt so the implementer artifact review actually executes between implementation and code review
- pr-prompt.txt already had the detailed section from #567

## Test plan
- [x] `pnpm build` succeeds
- [ ] Test with `iloom-issue-implementer` review enabled in settings