### PR TITLE
fix(list-children): pass Linear API token for child issue fetching

### DIFF
--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -493,15 +493,18 @@ export async function fetchLinearIssueComments(identifier: string): Promise<Line
 /**
  * Get child issues of a parent Linear issue
  * @param identifier - Linear issue identifier (e.g., "ENG-123")
+ * @param options - Optional settings
+ * @param options.apiToken - Optional API token (takes precedence over env var)
  * @returns Array of child issues
  * @throws LinearServiceError on fetch failure
  */
 export async function getLinearChildIssues(
   identifier: string,
+  options?: { apiToken?: string },
 ): Promise<Array<{ id: string; title: string; url: string; state: string }>> {
   try {
     logger.debug(`Fetching child issues for Linear issue: ${identifier}`)
-    const client = createLinearClient()
+    const client = createLinearClient(options?.apiToken)
 
     // Get issue by identifier
     const issue = await client.issue(identifier)

--- a/src/utils/list-children.test.ts
+++ b/src/utils/list-children.test.ts
@@ -172,7 +172,7 @@ describe('list-children', () => {
       } as Partial<IloomSettings>)
       const result = await fetchChildIssues('ENG-100', settings)
 
-      expect(getLinearChildIssues).toHaveBeenCalledWith('ENG-100')
+      expect(getLinearChildIssues).toHaveBeenCalledWith('ENG-100', undefined)
       expect(result).toEqual(mockChildIssues)
     })
 

--- a/src/utils/list-children.ts
+++ b/src/utils/list-children.ts
@@ -106,7 +106,9 @@ export async function fetchChildIssues(
         return getSubIssues(issueNum, repo)
       } else if (providerName === 'linear') {
         // Linear uses identifiers like "ENG-123"
-        return getLinearChildIssues(parentIssueNumber)
+        // Pass API token from settings since LinearService may not have been instantiated
+        const apiToken = settings.issueManagement?.linear?.apiToken
+        return getLinearChildIssues(parentIssueNumber, apiToken ? { apiToken } : undefined)
       } else {
         logger.warn(`Unsupported issue tracker provider: ${providerName}`)
         return []


### PR DESCRIPTION
## Summary

- `il list --children` was failing with `UNAUTHORIZED` for Linear-configured projects because `getLinearChildIssues` had no access to the API token
- The token was only available via `process.env.LINEAR_API_TOKEN` which gets set as a side effect of `LinearService` instantiation — but `il list --children` never creates a `LinearService`
- Added optional `apiToken` parameter to `getLinearChildIssues` and pass it from settings in `fetchChildIssues`

## Test plan

- [x] All 3821 tests pass
- [x] Build succeeds
- [ ] Run `il list --children --json` from a Linear-configured project and verify child issues appear