### PR TITLE
The main wrap-up commands at the end of the issue workflow and maybe the others don't account for if the command is running in Visual Studio.

### DIFF
--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -561,6 +561,64 @@ describe('IgniteCommand', () => {
 		})
 	})
 
+	describe('VS Code mode detection', () => {
+		it('should pass IS_VSCODE_MODE: true when ILOOM_VSCODE=1', async () => {
+			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
+
+			const originalCwd = process.cwd
+			process.cwd = vi.fn().mockReturnValue('/path/to/feat/issue-50__vscode-test')
+
+			const originalEnv = process.env.ILOOM_VSCODE
+			process.env.ILOOM_VSCODE = '1'
+
+			try {
+				await command.execute()
+
+				expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+					'issue',
+					expect.objectContaining({
+						IS_VSCODE_MODE: true,
+					})
+				)
+			} finally {
+				process.cwd = originalCwd
+				launchClaudeSpy.mockRestore()
+				if (originalEnv === undefined) {
+					delete process.env.ILOOM_VSCODE
+				} else {
+					process.env.ILOOM_VSCODE = originalEnv
+				}
+			}
+		})
+
+		it('should pass IS_VSCODE_MODE: false when ILOOM_VSCODE is not set', async () => {
+			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
+
+			const originalCwd = process.cwd
+			process.cwd = vi.fn().mockReturnValue('/path/to/feat/issue-50__vscode-test')
+
+			const originalEnv = process.env.ILOOM_VSCODE
+			delete process.env.ILOOM_VSCODE
+
+			try {
+				await command.execute()
+
+				expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+					'issue',
+					expect.objectContaining({
+						IS_VSCODE_MODE: false,
+					})
+				)
+			} finally {
+				process.cwd = originalCwd
+				launchClaudeSpy.mockRestore()
+				if (originalEnv !== undefined) {
+					process.env.ILOOM_VSCODE = originalEnv
+				}
+			}
+		})
+	})
+
 	describe('Error Handling', () => {
 		it('should handle git command failures gracefully', async () => {
 			// Spy on launchClaude

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -587,6 +587,10 @@ export class IgniteCommand {
 			variables.STANDARD_ISSUE_MODE = true
 		}
 
+		// Detect VS Code mode
+		const isVscodeMode = process.env.ILOOM_VSCODE === '1'
+		variables.IS_VSCODE_MODE = isVscodeMode
+
 		return variables
 	}
 

--- a/src/lib/ClaudeService.test.ts
+++ b/src/lib/ClaudeService.test.ts
@@ -89,6 +89,7 @@ describe('ClaudeService', () => {
 					ISSUE_TITLE: 'Add authentication',
 					WORKSPACE_PATH: '/workspace/issue-123',
 					PORT: 3123,
+					IS_VSCODE_MODE: false,
 				})
 
 				expect(claudeUtils.launchClaudeInNewTerminalWindow).toHaveBeenCalledWith(prompt, {
@@ -119,6 +120,7 @@ describe('ClaudeService', () => {
 					ISSUE_NUMBER: 123,
 					WORKSPACE_PATH: '/workspace',
 					PORT: 3123,
+					IS_VSCODE_MODE: false,
 				})
 			})
 
@@ -138,6 +140,7 @@ describe('ClaudeService', () => {
 				expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith('issue', {
 					ISSUE_NUMBER: 123,
 					WORKSPACE_PATH: '/workspace',
+					IS_VSCODE_MODE: false,
 				})
 			})
 		})
@@ -164,6 +167,7 @@ describe('ClaudeService', () => {
 					PR_TITLE: 'Fix bug',
 					WORKSPACE_PATH: '/workspace/pr-456',
 					PORT: 3456,
+					IS_VSCODE_MODE: false,
 				})
 
 				// PR workflow uses acceptEdits permission mode by default
@@ -194,6 +198,7 @@ describe('ClaudeService', () => {
 
 				expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith('regular', {
 					WORKSPACE_PATH: '/workspace/feature',
+					IS_VSCODE_MODE: false,
 				})
 
 				// Regular workflow uses acceptEdits permission mode by default
@@ -204,6 +209,70 @@ describe('ClaudeService', () => {
 					headless: false,
 					oneShot: 'default',
 				})
+			})
+		})
+
+		describe('VS Code mode detection', () => {
+			it('should pass IS_VSCODE_MODE: true when ILOOM_VSCODE=1', async () => {
+				const originalEnv = process.env.ILOOM_VSCODE
+				process.env.ILOOM_VSCODE = '1'
+
+				try {
+					const options: ClaudeWorkflowOptions = {
+						type: 'issue',
+						issueNumber: 123,
+						workspacePath: '/workspace/issue-123',
+					}
+
+					const prompt = 'Issue prompt'
+					vi.mocked(mockTemplateManager.getPrompt).mockResolvedValueOnce(prompt)
+					vi.mocked(claudeUtils.launchClaudeInNewTerminalWindow).mockResolvedValueOnce(undefined)
+
+					await service.launchForWorkflow(options)
+
+					expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+						'issue',
+						expect.objectContaining({
+							IS_VSCODE_MODE: true,
+						})
+					)
+				} finally {
+					if (originalEnv === undefined) {
+						delete process.env.ILOOM_VSCODE
+					} else {
+						process.env.ILOOM_VSCODE = originalEnv
+					}
+				}
+			})
+
+			it('should pass IS_VSCODE_MODE: false when ILOOM_VSCODE is not set', async () => {
+				const originalEnv = process.env.ILOOM_VSCODE
+				delete process.env.ILOOM_VSCODE
+
+				try {
+					const options: ClaudeWorkflowOptions = {
+						type: 'issue',
+						issueNumber: 123,
+						workspacePath: '/workspace/issue-123',
+					}
+
+					const prompt = 'Issue prompt'
+					vi.mocked(mockTemplateManager.getPrompt).mockResolvedValueOnce(prompt)
+					vi.mocked(claudeUtils.launchClaudeInNewTerminalWindow).mockResolvedValueOnce(undefined)
+
+					await service.launchForWorkflow(options)
+
+					expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+						'issue',
+						expect.objectContaining({
+							IS_VSCODE_MODE: false,
+						})
+					)
+				} finally {
+					if (originalEnv !== undefined) {
+						process.env.ILOOM_VSCODE = originalEnv
+					}
+				}
 			})
 		})
 

--- a/src/lib/ClaudeService.ts
+++ b/src/lib/ClaudeService.ts
@@ -94,6 +94,10 @@ export class ClaudeService {
 				variables.PORT = port
 			}
 
+			// Detect VS Code mode
+			const isVscodeMode = process.env.ILOOM_VSCODE === '1'
+			variables.IS_VSCODE_MODE = isVscodeMode
+
 			// Get the prompt from template manager
 			const prompt = await this.templateManager.getPrompt(type, variables)
 

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -1396,6 +1396,24 @@ When an epic issue is created or the user wants to break a large task into child
 
 When the user says they're done or ready to wrap up, provide these instructions:
 
+{{#if IS_VSCODE_MODE}}
+"## Wrapping Up
+
+To complete the workflow and merge your changes:
+
+1. In the iloom Explorer panel, click the **Finish** flag on this loom
+
+This will automatically detect the current issue and:
+- Stop any running web servers for this issue
+- Merge your changes back to the main branch
+- Clean up the worktree
+- Delete the database branch (if applicable)
+- Remove the workspace
+
+Alternatively, you can exit this Claude session (type `/exit`) and run `iloom finish` from the terminal.
+
+2. Once the finish process completes, you can close any IDE windows that were opened specifically for this issue"
+{{else}}
 "## Wrapping Up
 
 To complete the workflow and merge your changes:
@@ -1414,4 +1432,5 @@ This will automatically detect the current issue and:
 - Remove the workspace
 
 3. Once the finish command completes, you can close any terminal or IDE windows that were opened specifically for this issue"
+{{/if}}
 {{/unless}}

--- a/templates/prompts/pr-prompt.txt
+++ b/templates/prompts/pr-prompt.txt
@@ -269,6 +269,24 @@ This is NOT optional - if the reviewer requests Claude Local Review, it must be 
 
 When the user says they're done or ready to wrap up, provide these instructions:
 
+{{#if IS_VSCODE_MODE}}
+"## Wrapping Up
+
+To complete the workflow and merge your changes:
+
+1. In the iloom Explorer panel, click the **Finish** flag on this loom
+
+This will automatically detect the current PR and:
+- Stop any running web servers for this PR
+- Merge your changes back to the main branch
+- Clean up the worktree
+- Delete the database branch (if applicable)
+- Remove the workspace
+
+Alternatively, you can exit this Claude session (type `/exit`) and run `iloom finish` from the terminal.
+
+2. Once the finish process completes, you can close any IDE windows that were opened specifically for this PR"
+{{else}}
 "## Wrapping Up
 
 To complete the workflow and merge your changes:
@@ -287,3 +305,4 @@ This will automatically detect the current PR and:
 - Remove the workspace
 
 3. Once the finish command completes, you can close any terminal or IDE windows that were opened specifically for this PR"
+{{/if}}

--- a/templates/prompts/regular-prompt.txt
+++ b/templates/prompts/regular-prompt.txt
@@ -795,6 +795,31 @@ When an epic issue is created or the user wants to break a large task into child
 
 When the user says they're done or ready to wrap up, provide these instructions:
 
+{{#if IS_VSCODE_MODE}}
+"## Wrapping Up
+
+Your changes have been implemented in the current branch.
+
+**Note: This was branch mode - no GitHub issue is associated with this work. Context from this session is ephemeral and not persisted.**
+
+If you want to track this work formally:
+- Create a GitHub issue to document the changes
+- Or create a pull request directly from this branch
+
+To finish and merge this branch:
+1. In the iloom Explorer panel, click the **Finish** flag on this loom
+
+This will automatically:
+- Stop any running web servers
+- Merge your changes back to the main branch
+- Clean up the worktree
+- Delete the database branch (if applicable)
+- Remove the workspace
+
+Alternatively, you can exit this Claude session (type `/exit`) and run `iloom finish` from the terminal.
+
+2. Once the finish process completes, you can close any IDE windows that were opened for this branch"
+{{else}}
 "## Wrapping Up
 
 Your changes have been implemented in the current branch.
@@ -818,3 +843,4 @@ This will automatically:
 - Clean up the worktree
 - Delete the database branch (if applicable)
 - Remove the workspace"
+{{/if}}


### PR DESCRIPTION
Fixes #719

## The main wrap-up commands at the end of the issue workflow and maybe the others don't account for if the command is running in Visual Studio.

Tell you to exit and run the finish command, but they should be telling you to look for the Finish flag in the iloom Explorer.  Any of the users are running in Visual Studio. I think the environment variable is ILOOM_VSCODE=1

---
*This PR was created automatically by iloom.*