### PR TITLE
feat: export ILOOM_LOOM and ILOOM_COLOR_HEX env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Each loom is a fully isolated container for your work:
 
 *   **Environment Variables:** Each loom has its own environment files (`.env`, `.env.local`, `.env.development`, `.env.development.local`). Uses `development` by default, override with `DOTENV_FLOW_NODE_ENV`. See [Secret Storage Limitations](#multi-language-project-support) for frameworks with encrypted credentials.
 
+    When inside a loom shell (`il shell`), the following environment variables are automatically set:
+
+    | Variable | Description | Example |
+    |----------|-------------|---------|
+    | `ILOOM_LOOM` | Loom identifier for PS1 customization | `issue-87` |
+    | `ILOOM_COLOR_HEX` | Hex color assigned to this loom (if available) | `#dcebff` |
+
+    `ILOOM_COLOR_HEX` is useful for downstream tools that want to visually distinguish looms. For example, a Vite app can read it via `import.meta.env.VITE_ILOOM_COLOR_HEX` to tint the UI. See [Vite Integration Guide](docs/vite-iloom-color.md) for details.
+
 *   **Unique Runtime:**
     
     *   **Web Apps:** Runs on a deterministic port (e.g., base port 3000 + issue #25 = 3025).

--- a/docs/vite-iloom-color.md
+++ b/docs/vite-iloom-color.md
@@ -1,0 +1,101 @@
+# Using ILOOM_COLOR_HEX in a Vite App
+
+When you run a dev server inside a loom shell (`il shell`), the `ILOOM_COLOR_HEX` environment variable is automatically set to the hex color assigned to that loom (e.g., `#dcebff`). This lets your app visually distinguish which loom it's running in.
+
+## Setup
+
+### 1. Prefix the variable for Vite
+
+Vite only exposes env vars that start with `VITE_`. Add a `.env.local` (or use your existing one) in the project root:
+
+```bash
+# .env.local
+VITE_ILOOM_COLOR_HEX=$ILOOM_COLOR_HEX
+```
+
+Or, if you use `il shell` and then start the dev server manually, you can set it inline:
+
+```bash
+VITE_ILOOM_COLOR_HEX=$ILOOM_COLOR_HEX pnpm dev
+```
+
+### 2. Access it in your app
+
+```ts
+// src/main.ts (or any client-side file)
+const loomColor = import.meta.env.VITE_ILOOM_COLOR_HEX
+
+if (loomColor) {
+  document.documentElement.style.setProperty('--loom-color', loomColor)
+}
+```
+
+### 3. Use the CSS variable
+
+```css
+/* src/styles.css */
+:root {
+  --loom-color: transparent; /* fallback when not in a loom */
+}
+
+body {
+  border-top: 4px solid var(--loom-color);
+}
+```
+
+## Alternative: Use `define` in vite.config.ts
+
+If you don't want an extra `.env.local` entry, you can inject the value at build time:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  define: {
+    __ILOOM_COLOR_HEX__: JSON.stringify(process.env.ILOOM_COLOR_HEX ?? ''),
+  },
+})
+```
+
+Then in your app:
+
+```ts
+declare const __ILOOM_COLOR_HEX__: string
+
+if (__ILOOM_COLOR_HEX__) {
+  document.documentElement.style.setProperty('--loom-color', __ILOOM_COLOR_HEX__)
+}
+```
+
+## React Example
+
+```tsx
+// src/components/LoomIndicator.tsx
+function LoomIndicator() {
+  const color = import.meta.env.VITE_ILOOM_COLOR_HEX
+  if (!color) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 4,
+        backgroundColor: color,
+        zIndex: 9999,
+      }}
+    />
+  )
+}
+```
+
+## How It Works
+
+1. `il shell <issue>` reads the loom's metadata (stored in `~/.config/iloom-ai/looms/`) and exports `ILOOM_COLOR_HEX` into the shell environment.
+2. Any process spawned from that shell inherits the variable.
+3. Vite picks it up (via `VITE_` prefix or `define`) and makes it available to client code.
+
+When you're not inside a loom shell, the variable is simply absent and your fallback styles apply.

--- a/src/commands/dev-server.ts
+++ b/src/commands/dev-server.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
+import { MetadataManager } from '../lib/MetadataManager.js'
 import { ProjectCapabilityDetector } from '../lib/ProjectCapabilityDetector.js'
 import { DevServerManager } from '../lib/DevServerManager.js'
 import { SettingsManager } from '../lib/SettingsManager.js'
@@ -42,7 +43,8 @@ export class DevServerCommand {
 		private capabilityDetector = new ProjectCapabilityDetector(),
 		private identifierParser = new IdentifierParser(new GitWorktreeManager()),
 		private devServerManager = new DevServerManager(),
-		private settingsManager = new SettingsManager()
+		private settingsManager = new SettingsManager(),
+		private metadataManager = new MetadataManager()
 	) {}
 
 	/**
@@ -80,6 +82,15 @@ export class DevServerCommand {
 			if (envResult.error && !isNoEnvFilesFoundError(envResult.error)) {
 				logger.warn(`Failed to load env files: ${envResult.error.message}`)
 			}
+		}
+
+		// 3b. Set ILOOM_LOOM for loom identification
+		envOverrides.ILOOM_LOOM = this.formatLoomIdentifier(parsed)
+
+		// 3c. Set ILOOM_COLOR_HEX from loom metadata if available
+		const metadata = await this.metadataManager.readMetadata(worktree.path)
+		if (metadata?.colorHex) {
+			envOverrides.ILOOM_COLOR_HEX = metadata.colorHex
 		}
 
 		// 4. Detect project capabilities
@@ -311,5 +322,12 @@ export class DevServerCommand {
 			return `PR #${parsed.number}${autoLabel}`
 		}
 		return `branch "${parsed.branchName}"${autoLabel}`
+	}
+
+	/**
+	 * Format loom identifier for ILOOM_LOOM env var
+	 */
+	private formatLoomIdentifier(parsed: ParsedDevServerInput): string {
+		return parsed.originalInput
 	}
 }


### PR DESCRIPTION
## Summary
- Automatically sets `ILOOM_LOOM` and `ILOOM_COLOR_HEX` environment variables in loom shells and dev servers
- `ILOOM_LOOM` enables PS1 customization to identify which loom you're in
- `ILOOM_COLOR_HEX` allows downstream tools (e.g., Vite apps) to visually distinguish looms
- Includes Vite integration guide at `docs/vite-iloom-color.md`

## Test plan
- [ ] Run `il shell` on a loom and verify `echo $ILOOM_LOOM` returns the loom identifier
- [ ] Run `il shell` on a colored loom and verify `echo $ILOOM_COLOR_HEX` returns the hex color
- [ ] Run `il dev-server` and verify env vars are passed to the child process
- [ ] Run `pnpm vitest run src/commands/dev-server.test.ts src/commands/shell.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)