### PR TITLE
fix: remove gh pr/issue view from disallowed tools

### DIFF
--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -1016,7 +1016,7 @@ describe('IgniteCommand', () => {
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('disallowedTools')
-				expect(launchClaudeCall[1].disallowedTools).toEqual(['Bash(gh api:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh issue comment:*)'])
+				expect(launchClaudeCall[1].disallowedTools).toEqual(['Bash(gh api:*), Bash(gh issue comment:*)'])
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -1080,7 +1080,7 @@ describe('IgniteCommand', () => {
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('disallowedTools')
-				expect(launchClaudeCall[1].disallowedTools).toEqual(['Bash(gh api:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh issue comment:*)'])
+				expect(launchClaudeCall[1].disallowedTools).toEqual(['Bash(gh api:*), Bash(gh issue comment:*)'])
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -1154,7 +1154,7 @@ describe('IgniteCommand', () => {
 					'mcp__recap__set_loom_state',
 					'mcp__recap__get_loom_state',
 				])
-				expect(launchClaudeCall[1].disallowedTools).toEqual(['Bash(gh api:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh issue comment:*)'])
+				expect(launchClaudeCall[1].disallowedTools).toEqual(['Bash(gh api:*), Bash(gh issue comment:*)'])
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -382,7 +382,7 @@ export class IgniteCommand {
 					allowedTools = context.type === 'pr'
 						? [...baseTools, 'mcp__issue_management__get_pr', 'mcp__recap__set_goal']
 						: baseTools
-					disallowedTools = ['Bash(gh api:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh issue comment:*)']
+					disallowedTools = ['Bash(gh api:*), Bash(gh issue comment:*)']
 
 					logger.debug('Configured tool filtering for issue/PR workflow', { allowedTools, disallowedTools })
 				} catch (error) {


### PR DESCRIPTION
## Summary
- Removed `Bash(gh issue view:*)` and `Bash(gh pr view:*)` from the disallowed tools list in ignite command
- Agents can now use `gh pr view` and `gh issue view` directly, which is useful for inspecting PR/issue details
- `Bash(gh api:*)` and `Bash(gh issue comment:*)` remain disallowed since those have MCP equivalents

## Test plan
- [x] Updated test assertions to match new disallowed tools list
- [x] Pre-commit hooks pass (lint, compile, tests, build)