### PR TITLE
fix(spin): pass sessionId in epic swarm mode for session resume

### DIFF
--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -978,6 +978,7 @@ export class IgniteCommand {
 				permissionMode: 'bypassPermissions',
 				addDir: epicWorktreePath,
 				headless: false,
+				...(metadata.sessionId && { sessionId: metadata.sessionId }),
 				appendSystemPrompt: orchestratorPrompt,
 				mcpConfig: mcpConfigs,
 				allowedTools,


### PR DESCRIPTION
## Summary
- Epic swarm spins were not resuming Claude sessions because `executeSwarmMode()` never passed `sessionId` to `launchClaude()`
- The regular spin path extracts `sessionId` from loom metadata and includes it in `claudeOptions`, but the epic code path returned early and built its own options without it
- Added `sessionId` spread to the `launchClaude()` call in `executeSwarmMode()`

## Test plan
- [ ] Run `il spin` inside an epic loom and verify it resumes the existing Claude session instead of starting fresh