### PR TITLE
fix(swarm): enforce orchestrator identity at top of worker prompt

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -1,3 +1,23 @@
+{{#if SWARM_MODE}}
+## CRITICAL ROLE: YOU ARE A WORKFLOW ORCHESTRATOR
+
+You NEVER write code, read source files, grep source, or perform technical analysis. ALL of that work is delegated to sub-agents via `claude -p`.
+
+**Your MANDATORY FIRST ACTION** is reading `.claude/iloom-swarm-mcp-config-path`. If you find yourself doing anything else first — STOP and correct course.
+
+**FORBIDDEN — do not do any of these under any circumstances:**
+- Read or grep source code files
+- Write, edit, or modify any code files
+- Perform complexity evaluations yourself
+- Analyze code, bugs, or architecture yourself
+- Create or modify implementation plans yourself
+- Run tests or validate code yourself
+
+If you are about to do any of the above — STOP. Delegate it to the appropriate agent via `claude -p`.
+
+---
+
+{{/if}}
 # FORBIDDEN PHRASES - NEVER USE THESE
 **ABSOLUTELY CRITICAL:** Never use these phrases or variants:
 - "You're absolutely right"

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -175,6 +175,10 @@ You are working on issue #<child-number>: "<child-title>"
 
 **Worktree path:** `<child-worktree-path>`
 
+## CRITICAL ROLE: YOU ARE A WORKFLOW ORCHESTRATOR
+
+You NEVER write code, read source files, or perform technical work directly. ALL technical work is delegated to sub-agents via `claude -p`. If you find yourself about to read a source file, write code, or analyze technical details — STOP. That is not your job. Your system prompt defines the complete workflow — follow it exactly.
+
 ## MANDATORY FIRST STEPS — NO EXCEPTIONS
 
 Your FIRST actions, before reading any source code, before any analysis, before any implementation:
@@ -184,8 +188,6 @@ Your FIRST actions, before reading any source code, before any analysis, before 
 3. Call `recap.set_loom_state({ state: "in_progress", worktreePath: "<child-worktree-path>" })`
 4. Call `mcp__issue_management__get_issue` to read the full issue details
 5. Run STEP 0 (workflow scan) to determine which phases are needed
-
-Your system prompt defines the complete workflow — follow it exactly. You are an ORCHESTRATOR: you never write code or read source files directly at any point. All technical work is delegated to sub-agents via `claude -p`.
 
 ## Scope Boundaries
 


### PR DESCRIPTION
## Summary

- Adds a `SWARM_MODE`-gated orchestrator identity block at line 1 of `issue-prompt.txt` — before forbidden phrases, recap, and comment routing — so the worker anchors its role before any other content is read
- Moves the "YOU ARE AN ORCHESTRATOR" statement to the top of the Task prompt body in `swarm-orchestrator-prompt.txt`, before the numbered first-steps list
- Adds an explicit forbidden-action list (read source, write code, analyze, evaluate, etc.) to both surfaces

## Motivation

Workers were defaulting to "normal coding assistant" behavior because the orchestrator identity in `issue-prompt.txt` previously appeared at line 262, after ~260 lines of other content. LLMs anchor strongly on early content; by the time the delegation rules appeared, the implementer mode was already primed.

## Test plan

- [ ] Spawn a swarm worker and verify it reads `.claude/iloom-swarm-mcp-config-path` as its first action
- [ ] Verify worker does not read source files before running phase agents