### PR TITLE
Add swarmModel field to per-agent settings and workerModel to spin config

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -1626,7 +1626,7 @@ The swarm worker agent defaults to `sonnet`. To override, configure it via `.ilo
 }
 ```
 
-You can also set the worker model from the spin config using `swarmModel`:
+You can also set a different model for the spin orchestrator when running in swarm mode using `swarmModel`:
 
 ```json
 {
@@ -1637,7 +1637,7 @@ You can also set the worker model from the spin config using `swarmModel`:
 }
 ```
 
-The `spin.swarmModel` field is especially useful for presets that need to configure both the orchestrator and worker models together. The `agents.iloom-swarm-worker.model` setting takes priority over `spin.swarmModel`.
+In this example, `spin.model` (`sonnet`) is used when spin runs in issue, PR, or branch mode, while `spin.swarmModel` (`opus`) is used when spin runs in swarm mode. If `swarmModel` is not set, spin uses `model` for all modes. Note that `spin.swarmModel` only affects the spin orchestrator itself — it does not affect swarm worker agents or phase agents.
 
 **Phase Agent Model Overrides (Swarm Mode):**
 
@@ -1654,58 +1654,23 @@ Each agent supports a `swarmModel` field for a clean, per-agent swarm model over
 }
 ```
 
-For more granular control, you can also use the nested `agents.iloom-swarm-worker.agents` structure:
+If `swarmModel` is set for an agent, it overrides the agent's model in swarm mode. If not set, the agent uses its base `model` (or `.md` default) in both modes.
 
-```json
-{
-  "agents": {
-    "iloom-issue-implementer": { "model": "opus" },
-    "iloom-issue-planner": { "model": "opus" },
-    "iloom-swarm-worker": {
-      "model": "sonnet",
-      "agents": {
-        "iloom-issue-implementer": { "model": "haiku" }
-      }
-    }
-  }
-}
-```
+With the configuration above:
 
-**Fallback chain** for phase agent models in swarm mode (highest priority first):
-
-1. `agents.iloom-swarm-worker.agents.<agent-name>.model` -- Swarm-specific per-agent override
-2. `agents.<agent-name>.swarmModel` -- Per-agent swarm model
-3. `agents.iloom-swarm-worker.model` -- Blanket swarm worker model
-4. `spin.swarmModel` -- Spin config blanket swarm model
-5. Built-in swarm defaults (e.g., implementer defaults to `sonnet`)
-6. `agents.<agent-name>.model` -- Base per-agent override (also used in non-swarm mode)
-7. Agent default from `.md` file
-
-With the nested configuration above, the resolved models are:
-
-| Agent | Non-swarm mode | Swarm mode | Why |
-|-------|---------------|------------|-----|
-| `iloom-issue-implementer` | `opus` (base per-agent) | `haiku` (swarm-specific override) | Fallback step 1 |
-| `iloom-issue-planner` | `opus` (base per-agent) | `sonnet` (blanket swarm model) | Fallback step 3 |
-| `iloom-issue-analyzer` | `.md` default | `sonnet` (blanket swarm model) | Fallback step 3 |
-
-> **Important:** The blanket swarm model (step 3) overrides the base per-agent model (step 6). In the example above, `iloom-issue-planner` uses `opus` in non-swarm mode (from the base config) but `sonnet` in swarm mode (from the blanket swarm worker model). If you want a specific agent to use a different model than the blanket in swarm mode, use a swarm-specific per-agent override (step 1) or a per-agent `swarmModel` (step 2).
-
-> **Note:** The blanket overrides (steps 3-4) only activate when explicitly set in your configuration. If neither `agents.iloom-swarm-worker.model` nor `spin.swarmModel` is configured, phase agents in swarm mode use their per-agent `swarmModel`, built-in defaults, base per-agent model, or `.md` default -- the worker agent's implicit `sonnet` default does not propagate to phase agents.
+| Agent | Non-swarm mode | Swarm mode |
+|-------|---------------|------------|
+| `iloom-issue-implementer` | `opus` | `sonnet` (swarmModel) |
+| `iloom-issue-complexity-evaluator` | `haiku` | `haiku` (swarmModel) |
+| `iloom-issue-analyzer` | `.md` default | `.md` default (no swarmModel set) |
 
 **Example using the `--set` flag:**
 
 ```bash
-# Override a specific phase agent's model in swarm mode
-il spin --set agents.iloom-swarm-worker.agents.iloom-issue-implementer.model=sonnet
-
 # Set per-agent swarmModel
 il spin --set agents.iloom-issue-implementer.swarmModel=sonnet
 
-# Override ALL phase agent models in swarm mode
-il spin --set agents.iloom-swarm-worker.model=sonnet
-
-# Set worker model from spin config
+# Set spin orchestrator model for swarm mode
 il spin --set spin.swarmModel=sonnet
 ```
 

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -989,7 +989,7 @@ export class IgniteCommand {
 		]
 
 		// Launch Claude with agent teams enabled
-		const model = this.settingsManager.getSpinModel(settings)
+		const model = this.settingsManager.getSpinModel(settings, 'swarm')
 
 		logger.info('Launching swarm orchestrator...')
 		logger.info(`   Model: ${model ?? 'default'}`)

--- a/src/lib/SettingsManager.test.ts
+++ b/src/lib/SettingsManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { SettingsManager, BaseAgentSettingsSchema, SpinAgentSettingsSchema } from './SettingsManager.js'
+import { SettingsManager, BaseAgentSettingsSchema, SpinAgentSettingsSchema, type IloomSettings } from './SettingsManager.js'
 import { readFile } from 'fs/promises'
 
 // Mock fs/promises
@@ -2846,6 +2846,24 @@ const error: { code?: string; message: string } = {
 			// the default 'opus' should be applied
 			const settings = { sourceEnvOnStart: false, spin: {} as { model: 'opus' } }
 			const result = settingsManager.getSpinModel(settings)
+			expect(result).toBe('opus')
+		})
+
+		it('should return spin.swarmModel when mode is swarm and swarmModel is set', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'opus' as const, swarmModel: 'sonnet' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
+			expect(result).toBe('sonnet')
+		})
+
+		it('should fall back to spin.model when mode is swarm but swarmModel is not set', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'haiku' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
+			expect(result).toBe('haiku')
+		})
+
+		it('should ignore swarmModel when mode is not swarm', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'opus' as const, swarmModel: 'sonnet' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings)
 			expect(result).toBe('opus')
 		})
 	})

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -35,13 +35,12 @@ export const BaseAgentSettingsSchema = z.object({
 })
 
 /**
- * Zod schema for agent settings, extends base with optional nested agents sub-record.
- * The nested agents field is used for swarm-specific per-agent overrides under iloom-swarm-worker.
+ * Zod schema for agent settings, extends base with sub-agent timeout and nested agents record.
  */
 export const AgentSettingsSchema = BaseAgentSettingsSchema.extend({
 	agents: z.record(z.string(), BaseAgentSettingsSchema)
 		.optional()
-		.describe('Nested per-agent model overrides for swarm mode. Configure under agents.iloom-swarm-worker.agents.<agent-name>.model to set a different model for phase agents when running inside swarm workers. Fallback chain: swarm-specific agent model > explicit swarm worker model > base agent model. Only meaningful under the iloom-swarm-worker agent entry.'),
+		.describe('Nested per-agent settings. Only meaningful under the iloom-swarm-worker agent entry for sub-agent timeout configuration.'),
 	subAgentTimeout: z
 		.number()
 		.min(1, 'Sub-agent timeout must be at least 1 minute')
@@ -62,7 +61,7 @@ export const SpinAgentSettingsSchema = z.object({
 	swarmModel: z
 		.enum(['sonnet', 'opus', 'haiku'])
 		.optional()
-		.describe('Model for swarm worker agents. Sets the default model for all phase agents in swarm mode when not overridden by per-agent swarm-specific settings.'),
+		.describe('Model for the spin orchestrator when running in swarm mode. Overrides spin.model for swarm workflows.'),
 })
 
 /**
@@ -350,7 +349,7 @@ export const IloomSettingsSchema = z.object({
 				'iloom-code-reviewer (reviews code changes against requirements), ' +
 				'iloom-artifact-reviewer (reviews artifacts before posting), ' +
 				'iloom-swarm-worker (swarm worker agent, dynamically generated). ' +
-				'The iloom-swarm-worker agent supports a nested "agents" sub-record for configuring phase agent models specifically in swarm mode.',
+				'Use swarmModel on any agent to override its model in swarm mode.',
 		),
 	spin: SpinAgentSettingsSchema.optional().describe(
 		'Spin orchestrator configuration. Model defaults to opus when not configured.',
@@ -596,7 +595,7 @@ export const IloomSettingsSchemaNoDefaults = z.object({
 				'iloom-code-reviewer (reviews code changes against requirements), ' +
 				'iloom-artifact-reviewer (reviews artifacts before posting), ' +
 				'iloom-swarm-worker (swarm worker agent, dynamically generated). ' +
-				'The iloom-swarm-worker agent supports a nested "agents" sub-record for configuring phase agent models specifically in swarm mode.',
+				'Use swarmModel on any agent to override its model in swarm mode.',
 		),
 	spin: z
 		.object({
@@ -1122,7 +1121,10 @@ export class SettingsManager {
 	 * @param settings - Pre-loaded settings object
 	 * @returns Model shorthand ('opus', 'sonnet', or 'haiku')
 	 */
-	getSpinModel(settings?: IloomSettings): 'sonnet' | 'opus' | 'haiku' {
+	getSpinModel(settings?: IloomSettings, mode?: 'swarm'): 'sonnet' | 'opus' | 'haiku' {
+		if (mode === 'swarm' && settings?.spin?.swarmModel) {
+			return settings.spin.swarmModel
+		}
 		return settings?.spin?.model ?? SpinAgentSettingsSchema.parse({}).model
 	}
 

--- a/src/lib/SwarmSetupService.test.ts
+++ b/src/lib/SwarmSetupService.test.ts
@@ -326,7 +326,7 @@ describe('SwarmSetupService', () => {
 			const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
 
 			expect(result.metadata).toHaveProperty('iloom-swarm-issue-implementer')
-			expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
+			expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('opus')
 			expect(result.metadata['iloom-swarm-issue-implementer']!.tools).toEqual(['Bash', 'Read'])
 		})
 
@@ -345,346 +345,7 @@ describe('SwarmSetupService', () => {
 			expect(result.metadata['iloom-swarm-issue-analyzer']).not.toHaveProperty('tools')
 		})
 
-		describe('swarm-specific model overrides', () => {
-			it('uses swarm-specific agent model override when configured', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							agents: {
-								'iloom-issue-implementer': { model: 'sonnet' },
-							},
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-			})
-
-			it('falls back to swarm worker model when no agent-specific override', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							model: 'haiku',
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
-			})
-
-			it('blanket swarm model overrides base per-agent model', async () => {
-				// This tests the most subtle behavior: when the user sets BOTH:
-				// - agents.iloom-issue-implementer.model = 'opus' (base per-agent)
-				// - agents.iloom-swarm-worker.model = 'sonnet' (blanket swarm)
-				// The blanket swarm model should win in swarm mode.
-				// loadAgents has already applied the base per-agent model ('opus'),
-				// so the override logic must replace it with the blanket swarm model.
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-issue-implementer': { model: 'opus' },
-						'iloom-swarm-worker': {
-							model: 'sonnet',
-						},
-					},
-				} as unknown as IloomSettings)
-
-				// loadAgents returns the agent with model='opus' (applied from base per-agent settings)
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Blanket swarm model overrides the base per-agent model
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-			})
-
-			it('does NOT apply implicit opus default as blanket override', async () => {
-				// When iloom-swarm-worker has NO .model set, the implicit '?? opus'
-				// default from renderSwarmWorkerAgent line 318 must NOT leak into
-				// renderSwarmAgents. Phase agents keep their base per-agent model.
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-issue-implementer': { model: 'sonnet' },
-						'iloom-swarm-worker': {
-							// No model set -- simulating unconfigured blanket swarm model
-						},
-					},
-				} as unknown as IloomSettings)
-
-				// loadAgents returns implementer with model='sonnet' (from base per-agent)
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'sonnet',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Model should remain 'sonnet' (unchanged), NOT overridden to 'opus'
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-			})
-
-			it('falls back to base agent model when no swarm overrides at all', async () => {
-				// No swarm-worker config at all
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({})
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// implementer gets built-in swarm default of 'sonnet' (priority 2.5)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-			})
-
-			it('applies different overrides to different agents', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							agents: {
-								'iloom-issue-implementer': { model: 'sonnet' },
-								'iloom-issue-planner': { model: 'haiku' },
-							},
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-					'iloom-issue-planner': {
-						description: 'Planner agent',
-						prompt: 'Plan things',
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-				expect(result.metadata['iloom-swarm-issue-planner']!.model).toBe('haiku')
-			})
-
-			it('ignores swarm overrides for unknown agent names', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							agents: {
-								'typo-agent': { model: 'sonnet' },
-							},
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// No error thrown, implementer gets built-in swarm default of 'sonnet'
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-			})
-
-			it('prefers agent-specific override over blanket worker model', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							model: 'haiku',
-							agents: {
-								'iloom-issue-implementer': { model: 'sonnet' },
-							},
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-					'iloom-issue-planner': {
-						description: 'Planner agent',
-						prompt: 'Plan things',
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Implementer gets agent-specific override (sonnet), not blanket (haiku)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-				// Planner gets blanket swarm model (haiku) since no agent-specific override
-				expect(result.metadata['iloom-swarm-issue-planner']!.model).toBe('haiku')
-			})
-
-			it('applies built-in swarm default for implementer when no user overrides exist', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-					'iloom-issue-analyzer': {
-						description: 'Analyzer agent',
-						prompt: 'Analyze things',
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Implementer gets built-in swarm default of 'sonnet'
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
-				// Analyzer has no built-in swarm default, keeps base model
-				expect(result.metadata['iloom-swarm-issue-analyzer']!.model).toBe('opus')
-			})
-
-			it('user swarm-specific override beats built-in default', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							agents: {
-								'iloom-issue-implementer': { model: 'haiku' },
-							},
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// User override (haiku) wins over built-in default (sonnet)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
-			})
-
-			it('blanket swarm worker model beats built-in default', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							model: 'haiku',
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Blanket swarm model (haiku) wins over built-in default (sonnet)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
-			})
-
-			it('agent without built-in default keeps base model when no swarm overrides', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-analyzer': {
-						description: 'Analyzer agent',
-						prompt: 'Analyze things',
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Analyzer has no built-in swarm default, keeps base model from loadAgents
-				expect(result.metadata['iloom-swarm-issue-analyzer']!.model).toBe('opus')
-			})
-
-			it('swarm-specific per-agent override beats per-agent swarmModel', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-issue-implementer': { swarmModel: 'sonnet' },
-						'iloom-swarm-worker': {
-							agents: {
-								'iloom-issue-implementer': { model: 'haiku' },
-							},
-						},
-					},
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// Priority 1 (haiku) should beat Priority 2 per-agent swarmModel (sonnet)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
-			})
-
+		describe('phase agent swarmModel overrides', () => {
 			it('uses per-agent swarmModel when configured', async () => {
 				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
 					agents: {
@@ -706,13 +367,10 @@ describe('SwarmSetupService', () => {
 				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
 			})
 
-			it('per-agent swarmModel beats blanket swarm worker model', async () => {
+			it('keeps base model when no swarmModel configured', async () => {
 				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
 					agents: {
-						'iloom-issue-implementer': { swarmModel: 'haiku' },
-						'iloom-swarm-worker': {
-							model: 'sonnet',
-						},
+						'iloom-issue-implementer': { model: 'opus' },
 					},
 				} as unknown as IloomSettings)
 
@@ -727,16 +385,15 @@ describe('SwarmSetupService', () => {
 
 				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
 
-				// per-agent swarmModel (haiku) beats blanket swarm worker model (sonnet)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
+				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('opus')
 			})
 
-			it('per-agent swarmModel beats spin.swarmModel', async () => {
+			it('different agents can have different swarmModels', async () => {
 				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
 					agents: {
-						'iloom-issue-implementer': { swarmModel: 'haiku' },
+						'iloom-issue-implementer': { swarmModel: 'sonnet' },
+						'iloom-issue-planner': { swarmModel: 'haiku' },
 					},
-					spin: { swarmModel: 'sonnet' },
 				} as unknown as IloomSettings)
 
 				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
@@ -746,65 +403,23 @@ describe('SwarmSetupService', () => {
 						tools: ['Bash', 'Read'],
 						model: 'opus',
 					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// per-agent swarmModel (haiku) beats spin.swarmModel (sonnet)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
-			})
-
-			it('spin.swarmModel acts as blanket override when no swarm-worker.model set', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					spin: { swarmModel: 'haiku' },
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
+					'iloom-issue-planner': {
+						description: 'Planner agent',
+						prompt: 'Plan things',
 						model: 'opus',
 					},
 				})
 
 				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
 
-				// spin.swarmModel (haiku) overrides base per-agent model (opus)
-				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
-			})
-
-			it('agents.iloom-swarm-worker.model beats spin.swarmModel', async () => {
-				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-					agents: {
-						'iloom-swarm-worker': {
-							model: 'sonnet',
-						},
-					},
-					spin: { swarmModel: 'haiku' },
-				} as unknown as IloomSettings)
-
-				vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
-					'iloom-issue-implementer': {
-						description: 'Implementer agent',
-						prompt: 'Implement things',
-						tools: ['Bash', 'Read'],
-						model: 'opus',
-					},
-				})
-
-				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
-
-				// blanket swarm worker model (sonnet) beats spin.swarmModel (haiku)
 				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('sonnet')
+				expect(result.metadata['iloom-swarm-issue-planner']!.model).toBe('haiku')
 			})
 
-			it('swarm override does not mutate tools metadata', async () => {
+			it('swarmModel override preserves tools metadata', async () => {
 				vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
 					agents: {
-						'iloom-swarm-worker': {
-							model: 'haiku',
-						},
+						'iloom-issue-implementer': { swarmModel: 'haiku' },
 					},
 				} as unknown as IloomSettings)
 
@@ -819,7 +434,6 @@ describe('SwarmSetupService', () => {
 
 				const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
 
-				// Model overridden but tools preserved
 				expect(result.metadata['iloom-swarm-issue-implementer']!.model).toBe('haiku')
 				expect(result.metadata['iloom-swarm-issue-implementer']!.tools).toEqual(['Bash', 'Read'])
 			})
@@ -914,35 +528,6 @@ describe('SwarmSetupService', () => {
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string
 			expect(writtenContent).toContain('model: opus')
 			expect(writtenContent).not.toContain('model: sonnet')
-		})
-
-		it('uses spin.swarmModel for worker frontmatter when agents.iloom-swarm-worker.model not set', async () => {
-			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-				spin: { swarmModel: 'opus' },
-			} as unknown as IloomSettings)
-
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
-
-			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string
-			expect(writtenContent).toContain('model: opus')
-			expect(writtenContent).not.toContain('model: sonnet')
-		})
-
-		it('agents.iloom-swarm-worker.model beats spin.swarmModel for worker frontmatter', async () => {
-			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
-				agents: {
-					'iloom-swarm-worker': {
-						model: 'opus',
-					},
-				},
-				spin: { swarmModel: 'haiku' },
-			} as unknown as IloomSettings)
-
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
-
-			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string
-			expect(writtenContent).toContain('model: opus')
-			expect(writtenContent).not.toContain('model: haiku')
 		})
 
 		it('includes rendered template content in the body', async () => {

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -246,48 +246,12 @@ export class SwarmSetupService {
 
 		const agents = await this.agentManager.loadAgents(settings, templateVariables)
 
-		// Apply swarm-specific model overrides (fallback chain)
-		// Priority 1: agents.iloom-swarm-worker.agents.<agent-name>.model (swarm-specific per-agent)
-		// Priority 2: agents.<agent-name>.swarmModel (per-agent swarm model)
-		// Priority 3: agents.iloom-swarm-worker.model (blanket swarm worker model, explicitly configured)
-		// Priority 4: spin.swarmModel (spin config blanket swarm model)
-		// Priority 5: built-in swarm defaults (e.g., implementer defaults to sonnet)
-		// Priority 6: agents.<agent-name>.model (base per-agent, already applied by loadAgents)
-		// Priority 7: agent .md file default (already applied by loadAgents)
-		const swarmWorkerSettings = settings?.agents?.['iloom-swarm-worker']
-		const swarmAgentOverrides = swarmWorkerSettings?.agents
-		// NOTE: swarmWorkerModel is undefined when not explicitly set by the user.
-		// Do NOT use `?? 'opus'` here -- the implicit default must NOT participate
-		// in the fallback chain. It only activates in renderSwarmWorkerAgent for the
-		// worker agent's own frontmatter model.
-		const swarmWorkerModel = swarmWorkerSettings?.model
-		const spinSwarmModel = settings?.spin?.swarmModel
-
-		// Built-in defaults for phase agents in swarm mode (priority 3)
-		const swarmAgentDefaults: Record<string, string> = {
-			'iloom-issue-implementer': 'sonnet',
-		}
-
+		// Apply per-agent swarmModel overrides
 		for (const [agentName, agentConfig] of Object.entries(agents)) {
-			const swarmOverrideModel = swarmAgentOverrides?.[agentName]?.model
-			const perAgentSwarmModel = settings?.agents?.[agentName]?.swarmModel
-			if (swarmOverrideModel) {
-				// Priority 1: swarm-specific agent model override
-				agents[agentName] = { ...agentConfig, model: swarmOverrideModel }
-			} else if (perAgentSwarmModel) {
-				// Priority 2: per-agent swarmModel
-				agents[agentName] = { ...agentConfig, model: perAgentSwarmModel }
-			} else if (swarmWorkerModel) {
-				// Priority 3: blanket swarm worker model (overrides base per-agent model)
-				agents[agentName] = { ...agentConfig, model: swarmWorkerModel }
-			} else if (spinSwarmModel) {
-				// Priority 4: spin config blanket swarm model
-				agents[agentName] = { ...agentConfig, model: spinSwarmModel }
-			} else if (swarmAgentDefaults[agentName]) {
-				// Priority 5: built-in swarm defaults for specific agents
-				agents[agentName] = { ...agentConfig, model: swarmAgentDefaults[agentName] }
+			const swarmModel = settings?.agents?.[agentName]?.swarmModel
+			if (swarmModel) {
+				agents[agentName] = { ...agentConfig, model: swarmModel }
 			}
-			// Priority 6/7: keep model from loadAgents() (base agent model / .md default)
 		}
 
 		const renderedFiles: string[] = []
@@ -364,7 +328,7 @@ export class SwarmSetupService {
 			const agentBody = await this.templateManager.getPrompt('issue', variables)
 
 			// Build the agent file with frontmatter
-			const workerModel = settings?.agents?.['iloom-swarm-worker']?.model ?? settings?.spin?.swarmModel ?? 'sonnet'
+			const workerModel = settings?.agents?.['iloom-swarm-worker']?.model ?? 'sonnet'
 
 			const frontmatter = [
 				'---',


### PR DESCRIPTION
Fixes #735

## Add swarmModel field to per-agent settings and workerModel to spin config

## Problem

Configuring swarm-specific models for individual phase agents currently requires a verbose nested structure under `agents.iloom-swarm-worker.agents`:

```json
{
  "agents": {
    "iloom-swarm-worker": {
      "model": "sonnet",
      "agents": {
        "iloom-issue-implementer": { "model": "sonnet" },
        "iloom-issue-complexity-evaluator": { "model": "haiku" }
      }
    }
  }
}
```

This is awkward because:
- The swarm-specific model for an agent lives far away from that agent's own config entry
- There's no way to look at \`agents.iloom-issue-implementer\` and know what model it uses in swarm mode
- The init wizard has to teach users about the nested structure rather than a simple per-agent field

## Proposed Solution

### 1. Add \`swarmModel\` to \`BaseAgentSettingsSchema\`

Allow each agent to declare its own swarm-specific model directly:

\`\`\`json
{
  "agents": {
    "iloom-issue-implementer": {
      "model": "opus",
      "swarmModel": "sonnet"
    },
    "iloom-issue-complexity-evaluator": {
      "model": "haiku",
      "swarmModel": "haiku"
    }
  }
}
\`\`\`

This would insert into the fallback chain in \`SwarmSetupService.ts\` at a logical priority (e.g., between the existing \`agents.iloom-swarm-worker.agents.<name>.model\` and \`agents.iloom-swarm-worker.model\` steps):

1. \`agents.iloom-swarm-worker.agents.<agent>.model\` — swarm-specific per-agent override (existing)
2. **\`agents.<agent>.swarmModel\`** — per-agent swarm model (new)
3. \`agents.iloom-swarm-worker.model\` — blanket swarm worker model (existing)
4. Built-in swarm defaults (existing)
5. \`agents.<agent>.model\` — base per-agent model (existing)
6. Agent definition file default (existing)

### 2. Add \`workerModel\` to \`SpinAgentSettingsSchema\`

The spin config controls the orchestrator, but there's no way to set the worker model from the spin config. A \`workerModel\` field would allow co-locating orchestrator and worker model config:

\`\`\`json
{
  "spin": {
    "model": "sonnet",
    "workerModel": "sonnet"
  }
}
\`\`\`

This is especially useful for presets, which need to configure both the orchestrator and worker together.

## Impact

- Simplifies the init wizard — presets can reference clean per-agent \`swarmModel\` fields
- Makes swarm configuration more discoverable and self-documenting
- Backwards compatible — existing nested \`agents.iloom-swarm-worker.agents\` config still works at higher priority

---
*This PR was created automatically by iloom.*