### PR TITLE
Refactor Linear API token: pass through stack instead of setting env var

### DIFF
--- a/src/lib/LinearService.test.ts
+++ b/src/lib/LinearService.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { LinearService } from './LinearService.js'
+import { fetchLinearIssue, createLinearIssue, updateLinearIssueState } from '../utils/linear.js'
 
-// Mock the linear utils module
 vi.mock('../utils/linear.js', () => ({
 	fetchLinearIssue: vi.fn(),
 	createLinearIssue: vi.fn(),
@@ -9,60 +9,81 @@ vi.mock('../utils/linear.js', () => ({
 }))
 
 describe('LinearService', () => {
+	const testToken = 'lin_api_test_token_123'
+
 	describe('constructor', () => {
-		let originalToken: string | undefined
-
-		beforeEach(() => {
-			// Save original env value
-			originalToken = process.env.LINEAR_API_TOKEN
-			// Clear the env var for testing
+		it('should not set process.env.LINEAR_API_TOKEN when apiToken provided', () => {
 			delete process.env.LINEAR_API_TOKEN
-		})
-
-		afterEach(() => {
-			// Restore original env value
-			if (originalToken !== undefined) {
-				process.env.LINEAR_API_TOKEN = originalToken
-			} else {
-				delete process.env.LINEAR_API_TOKEN
-			}
-		})
-
-		it('should set LINEAR_API_TOKEN env var when apiToken provided in config', () => {
-			const testToken = 'lin_api_test_token_123'
 			new LinearService({ apiToken: testToken })
-
-			expect(process.env.LINEAR_API_TOKEN).toBe(testToken)
-		})
-
-		it('should not set LINEAR_API_TOKEN if not provided in config', () => {
-			new LinearService({ teamId: 'ENG' })
-
 			expect(process.env.LINEAR_API_TOKEN).toBeUndefined()
 		})
+	})
 
-		it('should not set LINEAR_API_TOKEN if config is undefined', () => {
-			new LinearService()
-
-			expect(process.env.LINEAR_API_TOKEN).toBeUndefined()
+	describe('fetchIssue', () => {
+		it('should pass apiToken to fetchLinearIssue when configured', async () => {
+			vi.mocked(fetchLinearIssue).mockResolvedValue({
+				id: 'uuid-1',
+				identifier: 'ENG-123',
+				title: 'Test Issue',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00.000Z',
+				updatedAt: '2024-01-01T00:00:00.000Z',
+			})
+			const service = new LinearService({ apiToken: testToken })
+			await service.fetchIssue('ENG-123')
+			expect(fetchLinearIssue).toHaveBeenCalledWith('ENG-123', testToken)
 		})
 
-		it('should override existing LINEAR_API_TOKEN when apiToken provided in config', () => {
-			process.env.LINEAR_API_TOKEN = 'existing_token'
-			const newToken = 'lin_api_new_token'
+		it('should pass undefined when apiToken not configured', async () => {
+			vi.mocked(fetchLinearIssue).mockResolvedValue({
+				id: 'uuid-1',
+				identifier: 'ENG-123',
+				title: 'Test Issue',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00.000Z',
+				updatedAt: '2024-01-01T00:00:00.000Z',
+			})
+			const service = new LinearService({ teamId: 'ENG' })
+			await service.fetchIssue('ENG-123')
+			expect(fetchLinearIssue).toHaveBeenCalledWith('ENG-123', undefined)
+		})
+	})
 
-			new LinearService({ apiToken: newToken })
-
-			expect(process.env.LINEAR_API_TOKEN).toBe(newToken)
+	describe('createIssue', () => {
+		it('should pass apiToken to createLinearIssue when configured', async () => {
+			vi.mocked(createLinearIssue).mockResolvedValue({
+				identifier: 'ENG-456',
+				url: 'https://linear.app/issue/ENG-456',
+			})
+			const service = new LinearService({ apiToken: testToken, teamId: 'ENG' })
+			await service.createIssue('Title', 'Body', undefined, ['bug'])
+			expect(createLinearIssue).toHaveBeenCalledWith('Title', 'Body', 'ENG', ['bug'], testToken)
 		})
 
-		it('should preserve existing LINEAR_API_TOKEN when apiToken not provided', () => {
-			const existingToken = 'existing_token'
-			process.env.LINEAR_API_TOKEN = existingToken
+		it('should pass undefined when apiToken not configured', async () => {
+			vi.mocked(createLinearIssue).mockResolvedValue({
+				identifier: 'ENG-456',
+				url: 'https://linear.app/issue/ENG-456',
+			})
+			const service = new LinearService({ teamId: 'ENG' })
+			await service.createIssue('Title', 'Body', undefined, ['bug'])
+			expect(createLinearIssue).toHaveBeenCalledWith('Title', 'Body', 'ENG', ['bug'], undefined)
+		})
+	})
 
-			new LinearService({ teamId: 'ENG' })
+	describe('moveIssueToInProgress', () => {
+		it('should pass apiToken to updateLinearIssueState when configured', async () => {
+			vi.mocked(updateLinearIssueState).mockResolvedValue(undefined)
+			const service = new LinearService({ apiToken: testToken })
+			await service.moveIssueToInProgress('ENG-123')
+			expect(updateLinearIssueState).toHaveBeenCalledWith('ENG-123', 'In Progress', testToken)
+		})
 
-			expect(process.env.LINEAR_API_TOKEN).toBe(existingToken)
+		it('should pass undefined when apiToken not configured', async () => {
+			vi.mocked(updateLinearIssueState).mockResolvedValue(undefined)
+			const service = new LinearService()
+			await service.moveIssueToInProgress('ENG-123')
+			expect(updateLinearIssueState).toHaveBeenCalledWith('ENG-123', 'In Progress', undefined)
 		})
 	})
 })

--- a/src/lib/LinearService.ts
+++ b/src/lib/LinearService.ts
@@ -23,7 +23,7 @@ export interface LinearServiceConfig {
   teamId?: string
   /** Branch naming template (e.g., "feat/{{key}}__{{title}}") */
   branchFormat?: string
-  /** Linear API token (lin_api_...). If provided, sets process.env.LINEAR_API_TOKEN */
+  /** Linear API token (lin_api_...). If provided, passed to Linear API calls */
   apiToken?: string
 }
 
@@ -37,6 +37,7 @@ export class LinearService implements IssueTracker {
 
   private config: LinearServiceConfig
   private prompter: (message: string) => Promise<boolean>
+  private apiToken: string | undefined
 
   constructor(
     config?: LinearServiceConfig,
@@ -44,11 +45,7 @@ export class LinearService implements IssueTracker {
   ) {
     this.config = config ?? {}
     this.prompter = options?.prompter ?? promptConfirmation
-
-    // Set API token from config if provided (follows mcp.ts pattern)
-    if (this.config.apiToken) {
-      process.env.LINEAR_API_TOKEN = this.config.apiToken
-    }
+    this.apiToken = this.config.apiToken
   }
 
   /**
@@ -98,7 +95,7 @@ export class LinearService implements IssueTracker {
    * @throws LinearServiceError if issue not found
    */
   public async fetchIssue(identifier: string | number, _repo?: string): Promise<Issue> {
-    const linearIssue = await fetchLinearIssue(String(identifier))
+    const linearIssue = await fetchLinearIssue(String(identifier), this.apiToken)
     return this.mapLinearIssueToIssue(linearIssue)
   }
 
@@ -163,7 +160,7 @@ export class LinearService implements IssueTracker {
 
     getLogger().info(`Creating Linear issue in team ${this.config.teamId}: ${title}`)
 
-    const result = await createLinearIssue(title, body, this.config.teamId, labels)
+    const result = await createLinearIssue(title, body, this.config.teamId, labels, this.apiToken)
 
     return {
       number: result.identifier,
@@ -189,7 +186,7 @@ export class LinearService implements IssueTracker {
    */
   public async moveIssueToInProgress(identifier: string | number): Promise<void> {
     getLogger().info(`Moving Linear issue ${identifier} to In Progress`)
-    await updateLinearIssueState(String(identifier), 'In Progress')
+    await updateLinearIssueState(String(identifier), 'In Progress', this.apiToken)
   }
 
   /**

--- a/src/mcp/LinearIssueManagementProvider.ts
+++ b/src/mcp/LinearIssueManagementProvider.ts
@@ -1,6 +1,11 @@
 /**
  * Linear implementation of Issue Management Provider
  * Uses @linear/sdk for all operations
+ *
+ * Note: This provider runs in an MCP subprocess where LINEAR_API_TOKEN is
+ * injected into the environment by mcp.ts before the process spawns.
+ * The linear.ts utility functions fall back to process.env.LINEAR_API_TOKEN
+ * via createLinearClient(), so explicit apiToken passing is not needed here.
  */
 
 import type {

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -122,13 +122,14 @@ function handleLinearError(error: unknown, context: string): never {
 /**
  * Fetch a Linear issue by identifier
  * @param identifier - Linear issue identifier (e.g., "ENG-123")
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Linear issue details
  * @throws LinearServiceError if issue not found or SDK error
  */
-export async function fetchLinearIssue(identifier: string): Promise<LinearIssue> {
+export async function fetchLinearIssue(identifier: string, apiToken?: string): Promise<LinearIssue> {
   try {
     logger.debug(`Fetching Linear issue: ${identifier}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
     const issue = await client.issue(identifier)
 
     if (!issue) {
@@ -172,6 +173,7 @@ export async function fetchLinearIssue(identifier: string): Promise<LinearIssue>
  * @param body - Issue description (markdown)
  * @param teamKey - Team key (e.g., "ENG", "PLAT")
  * @param labels - Optional label names to apply
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Created issue identifier and URL
  * @throws LinearServiceError on creation failure
  */
@@ -180,10 +182,11 @@ export async function createLinearIssue(
   body: string,
   teamKey: string,
   _labels?: string[],
+  apiToken?: string,
 ): Promise<{ identifier: string; url: string }> {
   try {
     logger.debug(`Creating Linear issue in team ${teamKey}: ${title}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get team by key
     const teams = await client.teams()
@@ -234,6 +237,7 @@ export async function createLinearIssue(
  * @param teamKey - Team key (e.g., "ENG")
  * @param parentId - Parent issue UUID (from issue.id, not identifier)
  * @param labels - Optional label names to apply
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Created issue identifier and URL
  * @throws LinearServiceError on creation failure
  */
@@ -243,10 +247,11 @@ export async function createLinearChildIssue(
   teamKey: string,
   parentId: string,
   _labels?: string[],
+  apiToken?: string,
 ): Promise<{ identifier: string; url: string }> {
   try {
     logger.debug(`Creating Linear child issue in team ${teamKey}: ${title}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get team by key
     const teams = await client.teams()
@@ -294,16 +299,18 @@ export async function createLinearChildIssue(
  * Create a comment on a Linear issue
  * @param identifier - Linear issue identifier (e.g., "ENG-123")
  * @param body - Comment body (markdown)
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Created comment details
  * @throws LinearServiceError on creation failure
  */
 export async function createLinearComment(
   identifier: string,
   body: string,
+  apiToken?: string,
 ): Promise<LinearComment> {
   try {
     logger.debug(`Creating comment on Linear issue ${identifier}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get issue by identifier to get its ID
     const issue = await client.issue(identifier)
@@ -342,15 +349,17 @@ export async function createLinearComment(
  * Update a Linear issue's workflow state
  * @param identifier - Linear issue identifier (e.g., "ENG-123")
  * @param stateName - Target state name (e.g., "In Progress", "Done")
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @throws LinearServiceError on update failure
  */
 export async function updateLinearIssueState(
   identifier: string,
   stateName: string,
+  apiToken?: string,
 ): Promise<void> {
   try {
     logger.debug(`Updating Linear issue ${identifier} state to: ${stateName}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get issue by identifier
     const issue = await client.issue(identifier)
@@ -390,13 +399,14 @@ export async function updateLinearIssueState(
 /**
  * Get a specific comment by ID
  * @param commentId - Linear comment UUID
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Comment details
  * @throws LinearServiceError if comment not found
  */
-export async function getLinearComment(commentId: string): Promise<LinearComment> {
+export async function getLinearComment(commentId: string, apiToken?: string): Promise<LinearComment> {
   try {
     logger.debug(`Fetching Linear comment: ${commentId}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
     const comment = await client.comment({ id: commentId })
 
     if (!comment) {
@@ -422,16 +432,18 @@ export async function getLinearComment(commentId: string): Promise<LinearComment
  * Update an existing comment
  * @param commentId - Linear comment UUID
  * @param body - New comment body (markdown)
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Updated comment details
  * @throws LinearServiceError on update failure
  */
 export async function updateLinearComment(
   commentId: string,
   body: string,
+  apiToken?: string,
 ): Promise<LinearComment> {
   try {
     logger.debug(`Updating Linear comment: ${commentId}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     const payload = await client.updateComment(commentId, { body })
     const comment = await payload.comment
@@ -458,13 +470,14 @@ export async function updateLinearComment(
 /**
  * Fetch all comments for a Linear issue
  * @param identifier - Linear issue identifier (e.g., "ENG-123")
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Array of comments
  * @throws LinearServiceError on fetch failure
  */
-export async function fetchLinearIssueComments(identifier: string): Promise<LinearComment[]> {
+export async function fetchLinearIssueComments(identifier: string, apiToken?: string): Promise<LinearComment[]> {
   try {
     logger.debug(`Fetching comments for Linear issue: ${identifier}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get issue by identifier
     const issue = await client.issue(identifier)
@@ -555,15 +568,17 @@ export interface LinearDependencyResult {
  * Create a blocking relationship between two issues
  * @param blockingIssueId - UUID of the issue that blocks (the blocker)
  * @param blockedIssueId - UUID of the issue being blocked
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @throws LinearServiceError on creation failure
  */
 export async function createLinearIssueRelation(
   blockingIssueId: string,
   blockedIssueId: string,
+  apiToken?: string,
 ): Promise<void> {
   try {
     logger.debug(`Creating Linear issue relation: ${blockingIssueId} blocks ${blockedIssueId}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Create a "blocks" relation from blockingIssue to blockedIssue
     // In Linear, the relation is created on the blocking issue pointing to the blocked issue
@@ -588,16 +603,18 @@ export async function createLinearIssueRelation(
  * Get dependencies for a Linear issue
  * @param identifier - Linear issue identifier (e.g., "ENG-123")
  * @param direction - 'blocking' for issues this blocks, 'blocked_by' for blockers, 'both' for all
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns Object with blocking and blockedBy arrays
  * @throws LinearServiceError on fetch failure
  */
 export async function getLinearIssueDependencies(
   identifier: string,
   direction: 'blocking' | 'blocked_by' | 'both',
+  apiToken?: string,
 ): Promise<{ blocking: LinearDependencyResult[]; blockedBy: LinearDependencyResult[] }> {
   try {
     logger.debug(`Fetching Linear issue dependencies: ${identifier} (direction: ${direction})`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get issue by identifier
     const issue = await client.issue(identifier)
@@ -679,12 +696,13 @@ export async function getLinearIssueDependencies(
 /**
  * Delete an issue relation by ID
  * @param relationId - UUID of the relation to delete
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @throws LinearServiceError on deletion failure
  */
-export async function deleteLinearIssueRelation(relationId: string): Promise<void> {
+export async function deleteLinearIssueRelation(relationId: string, apiToken?: string): Promise<void> {
   try {
     logger.debug(`Deleting Linear issue relation: ${relationId}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     const payload = await client.deleteIssueRelation(relationId)
 
@@ -779,16 +797,18 @@ export async function fetchLinearIssueList(
  * Find the relation ID between two issues for removal
  * @param blockingIdentifier - Identifier of the blocking issue
  * @param blockedIdentifier - Identifier of the blocked issue
+ * @param apiToken - Optional API token (takes precedence over env var)
  * @returns The relation ID if found, null otherwise
  * @throws LinearServiceError on fetch failure
  */
 export async function findLinearIssueRelation(
   blockingIdentifier: string,
   blockedIdentifier: string,
+  apiToken?: string,
 ): Promise<string | null> {
   try {
     logger.debug(`Finding Linear issue relation: ${blockingIdentifier} blocks ${blockedIdentifier}`)
-    const client = createLinearClient()
+    const client = createLinearClient(apiToken)
 
     // Get the blocking issue
     const blockingIssue = await client.issue(blockingIdentifier)


### PR DESCRIPTION
Fixes #590

## Refactor Linear API token: pass through stack instead of setting env var

## Problem

`LinearService` constructor sets `process.env.LINEAR_API_TOKEN` as a side effect (src/lib/LinearService.ts:50), and all functions in `src/utils/linear.ts` rely on this env var being set via `getLinearApiToken()` → `createLinearClient()`.

This caused a bug (#590) where `il list --children` called `getLinearChildIssues` without first instantiating `LinearService`, so the token was never in the environment.

Setting env vars as a side effect is fragile — any new code path that calls Linear utility functions without going through `LinearService` will hit the same `UNAUTHORIZED` error.

## Desired behavior

All functions in `src/utils/linear.ts` should accept the API token as a parameter (with env var as fallback), passed down through the call stack. `LinearService` should stop setting `process.env.LINEAR_API_TOKEN`.

## Scope

**`src/utils/linear.ts`** — Update all exported functions to accept an optional `apiToken` parameter and pass it to `createLinearClient()`:
- `fetchLinearIssue`
- `createLinearIssue`
- `createLinearChildIssue`
- `createLinearComment`
- `updateLinearIssueState`
- `getLinearComment`
- `updateLinearComment`
- `fetchLinearIssueComments`
- `getLinearChildIssues` (already done in #590)
- `createLinearIssueRelation`
- `getLinearIssueDependencies`
- `deleteLinearIssueRelation`
- `fetchLinearIssueList` (already accepts `apiToken`)
- `findLinearIssueRelation`

**`src/lib/LinearService.ts`** — Stop setting `process.env.LINEAR_API_TOKEN`. Instead, store the token as an instance property and pass it to each `linear.ts` function call.

**`src/utils/image-processor.ts`** — Check if it reads `LINEAR_API_TOKEN` from env; if so, update to accept it as a parameter.

**Tests** — Update `LinearService.test.ts` to remove env var assertions. Test files that set the env var for test setup are fine.

---
*This PR was created automatically by iloom.*