### PR TITLE
Add MCP tool for fetching PR review comments

### DIFF
--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -1057,7 +1057,7 @@ describe('IgniteCommand', () => {
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('allowedTools')
-				// For PR workflows, get_pr and set_goal are included (user's purpose unclear)
+				// For PR workflows, get_pr, get_review_comments, and set_goal are included (user's purpose unclear)
 				expect(launchClaudeCall[1].allowedTools).toEqual([
 					'mcp__issue_management__get_issue',
 					'mcp__issue_management__get_comment',
@@ -1074,6 +1074,7 @@ describe('IgniteCommand', () => {
 					'mcp__recap__set_loom_state',
 					'mcp__recap__get_loom_state',
 					'mcp__issue_management__get_pr',
+					'mcp__issue_management__get_review_comments',
 					'mcp__recap__set_goal',
 				])
 			} finally {
@@ -1180,7 +1181,7 @@ describe('IgniteCommand', () => {
 			}
 		})
 
-		it('should include mcp__issue_management__get_pr in allowedTools for PR workflows', async () => {
+		it('should include mcp__issue_management__get_pr and get_review_comments in allowedTools for PR workflows', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 			const getRepoInfoSpy = vi.spyOn(githubUtils, 'getRepoInfo').mockResolvedValue({
 				owner: 'testowner',
@@ -1195,6 +1196,7 @@ describe('IgniteCommand', () => {
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1].allowedTools).toContain('mcp__issue_management__get_pr')
+				expect(launchClaudeCall[1].allowedTools).toContain('mcp__issue_management__get_review_comments')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -1202,7 +1204,7 @@ describe('IgniteCommand', () => {
 			}
 		})
 
-		it('should NOT include mcp__issue_management__get_pr in allowedTools for issue workflows', async () => {
+		it('should NOT include mcp__issue_management__get_pr or get_review_comments in allowedTools for issue workflows', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 			const getRepoInfoSpy = vi.spyOn(githubUtils, 'getRepoInfo').mockResolvedValue({
 				owner: 'testowner',
@@ -1217,6 +1219,7 @@ describe('IgniteCommand', () => {
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1].allowedTools).not.toContain('mcp__issue_management__get_pr')
+				expect(launchClaudeCall[1].allowedTools).not.toContain('mcp__issue_management__get_review_comments')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -381,7 +381,7 @@ export class IgniteCommand {
 						'mcp__recap__get_loom_state'
 					]
 					allowedTools = context.type === 'pr'
-						? [...baseTools, 'mcp__issue_management__get_pr', 'mcp__recap__set_goal']
+						? [...baseTools, 'mcp__issue_management__get_pr', 'mcp__issue_management__get_review_comments', 'mcp__recap__set_goal']
 						: baseTools
 					disallowedTools = ['Bash(gh api:*), Bash(gh issue comment:*)']
 

--- a/src/mcp/GitHubIssueManagementProvider.ts
+++ b/src/mcp/GitHubIssueManagementProvider.ts
@@ -8,6 +8,7 @@ import type {
 	IssueManagementProvider,
 	GetIssueInput,
 	GetPRInput,
+	GetReviewCommentsInput,
 	GetCommentInput,
 	CreateCommentInput,
 	UpdateCommentInput,
@@ -23,6 +24,7 @@ import type {
 	CreateIssueResult,
 	IssueResult,
 	PRResult,
+	ReviewCommentResult,
 	CommentDetailResult,
 	CommentResult,
 	DependenciesResult,
@@ -321,6 +323,85 @@ export class GitHubIssueManagementProvider implements IssueManagementProvider {
 		}
 
 		return result
+	}
+
+	/**
+	 * Fetch PR review comments (inline code comments on specific files/lines)
+	 * Uses gh api with --paginate to handle PRs with many review comments
+	 * Optionally filters by review ID
+	 */
+	async getReviewComments(input: GetReviewCommentsInput): Promise<ReviewCommentResult[]> {
+		const { number, reviewId, repo } = input
+
+		// Convert string ID to number for GitHub API
+		const prNumber = parseInt(number, 10)
+		if (isNaN(prNumber)) {
+			throw new Error(`Invalid GitHub PR number: ${number}. GitHub PR IDs must be numeric.`)
+		}
+
+		// Validate reviewId early to avoid unnecessary API call
+		let numericReviewId: number | undefined
+		if (reviewId) {
+			numericReviewId = parseInt(reviewId, 10)
+			if (isNaN(numericReviewId)) {
+				throw new Error(`Invalid review ID: ${reviewId}. Review IDs must be numeric.`)
+			}
+		}
+
+		// GitHub API response structure for review comments
+		interface GitHubReviewComment {
+			id: number
+			body: string
+			path: string
+			line: number | null
+			side: string | null
+			user: GitHubAuthor | null
+			created_at: string
+			updated_at: string | null
+			in_reply_to_id: number | null
+			pull_request_review_id: number | null
+		}
+
+		// Use explicit repo path if provided, otherwise use :owner/:repo placeholder
+		const apiPath = repo
+			? `repos/${repo}/pulls/${prNumber}/comments`
+			: `repos/:owner/:repo/pulls/${prNumber}/comments`
+
+		const args = [
+			'api',
+			apiPath,
+			'--paginate',
+			'--jq',
+			'[.[] | {id: .id, body: .body, path: .path, line: .line, side: .side, user: .user, created_at: .created_at, updated_at: .updated_at, in_reply_to_id: .in_reply_to_id, pull_request_review_id: .pull_request_review_id}]',
+		]
+
+		const raw = await executeGhCommand<GitHubReviewComment[]>(args)
+
+		// Filter by reviewId if provided (already validated above)
+		let comments = raw
+		if (numericReviewId !== undefined) {
+			comments = comments.filter(c => c.pull_request_review_id === numericReviewId)
+		}
+
+		// Normalize and process each comment
+		const results: ReviewCommentResult[] = []
+		for (const comment of comments) {
+			const processedBody = await processMarkdownImages(comment.body, 'github')
+			results.push({
+				id: String(comment.id),
+				body: processedBody,
+				path: comment.path,
+				line: comment.line,
+				side: comment.side,
+				author: normalizeAuthor(comment.user),
+				createdAt: comment.created_at,
+				updatedAt: comment.updated_at ?? null,
+				inReplyToId: comment.in_reply_to_id ? String(comment.in_reply_to_id) : null,
+				pullRequestReviewId: comment.pull_request_review_id,
+			})
+		}
+
+		return results
 	}
 
 	/**

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -38,6 +38,32 @@ export interface GetPRInput {
 }
 
 /**
+ * Input schema for getting PR review comments (inline code comments)
+ * Note: PRs only exist on GitHub, so this always uses GitHub provider
+ */
+export interface GetReviewCommentsInput {
+	number: string // PR number
+	reviewId?: string | undefined // Optional review ID to filter by
+	repo?: string | undefined // Optional repository in "owner/repo" format or full GitHub URL
+}
+
+/**
+ * Output schema for a single PR review comment (inline code comment)
+ */
+export interface ReviewCommentResult {
+	id: string
+	body: string
+	path: string // File path the comment is on
+	line: number | null // Line number in the diff
+	side: string | null // Side of the diff ('LEFT' or 'RIGHT')
+	author: FlexibleAuthor | null
+	createdAt: string
+	updatedAt: string | null
+	inReplyToId: string | null // If this is a reply to another review comment
+	pullRequestReviewId: number | null // The review this comment belongs to
+}
+
+/**
  * Input schema for getting a specific comment
  */
 export interface GetCommentInput {

--- a/templates/prompts/pr-prompt.txt
+++ b/templates/prompts/pr-prompt.txt
@@ -56,6 +56,7 @@ Use these Recap MCP tools:
 ## Comment Routing: PR Mode
 
 - **Read PR details** using `mcp__issue_management__get_pr` with `{ number: "{{PR_NUMBER}}", includeComments: true }`
+- **Read inline code review comments** using `mcp__issue_management__get_review_comments` with `{ number: "{{PR_NUMBER}}" }`
 - **Write comments** to PR #{{PR_NUMBER}} using `type: "pr"`
 
 When calling `mcp__issue_management__create_comment`:
@@ -81,6 +82,14 @@ This will give you:
 - All comments and discussion
 - Commit history (commits) and changed files (files)
 - Current state and branch metadata (headRefName, baseRefName)
+
+To read inline code review comments (comments on specific files and lines), use:
+`mcp__issue_management__get_review_comments` with `{ number: "{{PR_NUMBER}}" }`
+
+This returns:
+- Inline comments on specific files and lines (path, line number, diff side)
+- Review comment threads and replies (inReplyToId)
+- Optionally filter by review ID: `{ number: "{{PR_NUMBER}}", reviewId: "REVIEW_ID" }`
 
 Also check if the branch name contains an issue number (like issue-123) and if so, read that issue for context:
 `mcp__issue_management__get_issue` with `{ number: "{{ISSUE_NUMBER}}", includeComments: true }`


### PR DESCRIPTION
Fixes #714

## Add MCP tool for fetching PR review comments

## Context

When working with PRs in Claude Code, inline review comments (code review comments on specific lines) are not accessible through the existing `get_pr` MCP tool. The `get_pr` tool returns top-level issue comments but not inline review comments left on specific files/lines.

Currently, fetching these requires using `gh api repos/{owner}/{repo}/pulls/{number}/comments` via Bash, which is clunky and not always permitted by the user's permission settings.

## Requirements

Add a new MCP tool (e.g., `get_review_comments`) to the `issue_management` MCP server that:

1. Accepts a PR number and optionally a review ID
2. Returns all inline review comments with their file path, line number, and body
3. Supports both single-review and all-reviews-on-PR queries

## Implementation Notes

- Update the `we_allow` tools list to include the new MCP tool so agents can use it
- The tool should work with the GitHub provider (and potentially other providers that support review comments)
- Follow the existing patterns in the issue_management MCP server for tool registration

---
*This PR was created automatically by iloom.*