### PR TITLE
Add a preset Modes to the init-prompt for swarms.

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -1637,7 +1637,7 @@ You can also set a different model for the spin orchestrator when running in swa
 }
 ```
 
-In this example, `spin.model` (`sonnet`) is used when spin runs in issue, PR, or branch mode, while `spin.swarmModel` (`opus`) is used when spin runs in swarm mode. If `swarmModel` is not set, spin uses `model` for all modes. Note that `spin.swarmModel` only affects the spin orchestrator itself — it does not affect swarm worker agents or phase agents.
+In this example, `spin.model` (`sonnet`) is used when spin runs in issue, PR, or branch mode, while `spin.swarmModel` (`opus`) is used when spin runs in swarm mode. If `swarmModel` is not set, the orchestrator defaults to `sonnet` in swarm mode (Balanced mode default) — it does not fall back to `spin.model`. Note that `spin.swarmModel` only affects the spin orchestrator itself — it does not affect swarm worker agents or phase agents.
 
 **Phase Agent Model Overrides (Swarm Mode):**
 
@@ -1654,7 +1654,9 @@ Each agent supports a `swarmModel` field for a clean, per-agent swarm model over
 }
 ```
 
-If `swarmModel` is set for an agent, it overrides the agent's model in swarm mode. If not set, the agent uses its base `model` (or `.md` default) in both modes.
+If `swarmModel` is set for an agent, it overrides the agent's model in swarm mode. If no `swarmModel` is set, the Swarm Quality Mode defaults apply (see below) — not the agent's base `model`. This separation is intentional: swarms run many agents in parallel and costs scale quickly, so swarm model choices should always be explicit.
+
+**Important:** Changing an agent's `model` only affects non-swarm mode (single-issue looms via `il start`). To change an agent's model in swarm mode, use `swarmModel` or choose a different Swarm Quality Mode.
 
 With the configuration above:
 
@@ -1662,7 +1664,7 @@ With the configuration above:
 |-------|---------------|------------|
 | `iloom-issue-implementer` | `opus` | `sonnet` (swarmModel) |
 | `iloom-issue-complexity-evaluator` | `haiku` | `haiku` (swarmModel) |
-| `iloom-issue-analyzer` | `.md` default | `.md` default (no swarmModel set) |
+| `iloom-issue-analyzer` | `.md` default | `opus` (Balanced mode default) |
 
 **Example using the `--set` flag:**
 
@@ -1681,7 +1683,7 @@ During `il init`, you'll be asked to choose a swarm quality mode that tunes the 
 | Mode | Focus | Models used | Best for |
 |------|-------|-------------|----------|
 | **Maximum Quality** | Deepest reasoning, best analysis | Opus everywhere (complexity evaluator stays Haiku) | Complex epics, critical features |
-| **Balanced** (default) | Good reasoning at reasonable cost | Sonnet everywhere (complexity evaluator stays Haiku) | Most tasks |
+| **Balanced** (default) | Opus for analysis, Sonnet for everything else | Opus: analyzer, analyze-and-plan. Sonnet: orchestrator, worker, planner, implementer, enhancer, code-reviewer. Haiku: complexity evaluator | Most tasks |
 | **Fast & Cheap** | Quick iterations, lowest cost | Haiku everywhere | Simple tasks, rapid prototyping |
 
 The complexity evaluator always stays on Haiku regardless of mode, since it performs a simple classification task that does not benefit from a larger model.
@@ -1711,11 +1713,11 @@ Example settings for each mode:
   "spin": { "swarmModel": "sonnet" },
   "agents": {
     "iloom-swarm-worker": { "model": "sonnet" },
-    "iloom-issue-analyzer": { "swarmModel": "sonnet" },
+    "iloom-issue-analyzer": { "swarmModel": "opus" },
     "iloom-issue-planner": { "swarmModel": "sonnet" },
     "iloom-issue-implementer": { "swarmModel": "sonnet" },
     "iloom-issue-enhancer": { "swarmModel": "sonnet" },
-    "iloom-issue-analyze-and-plan": { "swarmModel": "sonnet" },
+    "iloom-issue-analyze-and-plan": { "swarmModel": "opus" },
     "iloom-code-reviewer": { "swarmModel": "sonnet" },
     "iloom-issue-complexity-evaluator": { "swarmModel": "haiku" }
   }

--- a/src/lib/SettingsManager.test.ts
+++ b/src/lib/SettingsManager.test.ts
@@ -2855,16 +2855,46 @@ const error: { code?: string; message: string } = {
 			expect(result).toBe('sonnet')
 		})
 
-		it('should fall back to spin.model when mode is swarm but swarmModel is not set', () => {
+		it('should default to sonnet when mode is swarm but swarmModel is not set', () => {
 			const settings = { sourceEnvOnStart: false, spin: { model: 'haiku' as const } }
 			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
-			expect(result).toBe('haiku')
+			expect(result).toBe('sonnet')
 		})
 
 		it('should ignore swarmModel when mode is not swarm', () => {
 			const settings = { sourceEnvOnStart: false, spin: { model: 'opus' as const, swarmModel: 'sonnet' as const } }
 			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings)
 			expect(result).toBe('opus')
+		})
+
+		it('swarm mode defaults to sonnet even when spin.model is opus', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'opus' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
+			expect(result).toBe('sonnet')
+		})
+
+		it('swarm mode defaults to sonnet even when spin.model is haiku', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'haiku' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
+			expect(result).toBe('sonnet')
+		})
+
+		it('swarm mode defaults to sonnet even when no spin config exists', () => {
+			const settings = { sourceEnvOnStart: false }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
+			expect(result).toBe('sonnet')
+		})
+
+		it('explicit spin.swarmModel overrides the default in swarm mode', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'sonnet' as const, swarmModel: 'opus' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings, 'swarm')
+			expect(result).toBe('opus')
+		})
+
+		it('non-swarm mode ignores swarmModel and uses spin.model', () => {
+			const settings = { sourceEnvOnStart: false, spin: { model: 'haiku' as const, swarmModel: 'opus' as const } }
+			const result = settingsManager.getSpinModel(settings as unknown as IloomSettings)
+			expect(result).toBe('haiku')
 		})
 	})
 

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -1122,8 +1122,12 @@ export class SettingsManager {
 	 * @returns Model shorthand ('opus', 'sonnet', or 'haiku')
 	 */
 	getSpinModel(settings?: IloomSettings, mode?: 'swarm'): 'sonnet' | 'opus' | 'haiku' {
-		if (mode === 'swarm' && settings?.spin?.swarmModel) {
-			return settings.spin.swarmModel
+		if (mode === 'swarm') {
+			if (settings?.spin?.swarmModel) {
+				return settings.spin.swarmModel
+			}
+			// Default to sonnet for swarm orchestrator ("Balanced" mode)
+			return 'sonnet'
 		}
 		return settings?.spin?.model ?? SpinAgentSettingsSchema.parse({}).model
 	}

--- a/templates/prompts/init-prompt.txt
+++ b/templates/prompts/init-prompt.txt
@@ -588,9 +588,9 @@ Swarms are iloom's most powerful feature. Give them an epic and they'll decompos
 
 You can tune how swarms balance thinking depth versus speed:
 
-  🧠 Maximum Quality — Agents take more time to reason deeply, produce thorough analysis, and write more carefully considered code. Best when correctness matters most.
+  🧠 Maximum Quality — Agents take more time to reason deeply, produce thorough analysis, and write more carefully considered code. Best when correctness matters most. Uses Opus for all agents, which is significantly more expensive.
   ⚖️  Balanced (recommended) — Strong reasoning at a practical pace. The sweet spot for most work.
-  ⚡ Fast & Cheap — Agents move quickly through issues with lighter analysis. Great for well-scoped tasks or rapid prototyping where you'll review closely.
+  ⚡ Fast & Cheap — Agents move quickly through issues with lighter analysis. Great for rapid prototyping or if you're on a budget.
 ```
 
 Ask: "Which swarm mode would you prefer?"
@@ -1083,34 +1083,22 @@ When configuring agents, use these model identifiers:
    }
    ```
 
+   **Important: Non-swarm and swarm models are independent.** Changing an agent's `model` here only affects non-swarm mode (single-issue looms via `il start`). Swarm mode has its own model configuration via `swarmModel` and the Swarm Quality Mode presets (see item 2 below). This separation is intentional — swarms run many agents in parallel and costs scale quickly, so swarm models should be an explicit choice.
+
    **Swarm-Specific Phase Agent Models:**
 
-   In swarm mode, you can configure different models for phase agents (analyzer, planner, implementer, etc.) than in normal mode:
+   To override a specific agent's model in swarm mode, use `swarmModel`:
 
    ```json
    "agents": {
      "iloom-issue-implementer": {
-       "model": "opus"
-     },
-     "iloom-swarm-worker": {
        "model": "opus",
-       "agents": {
-         "iloom-issue-implementer": {
-           "model": "sonnet"
-         },
-         "iloom-issue-planner": {
-           "model": "haiku"
-         }
-       }
+       "swarmModel": "sonnet"
      }
    }
    ```
 
-   Fallback chain in swarm mode:
-   1. `agents.iloom-swarm-worker.agents.<agent>.model` (swarm-specific per-agent)
-   2. `agents.iloom-swarm-worker.model` (blanket swarm worker model)
-   3. `agents.<agent>.model` (base per-agent model)
-   4. Agent default from its definition file
+   In this example, the implementer uses Opus in non-swarm mode but Sonnet in swarm mode. If no `swarmModel` is set, the Swarm Quality Mode defaults apply (see item 2 below) — not the agent's base `model`.
 
 2. **Swarm Quality Mode:**
 
@@ -1119,7 +1107,7 @@ When configuring agents, use these model identifiers:
    | Mode | Focus | Models used | Best for |
    |------|-------|-------------|----------|
    | **Maximum Quality** | Deepest reasoning, best analysis | Opus everywhere (except complexity evaluator stays Haiku) | Complex epics, critical features |
-   | **Balanced** (default) | Good reasoning at reasonable cost | Sonnet everywhere (complexity evaluator stays Haiku) | Most tasks |
+   | **Balanced** (default) | Opus for analysis, Sonnet for everything else | Opus: analyzer, analyze-and-plan. Sonnet: orchestrator, worker, planner, implementer, enhancer, code-reviewer. Haiku: complexity evaluator | Most tasks |
    | **Fast & Cheap** | Quick iterations, lowest cost | Haiku everywhere | Simple tasks, rapid prototyping |
 
    Note: The complexity evaluator always stays on Haiku regardless of mode, since it performs a simple classification task that does not benefit from a larger model.
@@ -1129,7 +1117,7 @@ When configuring agents, use these model identifiers:
    When the user selects a mode, **merge** the model values into their existing settings. Only set the `swarmModel` (or `model` for the worker) field on each agent — do not overwrite or remove other agent settings.
 
    - **Maximum Quality:** Set `spin.swarmModel` to `"opus"`. Set `agents.iloom-swarm-worker.model` to `"opus"`. Set `swarmModel` to `"opus"` on all phase agents (`iloom-issue-analyzer`, `iloom-issue-planner`, `iloom-issue-implementer`, `iloom-issue-enhancer`, `iloom-issue-analyze-and-plan`, `iloom-code-reviewer`). Keep `iloom-issue-complexity-evaluator.swarmModel` as `"haiku"`.
-   - **Balanced (default):** This matches the existing defaults. If the user has no other agent model overrides, no explicit settings changes are needed — only write overrides if the user wants to be explicit.
+   - **Balanced (default):** Set `spin.swarmModel` to `"sonnet"`. Set `agents.iloom-swarm-worker.model` to `"sonnet"`. Set `swarmModel` to `"opus"` on analysis agents (`iloom-issue-analyzer`, `iloom-issue-analyze-and-plan`). Set `swarmModel` to `"sonnet"` on all other phase agents (`iloom-issue-planner`, `iloom-issue-implementer`, `iloom-issue-enhancer`, `iloom-code-reviewer`). Keep `iloom-issue-complexity-evaluator.swarmModel` as `"haiku"`.
    - **Fast & Cheap:** Set `spin.swarmModel` to `"haiku"`. Set `agents.iloom-swarm-worker.model` to `"haiku"`. Set `swarmModel` to `"haiku"` on all phase agents and `iloom-issue-complexity-evaluator`.
 
    **Important notes:**


### PR DESCRIPTION
Fixes #731

## Add a preset Modes to the init-prompt for swarms.

Presets are expensive/slow.
Balanced 
Fast / cheap. 

Expensive/slow is everything is opus (excpt what defaults to Haiku)
Balanced is Swarm Orchestrator, Swarm Worker, And swarm implementer are sonnet. Complexity evaluator is till haiku
Cheap/fast is "everything is haiku" anything involved in swarm.

---
*This PR was created automatically by iloom.*