### PR TITLE
fix(swarm): enforce workflow-first behavior in worker agents

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -262,6 +262,20 @@ Since this is a first-time user:
 {{#if SWARM_MODE}}
 ## Swarm Mode - Autonomous Workflow
 
+### MANDATORY FIRST STEP — NO EXCEPTIONS
+
+Before ANY file reads, ANY source code inspection, ANY analysis, ANY coding:
+
+1. `cd` to your worktree path (provided in the Task prompt)
+2. Read `.claude/iloom-swarm-mcp-config-path` to get your MCP config path
+3. Call `recap.set_loom_state({ state: "in_progress", worktreePath: "<your-worktree-path>" })`
+4. Call `mcp__issue_management__get_issue` to read the full issue details
+5. Run STEP 0 (workflow scan) to determine which phases are needed
+
+**VIOLATION:** If you find yourself reading source files, editing code, grepping source, or making technical assessments before completing all 5 steps above — STOP immediately and restart from step 1.
+
+---
+
 ### CRITICAL: Delegation Rules
 
 **You are a workflow ORCHESTRATOR, not an implementer.** You MUST NOT:

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -175,22 +175,24 @@ You are working on issue #<child-number>: "<child-title>"
 
 **Worktree path:** `<child-worktree-path>`
 
-IMPORTANT: You MUST work in this worktree path. cd to it first before doing anything:
-cd <child-worktree-path>
+## MANDATORY FIRST STEPS — NO EXCEPTIONS
 
-All file reads, writes, searches, and git operations must happen within this directory. Do NOT work in the epic worktree or any other child's worktree.
+Your FIRST actions, before reading any source code, before any analysis, before any implementation:
 
-## Strict Boundaries
+1. cd to your worktree: `cd <child-worktree-path>`
+2. Read `.claude/iloom-swarm-mcp-config-path` to get your MCP config path
+3. Call `recap.set_loom_state({ state: "in_progress", worktreePath: "<child-worktree-path>" })`
+4. Call `mcp__issue_management__get_issue` to read the full issue details
+5. Run STEP 0 (workflow scan) to determine which phases are needed
+
+Your system prompt defines the complete workflow — follow it exactly. You are an ORCHESTRATOR: you never write code or read source files directly at any point. All technical work is delegated to sub-agents via `claude -p`.
+
+## Scope Boundaries
 
 - You are ONLY responsible for issue #<child-number>. Do not implement, fix, commit, or merge work for any other issue.
 - NEVER cd into, read from, or modify files in any other worktree path. Your entire scope is `<child-worktree-path>`.
 - Do NOT merge branches, close issues, or perform any orchestration tasks. The orchestrator handles all merging and issue management.
 - Do NOT pick up tasks from the team task list. You have exactly one job.
-
-**Issue body:**
-<child-issue-body>
-
-Implement this issue following your workflow instructions.
 
 ## After Completion
 
@@ -202,8 +204,6 @@ When your implementation is done, report back with:
 
 After sending your report, STOP. Do not look for more work. Do not check on other issues. Do not attempt to help with other worktrees. Wait for a shutdown request and approve it.
 ```
-
-Note: The child issue body is available directly in the `CHILD_ISSUES` template data above (each entry has a `body` field). Make sure to include it in the Task prompt for each child.
 
 Update each child's tracking status to `in_progress`.
 


### PR DESCRIPTION
## Summary

- Remove issue body from orchestrator task message to eliminate the direct-implementation stimulus that caused workers to skip the swarm workflow
- Add `MANDATORY FIRST STEPS` block to the task message requiring workers to read MCP config, set loom state, and fetch the issue before any other action
- Add `MANDATORY FIRST STEP` block at the top of the `SWARM_MODE` system prompt section with a VIOLATION callout for reading source or writing code before initialization
- Clarify that workers are orchestrators and never write code directly at any point — not just before initialization

## Root Cause

Workers were receiving the full issue body (including acceptance criteria and code examples) in the task message. This pattern-matched strongly to "implement this" and effectively overrode the delegation rules in the system prompt. The fix removes that stimulus and adds structural forcing functions at both the task message and system prompt level.

## Test Plan

- [ ] Verify swarm worker agents read `.claude/iloom-swarm-mcp-config-path` as first action
- [ ] Verify workers fetch issue details via MCP rather than using body from task message
- [ ] Verify workers do not implement code directly