### PR TITLE
When running finish on a draft_pr or pr mergeMode we should open the PR in a browser so the user sees it

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -266,7 +266,7 @@ il finish [options]
 | `-n`, `--dry-run` | Preview actions without executing |
 | `--pr` | Treat input as PR number |
 | `--skip-build` | Skip post-merge build verification |
-| `--no-browser` | Skip opening PR in browser (github-pr mode only) |
+| `--no-browser` | Skip opening PR in browser (github-pr and github-draft-pr modes) |
 | `--cleanup` | Clean up worktree after finishing (default in local mode) |
 | `--no-cleanup` | Keep worktree after finishing (default in github-pr and github-draft-pr modes)|
 
@@ -289,7 +289,14 @@ Behavior depends on the `mergeBehavior.mode` setting in your iloom configuration
 1. Same validation pipeline as local mode
 2. Pushes branch to remote
 3. Creates GitHub pull request
-4. Opens PR in browser (unless `--no-browser`)
+4. Opens PR in browser (unless `--no-browser` or `openBrowserOnFinish: false`)
+5. Prompts for cleanup (or use `--cleanup`/`--no-cleanup` flags)
+
+**`github-draft-pr`:**
+1. Same validation pipeline as local mode
+2. Removes placeholder commit and pushes final commits
+3. Marks draft PR as ready for review
+4. Opens PR in browser (unless `--no-browser` or `openBrowserOnFinish: false`)
 5. Prompts for cleanup (or use `--cleanup`/`--no-cleanup` flags)
 
 **Examples:**
@@ -317,6 +324,21 @@ For Payload CMS projects, iloom automatically detects and handles migration conf
 - Identifies migration file conflicts
 - Launches Claude to help resolve discrepancies
 - Validates schema consistency
+
+**Browser Opening Configuration:**
+
+By default, `il finish` opens the PR in your browser after creation (github-pr mode) or marking ready (github-draft-pr mode). To disable this permanently, set `openBrowserOnFinish` to `false` in your settings:
+
+```json
+{
+  "mergeBehavior": {
+    "mode": "github-pr",
+    "openBrowserOnFinish": false
+  }
+}
+```
+
+Browser opening is also suppressed in `--json` mode and `--dry-run` mode.
 
 **Notes:**
 - Claude assists with fixing any test, typecheck, or lint failures

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -563,11 +563,15 @@ program
   .option('-n, --dry-run', 'Preview actions without executing')
   .option('--pr <number>', 'Treat input as PR number', parseFloat)
   .option('--skip-build', 'Skip post-merge build verification')
-  .option('--no-browser', 'Skip opening PR in browser (github-pr mode only)')
+  .option('--no-browser', 'Skip opening PR in browser (github-pr and github-draft-pr modes)')
   .option('--cleanup', 'Clean up worktree after finishing (default in local mode)')
   .option('--no-cleanup', 'Keep worktree after finishing')
   .option('--json', 'Output result as JSON')
-  .action(async (identifier: string | undefined, options: FinishOptions) => {
+  .action(async (identifier: string | undefined, options: FinishOptions & { browser?: boolean }) => {
+    // Commander.js --no-browser creates browser:false, map to noBrowser for FinishOptions
+    if (options.browser === false) {
+      options.noBrowser = true
+    }
     const executeAction = async (): Promise<void> => {
       try {
         const settingsManager = new SettingsManager()

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -832,6 +832,15 @@ export class FinishCommand {
 				result.prUrl = prUrl
 			}
 
+			// Open PR in browser if configured and not suppressed
+			const shouldOpenBrowser = !options.dryRun
+				&& !options.noBrowser
+				&& !options.json
+				&& settings.mergeBehavior?.openBrowserOnFinish !== false
+			if (shouldOpenBrowser && prUrl) {
+				await prManager.openPRInBrowser(prUrl)
+			}
+
 			result.operations.push({
 				type: 'pr-ready',
 				message: `PR #${metadata.draftPrNumber} marked as ready for review`,
@@ -1066,7 +1075,9 @@ export class FinishCommand {
 				success: true,
 			})
 		} else {
-			const openInBrowser = options.noBrowser !== true
+			const openInBrowser = !options.noBrowser
+				&& !options.json
+				&& settings.mergeBehavior?.openBrowserOnFinish !== false
 
 			const prResult = await prManager.createOrOpenPR(
 				worktree.branch,

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -437,6 +437,12 @@ export const IloomSettingsSchema = z.object({
 				.describe(
 					'Auto-commit and push after code review in draft PR mode. Defaults to true when mode is github-draft-pr.'
 				),
+			openBrowserOnFinish: z
+				.boolean()
+				.default(true)
+				.describe(
+					'Open the PR in the default browser after finishing in github-pr or github-draft-pr mode. Use --no-browser flag to override.'
+				),
 		})
 		.optional()
 		.describe('Merge behavior configuration: local (merge locally), github-pr (create PR), or github-draft-pr (create draft PR at start, mark ready on finish)'),
@@ -682,6 +688,12 @@ export const IloomSettingsSchemaNoDefaults = z.object({
 				.optional()
 				.describe(
 					'Auto-commit and push after code review in draft PR mode. Defaults to true when mode is github-draft-pr.'
+				),
+			openBrowserOnFinish: z
+				.boolean()
+				.optional()
+				.describe(
+					'Open the PR in the default browser after finishing in github-pr or github-draft-pr mode. Use --no-browser flag to override.'
 				),
 		})
 		.optional()


### PR DESCRIPTION
Fixes #672

## When running finish on a draft_pr or pr mergeMode we should open the PR in a browser so the user sees it

I think this might be happening for PR Merge Mode. Definitely not for draft PRs. 

We should have this enabled by default. But make it configurable.

---
*This PR was created automatically by iloom.*