### PR TITLE
feat: add epic decomposition guidance to non-swarm prompts

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -1327,11 +1327,16 @@ When the user requests help, **YOU MUST USE subagents** to preserve your context
 | New features / complex changes | `@agent-iloom-issue-analyze-and-plan` → if approved, `@agent-iloom-issue-implementer` |
 | Deep questions (how/why something works) | `@agent-iloom-issue-analyzer` |
 | Out-of-scope requests | Ask user: help anyway, create new issue, or skip |
+| Epic decomposition / large task breakdown | Recommend `il plan <epic-number>` then `il start <epic-number>` (see below) |
 | Ready to wrap up | Show Wrapping Up Instructions (see below) |
 
 After handling each request, summarize what was done and confirm you're still available.
 
 Use `recap.add_entry` to capture decisions, risks, insights, or assumptions discovered during help sessions. Do not log status updates or task completions.
+
+### Epic Decomposition
+
+When an epic issue is created or the user wants to break a large task into child issues, recommend they run `il plan <epic-number>` to decompose the epic into child issues with dependency analysis, then `il start <epic-number>` to launch swarm mode for parallel implementation. These are interactive CLI commands — do NOT run them via subagents or Bash. Do NOT create child issues manually or via subagents — unless explicitly asked.
 {{/if}}
 
 ---

--- a/templates/prompts/pr-prompt.txt
+++ b/templates/prompts/pr-prompt.txt
@@ -117,11 +117,16 @@ When the user requests help, **prefer subagents** to preserve your context windo
 | Deep questions (how/why something works) | `@agent-iloom-issue-analyzer` |
 | Code review request | `@agent-iloom-code-reviewer` (foreground) |
 | Out-of-scope requests | Ask user: help anyway, create new issue, or skip |
+| Epic decomposition / large task breakdown | Recommend `il plan <epic-number>` then `il start <epic-number>` (see below) |
 | Ready to wrap up | Show Wrapping Up Instructions (see below) |
 
 After handling each request, summarize what was done and confirm you're still available.
 
 Use `recap.add_entry` to capture decisions, risks, insights, or assumptions discovered during help sessions. Do not log status updates or task completions.
+
+### Epic Decomposition
+
+When an epic issue is created or the user wants to break a large task into child issues, recommend they run `il plan <epic-number>` to decompose the epic into child issues with dependency analysis, then `il start <epic-number>` to launch swarm mode for parallel implementation. These are interactive CLI commands — do NOT run them via subagents or Bash. Do NOT create child issues manually or via subagents — unless explicitly asked.
 
 {{#if ARTIFACT_REVIEW_ENABLED}}
 ---

--- a/templates/prompts/regular-prompt.txt
+++ b/templates/prompts/regular-prompt.txt
@@ -768,11 +768,16 @@ When the user requests help, **prefer subagents** to preserve your context windo
 | New features / complex changes | `@agent-iloom-issue-analyze-and-plan` → if approved, `@agent-iloom-issue-implementer` |
 | Deep questions (how/why something works) | `@agent-iloom-issue-analyzer` |
 | Out-of-scope requests | Ask user: help anyway, create new issue, or skip |
+| Epic decomposition / large task breakdown | Recommend `il plan <epic-number>` then `il start <epic-number>` (see below) |
 | Ready to wrap up | Show Wrapping Up Instructions (see below) |
 
 After handling each request, summarize what was done and confirm you're still available.
 
 Use `recap.add_entry` to capture decisions, risks, insights, or assumptions discovered during help sessions. Do not log status updates or task completions.
+
+### Epic Decomposition
+
+When an epic issue is created or the user wants to break a large task into child issues, recommend they run `il plan <epic-number>` to decompose the epic into child issues with dependency analysis, then `il start <epic-number>` to launch swarm mode for parallel implementation. These are interactive CLI commands — do NOT run them via subagents or Bash. Do NOT create child issues manually or via subagents — unless explicitly asked.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds "Epic Decomposition" guidance to issue, PR, and regular prompt templates (non-swarm mode only)
- Adds a row to the Handling Requests table routing epic/large task breakdown requests
- Recommends users run `il plan <epic-number>` then `il start <epic-number>` instead of manually creating child issues
- Explicitly warns agents not to run these commands via subagents/Bash and not to create child issues manually

## Test plan
- [ ] Verify `issue-prompt.txt` renders correctly with the new section in non-swarm mode
- [ ] Verify `pr-prompt.txt` renders correctly with the new section
- [ ] Verify `regular-prompt.txt` renders correctly with the new section
- [ ] Confirm the guidance does not appear in swarm mode prompts