### PR TITLE
fix: allow GIT_EDITOR=true git rebase in conflict wizard

### DIFF
--- a/src/lib/MergeManager.ts
+++ b/src/lib/MergeManager.ts
@@ -489,6 +489,7 @@ export class MergeManager {
 			'Bash(git log:*)',
 			'Bash(git add:*)',
 			'Bash(git rebase:*)',
+			'Bash(GIT_EDITOR=true git rebase:*)',
 		]
 
 		try {


### PR DESCRIPTION
## Summary
- The rebase conflict resolution wizard's allowed tools list only included `Bash(git rebase:*)`, which doesn't match commands prefixed with `GIT_EDITOR=true`
- Added `Bash(GIT_EDITOR=true git rebase:*)` so Claude can run `GIT_EDITOR=true git rebase --continue` without prompting the user

## Test plan
- [ ] Trigger a rebase conflict during `il finish` and verify the wizard can run `GIT_EDITOR=true git rebase --continue` without a permission prompt