### PR TITLE
fix(swarm): reduce default sub-agent Bash timeout from 20 to 10 minutes

### DIFF
--- a/src/lib/PromptTemplateManager.ts
+++ b/src/lib/PromptTemplateManager.ts
@@ -112,7 +112,7 @@ export interface TemplateVariables {
 	DEPENDENCY_MAP?: string  // JSON stringified dependency map
 	SWARM_MODE?: boolean  // True when rendering agents in swarm mode
 	SWARM_AGENT_METADATA?: string  // JSON string mapping agent names to { model, tools } for claude -p commands
-	SWARM_SUB_AGENT_TIMEOUT_MS?: number  // Timeout in milliseconds for sub-agent claude -p Bash tool calls (default: 1200000 = 20 minutes)
+	SWARM_SUB_AGENT_TIMEOUT_MS?: number  // Timeout in milliseconds for sub-agent claude -p Bash tool calls (default: 600000 = 10 minutes)
 	NO_CLEANUP?: boolean  // True when child loom cleanup should be skipped (e.g., manual cleanup later)
 	ISSUE_PREFIX?: string  // "#" for GitHub, "" for Linear/Jira — used in commit message templates
 }

--- a/src/lib/SettingsManager.test.ts
+++ b/src/lib/SettingsManager.test.ts
@@ -54,7 +54,16 @@ describe('SettingsManager', () => {
 
 			const result = await settingsManager.loadSettings(projectRoot)
 			// sourceEnvOnStart defaults to false, attribution defaults to 'upstreamOnly'
-			expect(result).toEqual({ ...validSettings, sourceEnvOnStart: false, attribution: 'upstreamOnly', ...defaultSettings })
+			// subAgentTimeout defaults to 10 for each agent
+			expect(result).toEqual({
+				agents: {
+					'iloom-issue-analyzer': { model: 'sonnet', subAgentTimeout: 10 },
+					'iloom-issue-planner': { model: 'opus', subAgentTimeout: 10 },
+				},
+				sourceEnvOnStart: false,
+				attribution: 'upstreamOnly',
+				...defaultSettings,
+			})
 		})
 
 		it('should return empty object when settings file does not exist', async () => {
@@ -183,7 +192,15 @@ describe('SettingsManager', () => {
 
 			const result = await settingsManager.loadSettings()
 			// sourceEnvOnStart defaults to false, attribution defaults to 'upstreamOnly'
-			expect(result).toEqual({ ...validSettings, sourceEnvOnStart: false, attribution: 'upstreamOnly', ...defaultSettings })
+			// subAgentTimeout defaults to 10 for each agent
+			expect(result).toEqual({
+				agents: {
+					'test-agent': { model: 'haiku', subAgentTimeout: 10 },
+				},
+				sourceEnvOnStart: false,
+				attribution: 'upstreamOnly',
+				...defaultSettings,
+			})
 		})
 
 		it('should load settings with mainBranch field', async () => {
@@ -3614,7 +3631,7 @@ const error: { code?: string; message: string } = {
 			await expect(settingsManager.loadSettings(projectRoot)).rejects.toThrow('Settings validation failed')
 		})
 
-		it('should leave subAgentTimeout undefined when not configured', async () => {
+		it('should default subAgentTimeout to 10 when not configured', async () => {
 			const projectRoot = '/test/project'
 			const settings = {
 				agents: {
@@ -3635,7 +3652,7 @@ const error: { code?: string; message: string } = {
 				.mockRejectedValueOnce(error) // settings.local.json
 
 			const result = await settingsManager.loadSettings(projectRoot)
-			expect(result.agents?.['iloom-swarm-worker']?.subAgentTimeout).toBeUndefined()
+			expect(result.agents?.['iloom-swarm-worker']?.subAgentTimeout).toBe(10)
 		})
 	})
 })

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -45,8 +45,8 @@ export const AgentSettingsSchema = BaseAgentSettingsSchema.extend({
 		.number()
 		.min(1, 'Sub-agent timeout must be at least 1 minute')
 		.max(120, 'Sub-agent timeout cannot exceed 120 minutes')
-		.optional()
-		.describe('Timeout in minutes for sub-agent claude -p invocations in swarm mode. Applies to each phase agent (evaluator, analyzer, planner, implementer) when invoked via the Bash tool. Default: 20 minutes. Only meaningful under the iloom-swarm-worker agent entry.'),
+		.default(10)
+		.describe('Timeout in minutes for sub-agent claude -p invocations in swarm mode. Applies to each phase agent (evaluator, analyzer, planner, implementer) when invoked via the Bash tool. Default: 10 minutes. Only meaningful under the iloom-swarm-worker agent entry.'),
 })
 
 /**

--- a/src/lib/SwarmSetupService.test.ts
+++ b/src/lib/SwarmSetupService.test.ts
@@ -659,13 +659,13 @@ describe('SwarmSetupService', () => {
 		})
 
 		describe('sub-agent timeout', () => {
-			it('passes default SWARM_SUB_AGENT_TIMEOUT_MS of 1200000 (20 minutes) when not configured', async () => {
+			it('passes default SWARM_SUB_AGENT_TIMEOUT_MS of 600000 (10 minutes) when not configured', async () => {
 				await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
 
 				expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
 					'issue',
 					expect.objectContaining({
-						SWARM_SUB_AGENT_TIMEOUT_MS: 1200000,
+						SWARM_SUB_AGENT_TIMEOUT_MS: 600000,
 					}),
 				)
 			})

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -325,8 +325,8 @@ export class SwarmSetupService {
 			const providerType = settings?.issueManagement?.provider ?? 'github'
 			const issuePrefix = IssueManagementProviderFactory.create(providerType, settings ?? undefined).issuePrefix
 
-			// Compute sub-agent timeout in milliseconds (default: 20 minutes)
-			const subAgentTimeoutMinutes = settings?.agents?.['iloom-swarm-worker']?.subAgentTimeout ?? 20
+			// Compute sub-agent timeout in milliseconds (default: 10 minutes)
+			const subAgentTimeoutMinutes = settings?.agents?.['iloom-swarm-worker']?.subAgentTimeout ?? 10
 			const subAgentTimeoutMs = subAgentTimeoutMinutes * 60 * 1000
 
 			// Build template variables for swarm worker agent rendering


### PR DESCRIPTION
## Summary

- Lower the default `subAgentTimeout` from 20 → 10 minutes
- Add `.default(10)` to the Zod schema in `AgentSettingsSchema` so the value is always populated after parsing (no longer requires `?? 20` fallback at usage sites)
- Update comments in `PromptTemplateManager.ts` and `SwarmSetupService.ts` to reflect new default
- Fix tests that expected `undefined` or the old 20-minute value

## Test plan

- [ ] All 126 test files pass (`pnpm test`)
- [ ] TypeScript compiles cleanly (`pnpm compile`)
- [ ] Pre-commit hooks pass (lint + compile + tests + build)