### PR TITLE
fix(plan): remove emoji prefix from YOLO mode warning

### DIFF
--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -472,7 +472,7 @@ describe('PlanCommand', () => {
 			await command.execute('test prompt', undefined, true)
 
 			expect(logger.warn).toHaveBeenCalledWith(
-				'⚠️  YOLO mode enabled - Claude will skip permission prompts and proceed autonomously. This could destroy important data or make irreversible changes. Proceeding means you accept this risk.'
+				'YOLO mode enabled - Claude will skip permission prompts and proceed autonomously. This could destroy important data or make irreversible changes. Proceeding means you accept this risk.'
 			)
 		})
 	})

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -467,7 +467,7 @@ export class PlanCommand {
 				throw new Error('--yolo requires a prompt or issue identifier (e.g., il plan --yolo "add gitlab support" or il plan --yolo 42)')
 			}
 			logger.warn(
-				'⚠️  YOLO mode enabled - Claude will skip permission prompts and proceed autonomously. This could destroy important data or make irreversible changes. Proceeding means you accept this risk.'
+				'YOLO mode enabled - Claude will skip permission prompts and proceed autonomously. This could destroy important data or make irreversible changes. Proceeding means you accept this risk.'
 			)
 		}
 


### PR DESCRIPTION
## Summary
- Remove the `⚠️` emoji prefix from the YOLO mode warning message in `il plan`
- Update corresponding test assertion to match

## Test plan
- [x] Pre-commit hooks pass (lint, compile, tests, build)