### PR TITLE
feat(swarm): pass ENABLE_TOOL_SEARCH to claude -p sub-agents

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -284,13 +284,13 @@ Return structured result:
 
 In swarm mode, phase agents are NOT invoked via @agent syntax (sub-agents cannot spawn sub-agents). Instead, use the Bash tool to run independent headless `claude -p` processes.
 
-**CRITICAL: You MUST prefix all `claude -p` commands with `env -u CLAUDECODE` to unset the CLAUDECODE environment variable. Without this, claude -p will fail with "Claude Code cannot be launched inside another Claude Code session".**
+**CRITICAL: You MUST prefix all `claude -p` commands with `env -u CLAUDECODE ENABLE_TOOL_SEARCH=auto:30` to unset the CLAUDECODE environment variable and enable deferred tool loading. Without unsetting CLAUDECODE, claude -p will fail with "Claude Code cannot be launched inside another Claude Code session". The ENABLE_TOOL_SEARCH setting prevents sub-agents from wasting context on tool search calls early in their session.**
 
 **MCP Config:** Read the file `.claude/iloom-swarm-mcp-config-path` in your worktree. This file contains the absolute path to your per-loom MCP config file. Use this path with `--mcp-config <path>` in all `claude -p` commands.
 
 **Command template:**
 ```bash
-env -u CLAUDECODE claude -p \
+env -u CLAUDECODE ENABLE_TOOL_SEARCH=auto:30 claude -p \
   --append-system-prompt-file {{EPIC_WORKTREE_PATH}}/.claude/agents/<agent-file>.md \
   --mcp-config <path-from-.claude/iloom-swarm-mcp-config-path> \
   --model <model-from-metadata> \


### PR DESCRIPTION
## Summary
- Adds `ENABLE_TOOL_SEARCH=auto:30` to the `env` prefix for all `claude -p` invocations in swarm mode
- Prevents sub-agents (evaluator, analyzer, planner, implementer) from wasting context on tool search calls early in their session
- Matches the same setting already applied to the orchestrator process in `ignite.ts`

## Test plan
- [ ] Run a swarm and verify sub-agents don't invoke ToolSearch below 30% context usage