### PR TITLE
fix(spin): improve error message visibility when Claude launch fails

### DIFF
--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -503,8 +503,6 @@ export class IgniteCommand {
 					success: false,
 					error: errorMessage
 				}))
-			} else {
-				logger.error(`Failed to launch Claude: ${errorMessage}`)
 			}
 			throw error
 		}

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -369,7 +369,8 @@ export async function launchClaude(
 			} catch (interactiveError) {
 				if (signal?.aborted) return
 				const interactiveExecaError = interactiveError as { stderr?: string; message?: string }
-				const interactiveErrorMessage = interactiveExecaError.stderr ?? interactiveExecaError.message ?? ''
+				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
+				const interactiveErrorMessage = interactiveExecaError.stderr || interactiveExecaError.message || ''
 
 				// Check for session ID conflict
 				const sessionMatch = interactiveErrorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
@@ -419,7 +420,8 @@ export async function launchClaude(
 			exitCode?: number
 		}
 
-		const errorMessage = execaError.stderr ?? execaError.message ?? 'Unknown Claude CLI error'
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
+		const errorMessage = execaError.stderr || execaError.message || 'Unknown Claude CLI error'
 
 		// Check for "Session ID ... is already in use" error and retry with --resume
 		const sessionInUseMatch = errorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
@@ -512,7 +514,8 @@ export async function launchClaude(
 				}
 			} catch (retryError) {
 				const retryExecaError = retryError as { stderr?: string; message?: string }
-				const retryErrorMessage = retryExecaError.stderr ?? retryExecaError.message ?? 'Unknown Claude CLI error'
+				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
+				const retryErrorMessage = retryExecaError.stderr || retryExecaError.message || 'Unknown Claude CLI error'
 				throw new Error(`Claude CLI error: ${retryErrorMessage}`)
 			}
 		}


### PR DESCRIPTION
## Summary

- **Fix swallowed error messages**: `launchClaude` was using `??` (nullish coalescing) to extract error details from execa errors. When Claude runs and exits without writing to stderr, `execaError.stderr` is `''` (empty string) — not `null`/`undefined`. Since `??` only falls through on null/undefined, the error message was silently dropped, leaving users with a bare "Failed to spin up loom:" message. Changed to `||` so empty strings properly fall through to `execaError.message`.
- **Remove duplicate logging**: `ignite.ts` was logging "Failed to launch Claude: ..." then re-throwing, and `cli.ts` was also logging "Failed to spin up loom: ..." for the same error. Removed the redundant log in `ignite.ts` so users see one clear message instead of two.

## Test plan

- [ ] Run `il spin` in a worktree — happy path unaffected
- [ ] Simulate a Claude launch failure (e.g., rename `claude` binary temporarily) — error message should now show the actual failure reason instead of a blank message