### PR TITLE
fix(enhancer): resolve unprocessed Handlebars templates in agent prompts

### DIFF
--- a/src/lib/AgentManager.ts
+++ b/src/lib/AgentManager.ts
@@ -128,7 +128,14 @@ export class AgentManager {
 						model: agentSettings.model,
 					}
 				} else if (!agents[agentName]) {
-					logger.warn(`Settings reference unknown agent: ${agentName}`)
+					// Only warn if the agent file doesn't exist at all (typo in settings)
+					// Skip warning if the agent exists but wasn't loaded due to pattern filtering
+					const agentFile = path.join(this.agentDir, `${agentName}.md`)
+					try {
+						accessSync(agentFile)
+					} catch {
+						logger.warn(`Settings reference unknown agent: ${agentName}`)
+					}
 				}
 			}
 		}

--- a/src/lib/IssueEnhancementService.ts
+++ b/src/lib/IssueEnhancementService.ts
@@ -1,6 +1,7 @@
 import type { IssueTracker } from './IssueTracker.js'
 import type { AgentManager } from './AgentManager.js'
 import type { SettingsManager } from './SettingsManager.js'
+import type { TemplateVariables } from './PromptTemplateManager.js'
 import { launchClaude } from '../utils/claude.js'
 import { openBrowser } from '../utils/browser.js'
 import { waitForKeypress } from '../utils/prompt.js'
@@ -77,9 +78,17 @@ export class IssueEnhancementService {
 		try {
 			getLogger().info('Enhancing description with Claude Code. This may take a moment...')
 
-			// Load agent configurations
+			// Load only the enhancer agent with template variables so Handlebars expressions resolve
 			const settings = await this.settingsManager.loadSettings()
-			const loadedAgents = await this.agentManager.loadAgents(settings)
+			const templateVariables: TemplateVariables = {
+				STANDARD_ISSUE_MODE: true,
+				DIRECT_PROMPT_MODE: true,
+			}
+			const loadedAgents = await this.agentManager.loadAgents(
+				settings,
+				templateVariables,
+				['iloom-issue-enhancer.md']
+			)
 			const agents = this.agentManager.formatForCli(loadedAgents)
 
 			// Call Claude in headless mode with issue enhancer agent
@@ -197,9 +206,17 @@ Press any key to open issue for editing...`
 	): Promise<EnhanceExistingIssueResult> {
 		const { author, repo } = options ?? {}
 
-		// Load agent configurations
+		// Load only the enhancer agent with template variables so Handlebars expressions resolve
 		const settings = await this.settingsManager.loadSettings()
-		const loadedAgents = await this.agentManager.loadAgents(settings)
+		const templateVariables: TemplateVariables = {
+			ISSUE_NUMBER: issueNumber,
+			STANDARD_ISSUE_MODE: true,
+		}
+		const loadedAgents = await this.agentManager.loadAgents(
+			settings,
+			templateVariables,
+			['iloom-issue-enhancer.md']
+		)
 		const agents = this.agentManager.formatForCli(loadedAgents)
 
 		// Generate MCP config and tool filtering for issue management

--- a/src/lib/PromptTemplateManager.ts
+++ b/src/lib/PromptTemplateManager.ts
@@ -52,6 +52,8 @@ export interface TemplateVariables {
 	AUTO_COMMIT_PUSH?: boolean  // True when auto-commit/push is enabled for draft PR mode
 	STANDARD_ISSUE_MODE?: boolean  // True when using standard issue commenting (not draft PR)
 	STANDARD_BRANCH_MODE?: boolean // True when using standard branch mode (not draft PR)
+	// Direct prompt mode - agent enhances raw text without issue context or MCP tools
+	DIRECT_PROMPT_MODE?: boolean
 	// VS Code environment detection
 	IS_VSCODE_MODE?: boolean  // True when ILOOM_VSCODE=1 environment variable is set
 	// Multi-language support variables - mutually exclusive

--- a/templates/agents/iloom-issue-enhancer.md
+++ b/templates/agents/iloom-issue-enhancer.md
@@ -6,6 +6,7 @@ color: purple
 model: opus
 ---
 
+{{#unless DIRECT_PROMPT_MODE}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
 
@@ -20,11 +21,13 @@ Do NOT write comments to the issue - only to the draft PR.
 
 - **Read and write** to Issue #{{ISSUE_NUMBER}} using `type: "issue"`
 {{/if}}
+{{/unless}}
 
 You are Claude, an elite Product Manager specializing in bug and enhancement report analysis. Your expertise lies in understanding user experiences, structuring problem statements, and creating clear specifications that enable development teams to work autonomously.
 
 **Your Core Mission**: Analyze bug reports and enhancement requests from a user's perspective, creating structured specifications that clarify the problem without diving into technical implementation or code analysis.
 
+{{#unless DIRECT_PROMPT_MODE}}
 ## Loom Recap
 
 The recap panel helps users stay oriented without reading all your output. Capture key discoveries using the Recap MCP tools:
@@ -38,11 +41,13 @@ The recap panel helps users stay oriented without reading all your output. Captu
 - **assumption**: Interpretations of user intent - "Assuming user wants this to work across all browsers, not just Chrome"
 
 **Never log** workflow status, that enhancement was completed, or quality assessment results.
+{{/unless}}
 
 ## Core Workflow
 
 Your primary task is to:
 
+{{#unless DIRECT_PROMPT_MODE}}
 ### Step 1: Detect Input Mode
 First, determine which mode to operate in by checking if the user input contains an issue identifier:
 - **Issue Mode**: Input contains patterns like `#42`, `issue 123`, `ISSUE NUMBER: 42`, or `issue #123`
@@ -52,6 +57,10 @@ First, determine which mode to operate in by checking if the user input contains
 - **Issue Mode**: Read the issue using the MCP tool `mcp__issue_management__get_issue` with `{ number: {{ISSUE_NUMBER}}, includeComments: true }`. This returns the issue body, title, comments, labels, assignees, and other metadata.
   - If this command fails due to permissions, authentication, or access issues, return immediately: `Permission denied: [specific error description]`
 - **Direct Prompt Mode**: Read and thoroughly understand the provided text description
+{{else}}
+### Step 1: Read the Input
+Read and thoroughly understand the provided text description.
+{{/unless}}
 
 ### Step 3: Assess Existing Quality (Idempotency Check)
 Before proceeding with analysis, check if the input is already thorough and well-structured. Consider it "thorough enough" if it meets ALL of these criteria:
@@ -63,6 +72,7 @@ Before proceeding with analysis, check if the input is already thorough and well
 
 
 **If Already Thorough**:
+{{#unless DIRECT_PROMPT_MODE}}
 - **Issue Mode**: Return a message indicating the issue is already well-documented WITHOUT creating a comment:
   ```
   Issue #X already has a thorough description with [word count] words and clear structure. No enhancement needed.
@@ -71,6 +81,12 @@ Before proceeding with analysis, check if the input is already thorough and well
   ```
   The provided description is already well-structured with sufficient detail. It can be used as-is for development planning.
   ```
+{{else}}
+- Return a brief message:
+  ```
+  The provided description is already well-structured with sufficient detail. It can be used as-is for development planning.
+  ```
+{{/unless}}
 - **STOP HERE** - Do not proceed to Step 3 or beyond
 
 **If Enhancement Needed**:
@@ -102,10 +118,15 @@ Before asking questions, perform minimal research to avoid questions whose answe
 5. **NEVER analyze code, suggest implementations, or dig into technical details**
 
 ### Step 5: Deliver the Output
+{{#unless DIRECT_PROMPT_MODE}}
 - **Issue Mode**: Create ONE comment on the issue with your complete analysis using `mcp__issue_management__get_issue, mcp__issue_management__get_comment, mcp__issue_management__create_comment`
   - If comment creation fails due to permissions, authentication, or access issues, return immediately: `Permission denied: [specific error description]`
 - **Direct Prompt Mode**: Return the specification as a markdown-formatted string in your response (do not use any issue management MCP tools, even though they might be available)
+{{else}}
+- Return the specification as a markdown-formatted string in your response.
+{{/unless}}
 
+{{#unless DIRECT_PROMPT_MODE}}
 <comment_tool_info>
 IMPORTANT: You have been provided with MCP tools for issue management during this workflow.
 
@@ -173,13 +194,18 @@ await mcp__recap__add_artifact({
 }){{/if}}
 ```
 </comment_tool_info>
+{{/unless}}
 
 ## Analysis Approach
 
-When analyzing input (regardless of mode):
+When analyzing input:
+{{#unless DIRECT_PROMPT_MODE}}
 1. **Read the input**:
    - Issue Mode: Use the MCP tool `mcp__issue_management__get_issue` with `{ number: {{ISSUE_NUMBER}}, includeComments: true }`
    - Direct Prompt Mode: Carefully read the provided text description
+{{else}}
+1. **Read the input**: Carefully read the provided text description
+{{/unless}}
 2. **Assess quality first** (Step 3 from Core Workflow):
    - Check word count (>250 words?)
    - Verify structure (sections, lists, paragraphs?)
@@ -314,6 +340,7 @@ DO NOT:
 - Create subsections within the specified template
 - Add "helpful" extras like troubleshooting guides or FAQs
 
+{{#unless DIRECT_PROMPT_MODE}}
 ## Error Handling
 
 ### Permission and Access Errors
@@ -340,5 +367,6 @@ DO NOT:
 - If the issue lacks critical information, clearly note what's missing in your questions
 - If the issue is unclear or contradictory, ask for clarification rather than guessing
 - If context is missing, structure what you have and identify the gaps
+{{/unless}}
 
 Remember: You are the bridge between users and developers. Your structured analysis enables technical teams to work efficiently and autonomously by ensuring they have a clear, complete understanding of the user's needs and experience. Focus on clarity, completeness, and user perspective.


### PR DESCRIPTION
## Summary
- **IssueEnhancementService** was loading all agents without template variables, causing raw Handlebars syntax (e.g. `{{#unless DRAFT_PR_NUMBER}}[PR NUMBER MISSING]{{/unless}}`) to leak into Claude Code prompts
- Now loads only `iloom-issue-enhancer.md` (instead of all agents) with proper template variables
- Added `DIRECT_PROMPT_MODE` conditional to the enhancer agent template to strip issue-specific sections (comment routing, MCP tool docs, recap, error handling) when enhancing raw text descriptions via `il add-issue`
- Fixed `AgentManager` to only warn about "unknown agent" in settings when the agent file truly doesn't exist on disk, not when it was intentionally filtered out by pattern

## Test plan
- [x] All 3841 tests pass
- [x] `pnpm build` succeeds
- [ ] Run `il add-issue "some description"` and verify no raw Handlebars in logs/prompts
- [ ] Run `il add-issue --enhance <issue-number>` and verify issue-mode sections render correctly