### PR TITLE
fix(start): skip bypassPermissions prompt for non-interactive modes

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -224,11 +224,11 @@ export class StartCommand {
 			}
 
 			// Step 2.7: Confirm bypassPermissions mode if applicable
-			if (input.options.oneShot === 'bypassPermissions') {
-				// JSON mode cannot use bypassPermissions confirmation prompt
-				if (isJsonMode) {
-					throw new Error('JSON mode does not support bypassPermissions confirmation prompt')
-				}
+			// Only prompt in interactive mode when Claude is enabled.
+			// Skip when: --no-claude (Claude won't launch now), JSON mode (non-interactive).
+			// The explicit --one-shot=bypassPermissions flag is sufficient intent.
+			// The warning is shown again when Claude launches via 'il spin'.
+			if (input.options.oneShot === 'bypassPermissions' && input.options.claude !== false && !isJsonMode) {
 				const { promptConfirmation } = await import('../utils/prompt.js')
 				const confirmed = await promptConfirmation(
 					'WARNING: bypassPermissions mode will allow Claude to execute all tool calls without confirmation. ' +


### PR DESCRIPTION
## Summary
- Skip the `bypassPermissions` confirmation prompt when `--no-claude` is passed or in JSON mode
- Previously JSON mode threw an error, blocking non-interactive workflows using `--one-shot=bypassPermissions`
- The explicit `--one-shot=bypassPermissions` flag is sufficient intent; the safety warning is still shown when Claude actually launches via `il spin`

## Test plan
- [ ] `il start <issue> --one-shot=bypassPermissions --no-claude` proceeds without prompt
- [ ] `il start <issue> --one-shot=bypassPermissions --json` no longer throws
- [ ] `il start <issue> --one-shot=bypassPermissions` (interactive, with Claude) still shows confirmation prompt
- [ ] `il spin` in a loom created with `bypassPermissions` still shows the warning and applies the mode