### PR TITLE
fix(telemetry): fix race conditions, event loss, and privacy bugs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,8 @@ const packageJson = getPackageInfo(__filename)
  * Extracted for testability.
  */
 export function handleTelemetryLifecycle(currentVersion: string, jsonMode: boolean): void {
-  const telemetryManager = new TelemetryManager()
+  const service = TelemetryService.getInstance()
+  const telemetryManager = service.getManager()
 
   // First-run disclosure
   if (!telemetryManager.hasBeenDisclosed()) {
@@ -51,7 +52,7 @@ export function handleTelemetryLifecycle(currentVersion: string, jsonMode: boole
       logger.info('')
     }
     telemetryManager.markDisclosed()
-    TelemetryService.getInstance().track('cli.installed', {
+    service.track('cli.installed', {
       version: currentVersion,
       os: process.platform,
       node_version: process.version,
@@ -61,7 +62,7 @@ export function handleTelemetryLifecycle(currentVersion: string, jsonMode: boole
   // Upgrade detection
   const lastVersion = telemetryManager.getLastVersion()
   if (lastVersion && lastVersion !== currentVersion) {
-    TelemetryService.getInstance().track('cli.upgraded', {
+    service.track('cli.upgraded', {
       version: currentVersion,
       previous_version: lastVersion,
       os: process.platform,

--- a/src/lib/TelemetryService.test.ts
+++ b/src/lib/TelemetryService.test.ts
@@ -45,6 +45,14 @@ describe('TelemetryService', () => {
 		})
 	})
 
+	describe('getManager', () => {
+		it('exposes the internal TelemetryManager instance', () => {
+			const manager = createMockManager()
+			const service = new TelemetryService(manager)
+			expect(service.getManager()).toBe(manager)
+		})
+	})
+
 	describe('track', () => {
 		it('sends event via posthog.capture() when enabled', () => {
 			const service = new TelemetryService(createMockManager())


### PR DESCRIPTION
## Summary

- **UUID clobber fix**: `handleTelemetryLifecycle` now uses shared `TelemetryManager` via `TelemetryService.getManager()` instead of creating a separate instance that could overwrite the other's UUID on disk
- **Eager ID generation**: `distinct_id` is generated and persisted in the constructor, so `telemetry.json` never exists on disk with an empty ID
- **Swarm race fix**: `setLastVersion()` skips write when version is unchanged, eliminating the `writeJsonSync` file truncation window that caused duplicate IDs in parallel swarm processes
- **Event loss fix**: PostHog configured with `flushAt: 1, flushInterval: 0` so events send immediately instead of batching — fixes `loom.created`, `loom.finished`, etc. being lost when `process.exit()` kills the process before batch flush
- **Shutdown timeout leak**: `clearTimeout` in `shutdown()` prevents orphaned timer from keeping event loop alive for 1 second after every CLI command
- **Privacy fix**: Corrupted/unreadable config files now default to `enabled: false` instead of silently re-enabling telemetry for users who opted out

## Test plan

- [x] All 60 telemetry tests pass
- [x] Pre-commit hooks pass (lint, compile, tests, build)
- [ ] Verify events appear in PostHog after running `il start` and `il finish`
- [ ] Verify `il telemetry off` + corrupt file does not re-enable telemetry