### PR TITLE
fix(list): scope enrichSwarmIssues by projectPath to prevent cross-project collisions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1139,7 +1139,7 @@ program
             activeJson = globalActiveLooms.map(loom => {
               const isEpic = (loom.issueType ?? 'branch') === 'epic'
               const swarmIssues = isEpic && loom.childIssues && loom.childIssues.length > 0
-                ? enrichSwarmIssues(loom.childIssues, globalActiveLooms, finishedLooms)
+                ? enrichSwarmIssues(loom.childIssues, globalActiveLooms, finishedLooms, loom.projectPath)
                 : isEpic ? [] : undefined
               const depMap = isEpic
                 ? (loom.dependencyMap && Object.keys(loom.dependencyMap).length > 0


### PR DESCRIPTION
## Summary
- `enrichSwarmIssues()` now accepts an optional `projectPath` parameter and filters metadata to entries from the same project before building lookup maps
- Adds `resolvePathSafe()` helper using `realpathSync` with try-catch fallback for symlink-safe path comparison
- Updates all call sites (`formatLoomForJson`, `formatFinishedLoomForJson`, `cli.ts` global mode) to pass `projectPath`
- Adds 6 new test cases covering cross-project collision prevention, finished metadata scoping, null/undefined backward compat, symlink handling, and legacy metadata exclusion

## Context
Issue numbers are only unique within a project, not globally. When a child loom's metadata is archived, the lookup maps in `enrichSwarmIssues` could match a different project's metadata with the same issue number — returning wrong `state` and `worktreePath`.

## Test plan
- [x] All existing tests pass (4246 passed)
- [x] New project-scoped filtering tests pass
- [x] `pnpm build` compiles clean
- [ ] Manual: run `il list --json` from a project with epic looms and verify `swarmIssues` show correct `state`/`worktreePath` for archived children