### PR TITLE
chore: add husky post-merge hook to auto-rebuild after pull

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Rebuild after merge so `il` CLI is up to date
+pnpm build


### PR DESCRIPTION
## Summary

- Adds a `post-merge` hook to `.husky/` that runs `pnpm build` after every `git pull`
- Ensures the `il` CLI is always up to date after pulling new commits
- Previously a `post-merge` hook existed in `.git/hooks/` but was ignored because Husky sets `core.hooksPath` to `.husky/_`

## Test plan

- [ ] Run `git pull` after merging this PR and verify `pnpm build` runs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)