### PR TITLE
Fix --set flag on spin command (accept directly + forward from start)

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -552,6 +552,7 @@ il spin [options]
 | `-p, --print` | | Enable print/headless mode for CI/CD (uses `bypassPermissions`) |
 | `--output-format` | `json`, `stream-json`, `text` | Output format for Claude CLI (requires `--print`) |
 | `--verbose` | | Enable verbose output (requires `--print`) |
+| `--set` | `key=value` | Override settings using dot notation (repeatable). Same as global `--set` flag. |
 
 **Behavior:**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -689,6 +689,7 @@ program
   .option('--verbose', 'Enable verbose output (requires --print)')
   .option('--json', 'Output final result as JSON object (requires --print)')
   .option('--json-stream', 'Stream JSONL output to stdout in real-time (requires --print)')
+  .option('--set <key=value>', 'Override settings (repeatable, e.g., --set workflows.issue.permissionMode=bypassPermissions)')
   .action(async (options: {
     oneShot?: import('./types/index.js').OneShotMode
     yolo?: boolean


### PR DESCRIPTION
Fixes #665

## Fix --set flag on spin command (accept directly + forward from start)

## Problem

The `spin` command doesn't declare `--set` as an option, so Commander rejects it. This means:

1. **Direct usage fails**: `il spin --set permissionMode=bypassPermissions` is rejected by Commander
2. **Forwarding from start fails**: `il start 123 --set permissionMode=bypassPermissions` tries to forward `--set` args to `spin` via `extractRawSetArguments()` / `LoomLauncher.setArguments`, but Commander rejects them on the `spin` end

Settings like `permissionMode=bypassPermissions` can't be passed independently of `--one-shot` mode, even though the settings schema supports it.

## Current behavior

1. `il start 123 --set permissionMode=bypassPermissions` — `extractSettingsOverrides()` correctly merges into local settings, **and** `extractRawSetArguments()` captures the raw strings for forwarding
2. `LoomLauncher` builds: `il spin --set permissionMode=bypassPermissions`
3. Commander rejects `--set` as unknown on `spin` → error in the terminal

## Fix

1. **Declare `--set <key=value>` on the `spin` command** — so Commander doesn't reject it. `extractSettingsOverrides()` already reads all occurrences from `process.argv` directly, so the handler works automatically.
2. **Keep the forwarding chain working** — `extractRawSetArguments()` and `LoomLauncher.setArguments` correctly capture and forward `--set` args from `start` to the `spin` command launched in a new terminal. Now that `spin` accepts `--set`, this forwarding will actually work.
3. **Clean up the forwarding code** — remove any dead or redundant parts of the chain, but preserve the functional forwarding path.
4. **Verify `ignite.ts` reads `permissionMode` from settings** and passes it to `launchClaude` so `--set permissionMode=bypassPermissions` flows through correctly without needing `--one-shot`.

## Files involved

- `src/cli.ts` — add `--set` option to `spin` command
- `src/commands/start.ts` — verify `extractRawSetArguments()` forwarding works
- `src/lib/LoomLauncher.ts` — verify `setArguments` handling appends to spin command
- `src/utils/cli-overrides.ts` — verify `extractRawSetArguments()` works correctly
- `src/commands/ignite.ts` — ensure `permissionMode` from settings flows to `launchClaude`

---
*This PR was created automatically by iloom.*