### PR TITLE
fix(draft-pr): target parent branch instead of main for child looms

### DIFF
--- a/src/lib/LoomManager.ts
+++ b/src/lib/LoomManager.ts
@@ -285,11 +285,14 @@ export class LoomManager {
         }
 
         // Create draft PR
+        // For child looms, target the parent branch; otherwise use the configured main branch
+        const draftBaseBranch = input.parentLoom?.branchName ?? settingsData.mainBranch ?? 'main'
         getLogger().info('Creating draft PR...')
         const prResult = await prManager.createDraftPR(
           branchName,
           prTitle,
           prBody,
+          draftBaseBranch,
           worktreePath
         )
 

--- a/src/lib/PRManager.ts
+++ b/src/lib/PRManager.ts
@@ -370,6 +370,7 @@ Start your response immediately with the PR body text.
 	 * @param branchName - Branch to create PR from (used as --head)
 	 * @param title - PR title
 	 * @param body - PR body
+	 * @param baseBranch - Base branch to target (used as --base)
 	 * @param cwd - Working directory
 	 * @returns PR URL and number
 	 */
@@ -377,6 +378,7 @@ Start your response immediately with the PR body text.
 		branchName: string,
 		title: string,
 		body: string,
+		baseBranch: string,
 		cwd?: string
 	): Promise<{ url: string; number: number }> {
 		try {
@@ -399,8 +401,7 @@ Start your response immediately with the PR body text.
 			}
 
 			// Build gh pr create command with --draft flag
-			// Omit --base to let GitHub use the repository's default branch (main, master, etc.)
-			const args = ['pr', 'create', '--head', headValue, '--title', title, '--body', body, '--draft']
+			const args = ['pr', 'create', '--head', headValue, '--title', title, '--body', body, '--base', baseBranch, '--draft']
 
 			// If target remote is not 'origin', we need to specify the repo
 			if (targetRemote !== 'origin') {


### PR DESCRIPTION
## Summary
- Draft PRs created during `il start` for child looms were incorrectly targeting the repository default branch (main) instead of the parent loom's branch
- Added `baseBranch` parameter to `PRManager.createDraftPR()` and included `--base` flag in the `gh pr create` args (matching how `createPR()` already works)
- `LoomManager.createIloom()` now computes the correct base branch: parent branch for child looms, configured `mainBranch` for regular looms

## Test plan
- [x] Updated existing draft PR test assertions to verify `baseBranch` parameter is passed
- [x] Added new test: child loom draft PR targets parent branch instead of main
- [x] All 3800 tests pass