### PR TITLE
Bug: PostHog throws SSL error when DNS resolution is blocked

### DIFF
--- a/src/lib/TelemetryService.ts
+++ b/src/lib/TelemetryService.ts
@@ -11,17 +11,57 @@ export class TelemetryService {
 	private static instance: TelemetryService | null = null
 	private client: PostHog | null = null
 	private manager: TelemetryManager
+	private originalConsoleError: typeof console.error | null = null
+	private patchedConsoleError: ((...args: unknown[]) => void) | null = null
 
 	constructor(manager?: TelemetryManager) {
 		this.manager = manager ?? new TelemetryManager()
 		if (this.manager.isEnabled()) {
 			try {
-				this.client = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, flushAt: 1, flushInterval: 0 })
+				this.client = new PostHog(POSTHOG_API_KEY, {
+					host: POSTHOG_HOST,
+					flushAt: 1,
+					flushInterval: 0,
+					fetchRetryCount: 0,
+					requestTimeout: 3000,
+				})
+				this.suppressPostHogConsoleErrors()
 			} catch (error) {
 				logger.debug(`TelemetryService: Failed to initialize PostHog: ${error}`)
 				this.client = null
 			}
 		}
+	}
+
+	private static isPostHogInternalError(message: string): boolean {
+		return (
+			message.startsWith('Error while flushing PostHog') ||
+			message.startsWith('Timed out while shutting down PostHog')
+		)
+	}
+
+	private suppressPostHogConsoleErrors(): void {
+		this.originalConsoleError = console.error
+		const wrapper = (...args: unknown[]): void => {
+			if (
+				typeof args[0] === 'string' &&
+				TelemetryService.isPostHogInternalError(args[0])
+			) {
+				logger.debug(`TelemetryService: Suppressed PostHog error: ${args[0]}`)
+				return
+			}
+			this.originalConsoleError?.call(console, ...args)
+		}
+		this.patchedConsoleError = wrapper
+		console.error = wrapper
+	}
+
+	private restoreConsoleError(): void {
+		if (this.originalConsoleError && console.error === this.patchedConsoleError) {
+			console.error = this.originalConsoleError
+		}
+		this.originalConsoleError = null
+		this.patchedConsoleError = null
 	}
 
 	getManager(): TelemetryManager {
@@ -69,6 +109,7 @@ export class TelemetryService {
 			logger.debug(`TelemetryService: Shutdown error: ${error}`)
 		} finally {
 			if (timeoutId) globalThis.clearTimeout(timeoutId)
+			this.restoreConsoleError()
 		}
 	}
 }


### PR DESCRIPTION
Fixes #748

## Bug: PostHog throws SSL error when DNS resolution is blocked

# Problem
Users with aggressive DNS filtering (e.g. NextDNS with tracking/malicious domain blocking) will find that PostHog's telemetry domains are blocked, causing every `il` command to hang for a few seconds before throwing a noisy error to the console.

## Error
```
Error while flushing PostHog PostHogFetchNetworkError: Network error while fetching PostHog
    at retriable (file:///Users/helix/dev/iloom-cli/node_modules/.pnpm/posthog-node@4.18.0/node_modules/posthog-node/lib/node/index.mjs:2835:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async retriable (file:///Users/helix/dev/iloom-cli/node_modules/.pnpm/posthog-node@4.18.0/node_modules/posthog-node/lib/node/index.mjs:1601:25)
    at async PostHog.fetchWithRetry (file:///Users/helix/dev/iloom-cli/node_modules/.pnpm/posthog-node@4.18.0/node_modules/posthog-node/lib/node/index.mjs:2825:16)
    at async PostHog._flush (file:///Users/helix/dev/iloom-cli/node_modules/.pnpm/posthog-node@4.18.0/node_modules/posthog-node/lib/node/index.mjs:2786:17) {
  error: [TypeError: fetch failed] {
    [cause]: [Error: 40E83F4BF87F0000:error:0A000438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:ssl/record/rec_layer_s3.c:918:SSL alert number 80
    ] {
      library: 'SSL routines',
      reason: 'tlsv1 alert internal error',
      code: 'ERR_SSL_TLSV1_ALERT_INTERNAL_ERROR'
    }
  },
  [cause]: [TypeError: fetch failed] {
    [cause]: [Error: 40E83F4BF87F0000:error:0A000438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:ssl/record/rec_layer_s3.c:918:SSL alert number 80
    ] {
      library: 'SSL routines',
      reason: 'tlsv1 alert internal error',
      code: 'ERR_SSL_TLSV1_ALERT_INTERNAL_ERROR'
    }
  }
}
```

## Proposed Solution

At minimum, iloom should catch and suppress this error so it doesn't surface to the user. Ideally, we could also detect when the failure is caused by a blocked DNS resolution and automatically disable telemetry, similar to what `il telemetry off` does manually.

> **Workaround:** `il telemetry off`

---
*This PR was created automatically by iloom.*