### PR TITLE
fix(swarm): prevent workers from going rogue on detailed task prompts

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -15,6 +15,14 @@ You NEVER write code, read source files, grep source, or perform technical analy
 
 If you are about to do any of the above — STOP. Delegate it to the appropriate agent via `claude -p`.
 
+**CRITICAL: Detailed task instructions are INPUTS, not orders to execute yourself.**
+
+Your task prompt may contain highly specific details: file paths, code snippets, parameter names, step-by-step instructions, or even a fully described implementation. **This does NOT mean you should implement it.** All of that is context to hand off to phase agents. Your job is to route it — not to do it.
+
+Before taking ANY action after reading your task prompt, run this self-check:
+> "Am I about to read a source file, grep code, or edit a file myself?"
+> If yes → STOP. That is forbidden. Go to your MANDATORY FIRST STEP below.
+
 ---
 
 {{/if}}
@@ -293,6 +301,8 @@ Before ANY file reads, ANY source code inspection, ANY analysis, ANY coding:
 5. Run STEP 0 (workflow scan) to determine which phases are needed
 
 **VIOLATION:** If you find yourself reading source files, editing code, grepping source, or making technical assessments before completing all 5 steps above — STOP immediately and restart from step 1.
+
+**REMINDER:** If your task prompt contains specific implementation instructions (file names, code details, parameter changes, etc.) — that is context to give to the phase agents, not instructions for you to execute directly. Complete steps 1-5 above first, then delegate to the appropriate agents.
 
 ---
 

--- a/templates/prompts/plan-prompt.txt
+++ b/templates/prompts/plan-prompt.txt
@@ -236,7 +236,7 @@ A sign that issues should be consolidated: several small issues share the same d
 | Breaking changes | None |
 | Database migrations | None |
 | Cross-cutting changes | None — avoid issues that pass parameters/config through 3+ architectural layers |
-| Architectural complexity signals | None — the "how" should be obvious from the "what" |
+| Architectural complexity signals | None — no deep architectural decisions required to implement it |
 | Risk level | Low or Medium |
 | File quality | All modified files < 500 LOC, or well-architected if larger |
 
@@ -261,9 +261,13 @@ Each child issue should include:
 1. **Summary**: One-sentence description of what this issue accomplishes
 2. **Context**: Why this issue exists (relationship to parent feature)
 3. **Acceptance Criteria**: Clear, testable conditions for "done"
-4. **Shared Contracts**: Specify the exact contracts defined in Step 1 that this issue produces or consumes (function signatures, types, module exports)
+4. **Shared Contracts**: Specify the exact contracts defined in Step 1 that this issue produces or consumes (function signatures, types, module exports). A contract is an interface boundary — what one issue exposes for another to consume. Example: `PlanCommand.execute()` gains an optional `autoSwarm?: boolean` 7th parameter. NOT an implementation: do not describe what happens internally when `autoSwarm` is true — that is implementation detail, not a contract.
 5. **Hard Blocking Dependencies** *(minimize these)*: Which issues must be completed first, if any — each one should have been validated in Step 1 as not replaceable by a contract
 6. **Scope Boundaries**: What is explicitly NOT included
+
+**CRITICAL: Issue bodies must NOT contain implementation details.** A contract describes an interface boundary (what a function accepts and returns). Implementation detail describes HOW something works internally (conditional logic, specific APIs to call, code sequences, error handling patterns). Contracts belong in the issue body. Implementation detail does NOT — the implementing agent will discover the how through its own codebase research. Baking implementation instructions into the issue body causes agents to skip their research phase and treat your instructions as ground truth, which produces brittle implementations.
+
+**The test:** "Does this sentence tell the implementing agent *what* to build, or *how* to build it?" If it's how — remove it.
 
 ---
 

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -168,44 +168,16 @@ For each child issue, use these parameters:
 - `team_name`: `"swarm-epic-{{EPIC_ISSUE_NUMBER}}"`
 - `name`: `"issue-<child-number>"`
 
-The prompt for each child agent should be:
+**CRITICAL: The task prompt MUST contain only the issue number and worktree path. Do NOT include the issue title, issue body, analysis, planning details, implementation instructions, code snippets, or any other content from CHILD_ISSUES. The child agent retrieves all issue context itself via `mcp__issue_management__get_issue` as its first action.**
+
+The prompt for each child agent should be exactly:
 
 ```
-You are working on issue #<child-number>: "<child-title>"
-
-**Worktree path:** `<child-worktree-path>`
-
-## CRITICAL ROLE: YOU ARE A WORKFLOW ORCHESTRATOR
-
-You NEVER write code, read source files, or perform technical work directly. ALL technical work is delegated to sub-agents via `claude -p`. If you find yourself about to read a source file, write code, or analyze technical details — STOP. That is not your job. Your system prompt defines the complete workflow — follow it exactly.
-
-## MANDATORY FIRST STEPS — NO EXCEPTIONS
-
-Your FIRST actions, before reading any source code, before any analysis, before any implementation:
-
-1. cd to your worktree: `cd <child-worktree-path>`
-2. Read `.claude/iloom-swarm-mcp-config-path` to get your MCP config path
-3. Call `recap.set_loom_state({ state: "in_progress", worktreePath: "<child-worktree-path>" })`
-4. Call `mcp__issue_management__get_issue` to read the full issue details
-5. Run STEP 0 (workflow scan) to determine which phases are needed
-
-## Scope Boundaries
-
-- You are ONLY responsible for issue #<child-number>. Do not implement, fix, commit, or merge work for any other issue.
-- NEVER cd into, read from, or modify files in any other worktree path. Your entire scope is `<child-worktree-path>`.
-- Do NOT merge branches, close issues, or perform any orchestration tasks. The orchestrator handles all merging and issue management.
-- Do NOT pick up tasks from the team task list. You have exactly one job.
-
-## After Completion
-
-When your implementation is done, report back with:
-- Issue number
-- Status (success or failed)
-- Brief summary of what was implemented or what went wrong
-- Number of files changed (if successful)
-
-After sending your report, STOP. Do not look for more work. Do not check on other issues. Do not attempt to help with other worktrees. Wait for a shutdown request and approve it.
+Issue: #<child-number>
+Worktree: <child-worktree-path>
 ```
+
+Nothing else. No title. No body. No instructions. No context. The child's system prompt defines everything it needs to do.
 
 Update each child's tracking status to `in_progress`.
 


### PR DESCRIPTION
## Summary

- **Worker prompt**: adds explicit self-check gate — if detailed implementation instructions appear in the task prompt, they are context to pass to phase agents, not orders to execute directly; reinforced at MANDATORY FIRST STEP
- **Orchestrator prompt**: strips child task prompts to bare minimum (issue number + worktree path only); explicitly prohibits including `CHILD_ISSUES` body/title/implementation content, which was the root cause of workers pattern-matching "this looks like an implementation task"
- **Plan prompt**: tightens Shared Contracts definition — contracts are interface boundaries (what a function accepts/returns), not implementation detail; adds CRITICAL prohibition on HOW-to instructions in issue bodies; adds a decision rule ("does this tell the agent *what* to build or *how* to build it?")

## Root cause

Workers were receiving task prompts from the orchestrator that included the child issue title and a detailed inline prompt with file paths, code snippets, and step-by-step instructions. This triggered "implementation mode" — the worker bypassed its own STEP 0 scan and started coding directly instead of delegating to phase agents. Two contributing factors: (1) the orchestrator was leaking issue content into task prompts, and (2) the plan prompt was allowing implementation-level detail to accumulate in issue bodies.

## Test plan

- [ ] Verify worker prompt self-check language is present and clearly prohibits acting on task-prompt implementation details
- [ ] Verify orchestrator task prompts for children are stripped to `Issue: #N\nWorktree: <path>` only
- [ ] Verify plan session no longer produces issue bodies with conditional logic, code sequences, or error handling patterns