### PR TITLE
il start fails for PRs from forks

### DIFF
--- a/src/lib/GitHubService.test.ts
+++ b/src/lib/GitHubService.test.ts
@@ -45,6 +45,7 @@ describe('GitHubService', () => {
 				baseRefName: 'main',
 				url: 'https://github.com/owner/repo/pull/123',
 				isDraft: false,
+				isCrossRepository: false,
 				mergeable: 'MERGEABLE',
 				createdAt: '2024-01-01',
 				updatedAt: '2024-01-02',
@@ -181,6 +182,7 @@ describe('GitHubService', () => {
 				baseRefName: 'main',
 				url: 'https://github.com/owner/repo/pull/20',
 				isDraft: false,
+				isCrossRepository: false,
 				mergeable: 'MERGEABLE',
 				createdAt: '2024-01-01',
 				updatedAt: '2024-01-02',
@@ -279,6 +281,7 @@ describe('GitHubService', () => {
 				baseRefName: 'main',
 				url: 'https://github.com/acreeger/repo/pull/30',
 				isDraft: false,
+				isCrossRepository: false,
 				mergeable: 'MERGEABLE',
 				createdAt: '2024-01-01',
 				updatedAt: '2024-01-02',
@@ -304,6 +307,7 @@ describe('GitHubService', () => {
 				baseRefName: 'main',
 				url: 'https://github.com/owner/repo/pull/31',
 				isDraft: false,
+				isCrossRepository: false,
 				mergeable: 'MERGEABLE',
 				createdAt: '2024-01-01',
 				updatedAt: '2024-01-02',
@@ -329,6 +333,50 @@ describe('GitHubService', () => {
 
 			// Should throw the original error, not wrap it as NOT_FOUND
 			await expect(service.fetchPR(5)).rejects.toThrow('Unknown JSON field: "repository"')
+		})
+	})
+
+	describe('isFork mapping', () => {
+		it('should map isCrossRepository true to isFork true for fork PRs', async () => {
+			vi.mocked(githubUtils.fetchGhPR).mockResolvedValueOnce({
+				number: 586,
+				title: 'Add git commit timeout',
+				body: 'Description',
+				state: 'OPEN',
+				headRefName: 'feature/git-commit-timeout',
+				baseRefName: 'main',
+				url: 'https://github.com/owner/repo/pull/586',
+				isDraft: false,
+				isCrossRepository: true,
+				mergeable: 'MERGEABLE',
+				createdAt: '2024-01-01',
+				updatedAt: '2024-01-02',
+			})
+
+			const pr = await service.fetchPR(586)
+
+			expect(pr.isFork).toBe(true)
+		})
+
+		it('should map isCrossRepository false to isFork false for same-repo PRs', async () => {
+			vi.mocked(githubUtils.fetchGhPR).mockResolvedValueOnce({
+				number: 587,
+				title: 'Fix bug',
+				body: 'Description',
+				state: 'OPEN',
+				headRefName: 'fix/bug',
+				baseRefName: 'main',
+				url: 'https://github.com/owner/repo/pull/587',
+				isDraft: false,
+				isCrossRepository: false,
+				mergeable: 'MERGEABLE',
+				createdAt: '2024-01-01',
+				updatedAt: '2024-01-02',
+			})
+
+			const pr = await service.fetchPR(587)
+
+			expect(pr.isFork).toBe(false)
 		})
 	})
 

--- a/src/lib/GitHubService.ts
+++ b/src/lib/GitHubService.ts
@@ -352,6 +352,7 @@ export class GitHubService implements IssueTracker {
 			baseBranch: ghPR.baseRefName,
 			url: ghPR.url,
 			isDraft: ghPR.isDraft,
+			isFork: ghPR.isCrossRepository,
 		}
 	}
 

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -21,6 +21,7 @@ export interface GitHubPullRequest {
 	baseRefName: string // target branch
 	url: string
 	isDraft: boolean
+	isCrossRepository: boolean
 	mergeable: 'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN'
 	createdAt: string
 	updatedAt: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,7 @@ export interface PullRequest {
   baseBranch: string
   url: string
   isDraft: boolean
+  isFork?: boolean
 }
 
 // Issue Tracker types

--- a/src/utils/github.test.ts
+++ b/src/utils/github.test.ts
@@ -336,7 +336,7 @@ describe('github utils', () => {
 					'view',
 					'456',
 					'--json',
-					'number,title,body,state,headRefName,baseRefName,url,isDraft,mergeable,createdAt,updatedAt',
+					'number,title,body,state,headRefName,baseRefName,url,isDraft,isCrossRepository,mergeable,createdAt,updatedAt',
 				],
 				expect.any(Object)
 			)

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -142,7 +142,7 @@ export async function fetchGhPR(
 		'view',
 		String(prNumber),
 		'--json',
-		'number,title,body,state,headRefName,baseRefName,url,isDraft,mergeable,createdAt,updatedAt',
+		'number,title,body,state,headRefName,baseRefName,url,isDraft,isCrossRepository,mergeable,createdAt,updatedAt',
 	]
 
 	if (repo) {


### PR DESCRIPTION
Fixes #593

## il start fails for PRs from forks

## Problem

`il start <PR-number>` fails for pull requests from forks because the contributor's branch only exists on their fork, not on `origin`.

```
🗂️  Validated input: PR #586
🗂️  Fetching issue data...
🗂️  No existing worktree found, creating new one...
🗂️  Preparing branch name...
🗂️  Creating git worktree...
🗂️  Fetching all remote branches...
✅ Successfully fetched from remote
❌ Git command failed: fatal: invalid reference: feature/git-commit-timeout
❌ Failed to start workspace: Git command failed: fatal: invalid reference: feature/git-commit-timeout
```

### Root cause

1. `prepareBranchName()` returns `issueData.branch` (the PR's `headRefName`), e.g. `feature/git-commit-timeout`
2. `createWorktreeOnly()` runs `git fetch origin` then `git worktree add <path> feature/git-commit-timeout`
3. That branch doesn't exist on `origin` — it only exists on the contributor's fork
4. Git fails with `fatal: invalid reference`

## Proposed fix

Use GitHub's PR ref (`refs/pull/{N}/head`) for fork PRs instead of the contributor's branch name. Same-repo PRs continue to use the branch name directly.

### Detection

`gh pr view` supports an `isCrossRepository` boolean field that is `true` when a PR comes from a fork. We can add this to our fetch and use it to switch behavior.

### Implementation

1. **`src/utils/github.ts`** — Add `isCrossRepository` to the `--json` fields in `fetchGhPR()`
2. **`src/types/github.ts`** — Add `isCrossRepository: boolean` to `GitHubPullRequest`
3. **`src/types/index.ts`** — Add `isFork?: boolean` to `PullRequest`
4. **`src/lib/GitHubService.ts`** — Map `isCrossRepository` → `isFork` in `mapGitHubPRToPullRequest()`
5. **`src/lib/LoomManager.ts`** — Update `createWorktreeOnly()` for fork PRs:
   - `git fetch origin refs/pull/{N}/head` to fetch the PR ref
   - Create worktree from `FETCH_HEAD` with a local branch name (e.g. the original `headRefName` or `pr-{N}`)
   - Skip the `reset --hard origin/{branch}` and `set-upstream-to` steps for fork PRs

### Behavior

| PR type | Branch resolution | Worktree creation |
|---------|------------------|-------------------|
| Same-repo | Use `headRefName` directly | `git worktree add <path> <branch>` (existing behavior) |
| Fork | Fetch `refs/pull/{N}/head` | `git fetch origin refs/pull/{N}/head` then create from `FETCH_HEAD` |

---
*This PR was created automatically by iloom.*