### PR TITLE
BeadsManager.init() fails on re-run when Beads database already exists

### DIFF
--- a/src/lib/BeadsManager.test.ts
+++ b/src/lib/BeadsManager.test.ts
@@ -24,6 +24,7 @@ vi.mock('../utils/logger.js', () => ({
 }))
 
 import { promptConfirmation, isInteractiveEnvironment } from '../utils/prompt.js'
+import { logger } from '../utils/logger.js'
 
 describe('BeadsManager', () => {
 	let beadsManager: BeadsManager
@@ -208,6 +209,54 @@ describe('BeadsManager', () => {
 
 			await expect(beadsManager.init()).rejects.toThrow(BeadsError)
 		})
+
+		it('should succeed silently when beads is already initialized', async () => {
+			const error = new Error('bd init failed') as Error & { stderr: string; exitCode: number }
+			error.stderr = 'This workspace is already initialized.'
+			error.exitCode = 1
+			vi.mocked(execa).mockRejectedValueOnce(error)
+
+			await expect(beadsManager.init()).resolves.toBeUndefined()
+			expect(logger.debug).toHaveBeenCalledWith('Beads already initialized, skipping')
+		})
+
+		it('should re-throw non-"already initialized" BeadsErrors', async () => {
+			const error = new Error('bd init failed') as Error & { stderr: string; exitCode: number }
+			error.stderr = 'Permission denied: /some/path'
+			error.exitCode = 1
+			vi.mocked(execa).mockRejectedValueOnce(error)
+
+			await expect(beadsManager.init()).rejects.toThrow(BeadsError)
+			await expect(
+				// Need to re-mock since the previous call consumed it
+				(async () => {
+					const err = new Error('bd init failed') as Error & { stderr: string; exitCode: number }
+					err.stderr = 'Permission denied: /some/path'
+					err.exitCode = 1
+					vi.mocked(execa).mockRejectedValueOnce(err)
+					return beadsManager.init()
+				})()
+			).rejects.toThrow('Permission denied')
+		})
+
+		it('should re-throw errors that are not BeadsError instances', async () => {
+			// Simulate an unexpected error type (not an ExecaError with exitCode)
+			vi.mocked(execa).mockRejectedValueOnce(new TypeError('unexpected type error'))
+
+			// Non-execa errors are re-thrown without wrapping in BeadsError
+			await expect(beadsManager.init()).rejects.toThrow(TypeError)
+			vi.mocked(execa).mockRejectedValueOnce(new TypeError('unexpected type error'))
+			await expect(beadsManager.init()).rejects.toThrow('unexpected type error')
+		})
+
+		it('should handle stderr containing "already initialized" anywhere in the message', async () => {
+			const error = new Error('bd init failed') as Error & { stderr: string; exitCode: number }
+			error.stderr = 'Found existing database: /path/to/beads.db\n\nThis workspace is already initialized.\n\nTo use the existing database...'
+			error.exitCode = 1
+			vi.mocked(execa).mockRejectedValueOnce(error)
+
+			await expect(beadsManager.init()).resolves.toBeUndefined()
+		})
 	})
 
 	describe('create', () => {
@@ -288,7 +337,11 @@ describe('BeadsManager', () => {
 		})
 
 		it('should throw BeadsError when output is not valid JSON', async () => {
-			vi.mocked(execa).mockResolvedValue({
+			vi.mocked(execa).mockResolvedValueOnce({
+				stdout: 'not json',
+				stderr: '',
+			} as never)
+			vi.mocked(execa).mockResolvedValueOnce({
 				stdout: 'not json',
 				stderr: '',
 			} as never)
@@ -358,7 +411,7 @@ describe('BeadsManager', () => {
 
 			await beadsManager.ready()
 
-			const callArgs = vi.mocked(execa).mock.calls[0]
+			const callArgs = vi.mocked(execa).mock.calls[0] as unknown as [string, string[], Record<string, unknown>]
 			expect(callArgs[2]).toEqual(
 				expect.objectContaining({
 					env: expect.objectContaining({
@@ -371,15 +424,15 @@ describe('BeadsManager', () => {
 
 		it('should only pass allowed environment variables to bd subprocess', async () => {
 			// Set a secret env var that should NOT be passed through
-			process.env.SECRET_API_KEY = 'super-secret'
-			process.env.BD_CUSTOM = 'bd-value'
+			vi.stubEnv('SECRET_API_KEY', 'super-secret')
+			vi.stubEnv('BD_CUSTOM', 'bd-value')
 
 			vi.mocked(execa).mockResolvedValueOnce({ stdout: '[]', stderr: '' } as never)
 
 			await beadsManager.ready()
 
-			const callArgs = vi.mocked(execa).mock.calls[0]
-			const env = (callArgs[2] as { env: Record<string, string> }).env
+			const callArgs = vi.mocked(execa).mock.calls[0] as unknown as [string, string[], { env: Record<string, string> }]
+			const env = callArgs[2].env
 
 			// Should NOT include arbitrary env vars
 			expect(env).not.toHaveProperty('SECRET_API_KEY')
@@ -388,10 +441,6 @@ describe('BeadsManager', () => {
 			// Should include required vars
 			expect(env.BEADS_DIR).toBe(beadsManager.getBeadsDir())
 			expect(env.BEADS_NO_DAEMON).toBe('1')
-
-			// Clean up
-			delete process.env.SECRET_API_KEY
-			delete process.env.BD_CUSTOM
 		})
 	})
 
@@ -417,7 +466,11 @@ describe('BeadsManager', () => {
 		})
 
 		it('should throw BeadsError when output is not valid JSON', async () => {
-			vi.mocked(execa).mockResolvedValue({
+			vi.mocked(execa).mockResolvedValueOnce({
+				stdout: 'not json',
+				stderr: '',
+			} as never)
+			vi.mocked(execa).mockResolvedValueOnce({
 				stdout: 'not json',
 				stderr: '',
 			} as never)

--- a/src/lib/BeadsManager.ts
+++ b/src/lib/BeadsManager.ts
@@ -4,7 +4,15 @@ import os from 'os'
 import { execa, type ExecaError } from 'execa'
 import { logger } from '../utils/logger.js'
 import { promptConfirmation, isInteractiveEnvironment } from '../utils/prompt.js'
-import type { SwarmSettings } from './SettingsManager.js'
+
+/**
+ * Subset of SwarmSettings used by BeadsManager.
+ * Defined locally to avoid coupling to the full SwarmSettings schema
+ * which lives in SettingsManager and may not be present on all branches.
+ */
+interface BeadsManagerSettings {
+	beadsDir?: string
+}
 
 /**
  * Error class for Beads CLI failures
@@ -57,7 +65,7 @@ export class BeadsManager {
 
 	constructor(
 		private readonly projectPath: string,
-		swarmSettings?: Partial<SwarmSettings>,
+		swarmSettings?: Partial<BeadsManagerSettings>,
 	) {
 		const baseDir = swarmSettings?.beadsDir ?? '~/.config/iloom-ai/beads'
 		const resolvedBaseDir = baseDir.startsWith('~')
@@ -161,19 +169,28 @@ export class BeadsManager {
 
 	/**
 	 * Initialize Beads for this project.
-	 * Idempotent - safe to re-run.
+	 * Idempotent - safe to re-run. If the database already exists,
+	 * the "already initialized" error is caught and treated as success.
 	 *
-	 * @throws BeadsError if init fails
+	 * @throws BeadsError if init fails for reasons other than already being initialized
 	 */
 	async init(): Promise<void> {
 		logger.debug('Initializing Beads', { beadsDir: this.beadsDir, projectPath: this.projectPath })
 
-		await this.execBd([
-			'init',
-			'--quiet',
-			'--skip-hooks',
-			'--skip-merge-driver',
-		], { cwd: this.projectPath })
+		try {
+			await this.execBd([
+				'init',
+				'--quiet',
+				'--skip-hooks',
+				'--skip-merge-driver',
+			], { cwd: this.projectPath })
+		} catch (error) {
+			if (error instanceof BeadsError && error.stderr.includes('already initialized')) {
+				logger.debug('Beads already initialized, skipping')
+				return
+			}
+			throw error
+		}
 
 		logger.debug('Beads initialized successfully')
 	}
@@ -329,13 +346,16 @@ export class BeadsManager {
 			})
 			return { stdout: result.stdout, stderr: result.stderr }
 		} catch (error) {
-			const execaError = error as ExecaError
-			const stderr = execaError.stderr ?? execaError.message ?? 'Unknown Beads error'
-			throw new BeadsError(
-				`Beads command failed: bd ${args.join(' ')}: ${stderr}`,
-				execaError.exitCode,
-				stderr,
-			)
+			if (error instanceof Error && 'exitCode' in error) {
+				const execaError = error as ExecaError
+				const stderr = execaError.stderr ?? execaError.message ?? 'Unknown Beads error'
+				throw new BeadsError(
+					`Beads command failed: bd ${args.join(' ')}: ${stderr}`,
+					execaError.exitCode,
+					stderr,
+				)
+			}
+			throw error
 		}
 	}
 


### PR DESCRIPTION
Fixes #571

## BeadsManager.init() fails on re-run when Beads database already exists

## Bug

When re-using an epic loom (e.g. running `il start` on an epic that was previously started), `BeadsManager.init()` fails because `bd init` exits with an error when the Beads database already exists:

```
⚠ Found existing database: /Users/adam/.config/iloom-ai/beads/5a3edb9365e0/beads.db

This workspace is already initialized.

To use the existing database:
  Just run bd commands normally (e.g., bd list)

To completely reinitialize (data loss warning):
  rm -rf /Users/adam/.config/iloom-ai/beads/5a3edb9365e0 && bd init --prefix

Aborting.
```

## Expected Behavior

`init()` should be idempotent - if the database already exists, it should skip initialization and continue normally. The docstring even says "Idempotent - safe to re-run" but the underlying `bd init` command doesn't support that.

## Fix

In `BeadsManager.init()`, catch the "already initialized" error from `bd init` and treat it as a success. Something like:

```typescript
async init(): Promise<void> {
    try {
        await this.execBd(['init', '--quiet', '--skip-hooks', '--skip-merge-driver'], { cwd: this.projectPath })
    } catch (error) {
        if (error instanceof BeadsError && error.stderr.includes('already initialized')) {
            logger.debug('Beads already initialized, skipping')
        } else {
            throw error
        }
    }
    await this.execBd(['config', 'set', 'beads.role', 'maintainer'])
}
```

## Prior Implementation

A reviewed and tested implementation exists on branch `temp/issue-571-implementation`. The implementing agent should:

1. Pull the changes from `temp/issue-571-implementation` (commit `dcf442b`) and manually implement them  - don't cherry pick
2. The branch contains:
   - `src/lib/BeadsManager.ts` - Full BeadsManager class with the idempotent `init()` fix applied
   - `src/lib/BeadsManager.test.ts` - Comprehensive tests including 4 tests for the idempotent init behavior
3. All tests pass (3829/3829), typecheck, lint, and build are green
4. The temp branch can be deleted after the changes are incorporated

---
*This PR was created automatically by iloom.*