### PR TITLE
chore(settings): update gemini model to 3.1-pro-preview

### DIFF
--- a/.iloom/settings.json
+++ b/.iloom/settings.json
@@ -14,8 +14,8 @@
     "iloom-issue-planner": { "model": "opus", "review": true },
     "iloom-issue-analyze-and-plan": { "model": "opus", "review": true },
     "iloom-issue-implementer": { "model": "opus" },
-    "iloom-code-reviewer": { "providers": { "gemini": "gemini-3-pro-preview" } },
-    "iloom-artifact-reviewer": { "enabled": true, "providers": { "gemini": "gemini-3-pro-preview" } }
+    "iloom-code-reviewer": { "providers": { "gemini": "gemini-3.1-pro-preview" } },
+    "iloom-artifact-reviewer": { "enabled": true, "providers": { "gemini": "gemini-3.1-pro-preview" } }
   },
   "colors": {
     "terminal": true,


### PR DESCRIPTION
## Summary
- Updates Gemini model version from `gemini-3-pro-preview` to `gemini-3.1-pro-preview` for both code reviewer and artifact reviewer agents in `.iloom/settings.json`