### PR TITLE
fix(cleanup): delete metadata files during worktree cleanup

### DIFF
--- a/src/lib/ResourceCleanup.test.ts
+++ b/src/lib/ResourceCleanup.test.ts
@@ -152,13 +152,14 @@ describe('ResourceCleanup', () => {
 
 			expect(result.success).toBe(true)
 			expect(result.errors).toHaveLength(0)
-			expect(result.operations).toHaveLength(5) // dev-server, worktree, recap, branch, database
+			expect(result.operations).toHaveLength(6) // dev-server, worktree, recap, branch, database, metadata
 			expect(result.operations[0]?.type).toBe('dev-server')
 			expect(result.operations[0]?.success).toBe(true)
 			expect(result.operations[1]?.type).toBe('worktree')
 			expect(result.operations[2]?.type).toBe('recap')
 			expect(result.operations[3]?.type).toBe('branch')
 			expect(result.operations[4]?.type).toBe('database')
+			expect(result.operations[5]?.type).toBe('metadata')
 		})
 
 		it('should pre-fetch merge target BEFORE worktree deletion (bug fix for issue #328)', async () => {
@@ -331,7 +332,7 @@ describe('ResourceCleanup', () => {
 				keepDatabase: true,
 			})
 
-			expect(result.operations).toHaveLength(3) // dev-server check + worktree removal + recap archival
+			expect(result.operations).toHaveLength(4) // dev-server check + worktree removal + recap archival + metadata
 			expect(result.operations.every(op => 'type' in op)).toBe(true)
 			expect(result.operations.every(op => 'success' in op)).toBe(true)
 			expect(result.operations.every(op => 'message' in op)).toBe(true)

--- a/src/lib/ResourceCleanup.ts
+++ b/src/lib/ResourceCleanup.ts
@@ -458,6 +458,37 @@ export class ResourceCleanup {
 			}
 		}
 
+		// Step 7: Delete metadata file
+		if (worktree) {
+			if (options.dryRun) {
+				operations.push({
+					type: 'metadata',
+					success: true,
+					message: `[DRY RUN] Would delete metadata for worktree: ${worktree.path}`,
+				})
+			} else {
+				try {
+					await this.metadataManager.deleteMetadata(worktree.path)
+					getLogger().info(`Metadata deleted for worktree: ${worktree.path}`)
+					operations.push({
+						type: 'metadata',
+						success: true,
+						message: 'Metadata deleted',
+					})
+				} catch (error) {
+					const err = error instanceof Error ? error : new Error(String(error))
+					errors.push(err)
+					getLogger().warn(`Metadata deletion failed: ${err.message}`)
+					operations.push({
+						type: 'metadata',
+						success: false,
+						message: 'Metadata deletion failed (non-fatal)',
+						error: err.message,
+					})
+				}
+			}
+		}
+
 		// Calculate overall success
 		const success = errors.length === 0
 

--- a/src/types/cleanup.ts
+++ b/src/types/cleanup.ts
@@ -43,7 +43,7 @@ export interface CleanupResult {
  */
 export interface OperationResult {
 	/** Type of operation performed */
-	type: 'dev-server' | 'worktree' | 'branch' | 'database' | 'cli-symlinks' | 'recap'
+	type: 'dev-server' | 'worktree' | 'branch' | 'database' | 'cli-symlinks' | 'recap' | 'metadata'
 	/** Whether operation succeeded */
 	success: boolean
 	/** Human-readable message */


### PR DESCRIPTION
## Summary
- `ResourceCleanup.cleanupWorktree()` was missing a step to delete metadata files from `~/.config/iloom-ai/looms/`, leaving orphaned metadata after `il cleanup`
- Added Step 7 that calls `metadataManager.deleteMetadata()` after database cleanup, with dry-run support and non-fatal error handling
- Added `'metadata'` to the `OperationResult.type` union in cleanup types
- Updated test assertions for operation counts to include the new metadata operation

## Test plan
- [x] All 89 ResourceCleanup tests pass (56 in main + 33 in supplementary test files)
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)