### PR TITLE
fix(prompts): add update_comment examples with type param

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -76,6 +76,16 @@ When calling `mcp__issue_management__create_comment`:
   type: "issue"
 }
 ```
+
+When calling `mcp__issue_management__update_comment`:
+```
+{
+  commentId: "COMMENT_ID",
+  number: "<issue-number-from-task-prompt>",
+  body: "updated comment content",
+  type: "issue"
+}
+```
 {{else}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
@@ -99,6 +109,16 @@ When calling `mcp__issue_management__create_comment`:
 {
   number: "{{DRAFT_PR_NUMBER}}",
   body: "your comment content",
+  type: "pr"
+}
+```
+
+When calling `mcp__issue_management__update_comment`:
+```
+{
+  commentId: "COMMENT_ID",
+  number: "{{DRAFT_PR_NUMBER}}",
+  body: "updated comment content",
   type: "pr"
 }
 ```
@@ -131,6 +151,16 @@ When calling `mcp__issue_management__create_comment`:
 {
   number: "{{ISSUE_NUMBER}}",
   body: "your comment content",
+  type: "issue"
+}
+```
+
+When calling `mcp__issue_management__update_comment`:
+```
+{
+  commentId: "COMMENT_ID",
+  number: "{{ISSUE_NUMBER}}",
+  body: "updated comment content",
   type: "issue"
 }
 ```

--- a/templates/prompts/pr-prompt.txt
+++ b/templates/prompts/pr-prompt.txt
@@ -68,6 +68,16 @@ When calling `mcp__issue_management__create_comment`:
 }
 ```
 
+When calling `mcp__issue_management__update_comment`:
+```
+{
+  commentId: "COMMENT_ID",
+  number: "{{PR_NUMBER}}",
+  body: "updated comment content",
+  type: "pr"
+}
+```
+
 This ensures PR comments always go to GitHub regardless of the configured issue tracker.
 
 ---

--- a/templates/prompts/regular-prompt.txt
+++ b/templates/prompts/regular-prompt.txt
@@ -80,6 +80,16 @@ When calling `mcp__issue_management__create_comment`:
 }
 ```
 
+When calling `mcp__issue_management__update_comment`:
+```
+{
+  commentId: "COMMENT_ID",
+  number: "{{DRAFT_PR_NUMBER}}",
+  body: "updated comment content",
+  type: "pr"
+}
+```
+
 This keeps all AI workflow comments on the draft PR for visibility and traceability.
 {{/if}}
 {{#if STANDARD_BRANCH_MODE}}


### PR DESCRIPTION
## Summary
- Adds `update_comment` examples alongside existing `create_comment` examples in all Comment Routing sections
- Without `type: "pr"`, `update_comment` defaults to Linear and returns "Linear issue or resource not found"
- Updated templates: `issue-prompt.txt`, `regular-prompt.txt`, `pr-prompt.txt`

## Test plan
- [ ] Verify agents in draft PR mode correctly include `type: "pr"` when calling `update_comment`