### PR TITLE
Move worktrees out of project tree, pre-accept Claude trust, add il switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,9 @@
     "jsonc-parser": "^3.3.1",
     "omelette": "^0.4.17",
     "ora": "^7.0.1",
-    "string-width": "^6.1.0",
     "posthog-node": "^4.0.0",
+    "proper-lockfile": "^4.1.2",
+    "string-width": "^6.1.0",
     "uuid": "^11.1.0",
     "zod": "^3.23.8"
   },
@@ -93,6 +94,7 @@
     "@types/handlebars": "^4.1.0",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^20.8.10",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       posthog-node:
         specifier: ^4.0.0
         version: 4.18.0
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       string-width:
         specifier: ^6.1.0
         version: 6.1.0
@@ -87,6 +90,9 @@ importers:
       '@types/node':
         specifier: ^20.8.10
         version: 20.19.14
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -624,6 +630,12 @@ packages:
 
   '@types/node@20.19.14':
     resolution: {integrity: sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==}
+
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -1942,6 +1954,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2016,6 +2031,10 @@ packages:
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2861,6 +2880,12 @@ snapshots:
   '@types/node@20.19.14':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
+  '@types/retry@0.12.5': {}
 
   '@types/through@0.0.33':
     dependencies:
@@ -4418,6 +4443,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4513,6 +4544,8 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 

--- a/src/lib/LoomManager.test.ts
+++ b/src/lib/LoomManager.test.ts
@@ -21,6 +21,9 @@ const testOptions: TestOptions = { timeout: 30_000 }
 // Mock all dependencies
 vi.mock('./GitWorktreeManager.js')
 vi.mock('./GitHubService.js')
+vi.mock('../utils/claude-trust.js', () => ({
+  preAcceptClaudeTrust: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('./BranchNamingService.js')
 vi.mock('./EnvironmentManager.js')
 vi.mock('./ClaudeContextManager.js')

--- a/src/lib/LoomManager.ts
+++ b/src/lib/LoomManager.ts
@@ -14,6 +14,7 @@ import { MetadataManager, type WriteMetadataInput } from './MetadataManager.js'
 import { branchExists, executeGitCommand, ensureRepositoryHasCommits, extractIssueNumber, isFileTrackedByGit, extractPRNumber, PLACEHOLDER_COMMIT_PREFIX, pushBranchToRemote, GitCommandError, fetchOrigin } from '../utils/git.js'
 import { GitHubService } from './GitHubService.js'
 import { generateRandomSessionId } from '../utils/claude.js'
+import { preAcceptClaudeTrust } from '../utils/claude-trust.js'
 import { installDependencies } from '../utils/package-manager.js'
 import { generateColorFromBranchName, selectDistinctColor, hexToRgb, type ColorData } from '../utils/color.js'
 import { detectDarkMode } from '../utils/terminal.js'
@@ -792,6 +793,13 @@ export class LoomManager {
           getLogger().warn(`Failed to reset to match remote: ${error instanceof Error ? error.message : 'Unknown error'}`)
         }
       }
+    }
+
+    // Pre-accept Claude Code trust for the new worktree path
+    try {
+      await preAcceptClaudeTrust(worktreePath)
+    } catch (error) {
+      getLogger().warn(`Failed to pre-accept Claude trust: ${error instanceof Error ? error.message : String(error)}`)
     }
 
     return worktreePath

--- a/src/lib/ResourceCleanup.test.ts
+++ b/src/lib/ResourceCleanup.test.ts
@@ -15,6 +15,10 @@ vi.mock('./DatabaseManager.js')
 vi.mock('./process/ProcessManager.js')
 vi.mock('./SettingsManager.js')
 
+vi.mock('../utils/claude-trust.js', () => ({
+	removeClaudeTrust: vi.fn().mockResolvedValue(undefined),
+}))
+
 // Mock MetadataManager to prevent real file creation during tests
 vi.mock('./MetadataManager.js', () => ({
 	MetadataManager: vi.fn(() => ({
@@ -152,7 +156,7 @@ describe('ResourceCleanup', () => {
 
 			expect(result.success).toBe(true)
 			expect(result.errors).toHaveLength(0)
-			expect(result.operations).toHaveLength(6) // dev-server, worktree, recap, branch, database, metadata
+			expect(result.operations).toHaveLength(7) // dev-server, worktree, recap, branch, database, metadata, trust
 			expect(result.operations[0]?.type).toBe('dev-server')
 			expect(result.operations[0]?.success).toBe(true)
 			expect(result.operations[1]?.type).toBe('worktree')
@@ -160,6 +164,7 @@ describe('ResourceCleanup', () => {
 			expect(result.operations[3]?.type).toBe('branch')
 			expect(result.operations[4]?.type).toBe('database')
 			expect(result.operations[5]?.type).toBe('metadata')
+			expect(result.operations[6]?.type).toBe('trust')
 		})
 
 		it('should pre-fetch merge target BEFORE worktree deletion (bug fix for issue #328)', async () => {
@@ -332,7 +337,7 @@ describe('ResourceCleanup', () => {
 				keepDatabase: true,
 			})
 
-			expect(result.operations).toHaveLength(4) // dev-server check + worktree removal + recap archival + metadata
+			expect(result.operations).toHaveLength(5) // dev-server check + worktree removal + recap archival + metadata + trust
 			expect(result.operations.every(op => 'type' in op)).toBe(true)
 			expect(result.operations.every(op => 'success' in op)).toBe(true)
 			expect(result.operations.every(op => 'message' in op)).toBe(true)

--- a/src/lib/SwarmSetupService.test.ts
+++ b/src/lib/SwarmSetupService.test.ts
@@ -8,6 +8,9 @@ import type { SettingsManager, IloomSettings } from './SettingsManager.js'
 import type { PromptTemplateManager } from './PromptTemplateManager.js'
 
 // Mock dependencies
+vi.mock('../utils/claude-trust.js', () => ({
+	preAcceptClaudeTrust: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('../utils/package-manager.js', () => ({
 	installDependencies: vi.fn().mockResolvedValue(undefined),
 }))

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -8,6 +8,7 @@ import { PromptTemplateManager, buildReviewTemplateVariables, type TemplateVaria
 import { IssueTrackerFactory } from './IssueTrackerFactory.js'
 import { IssueManagementProviderFactory } from '../mcp/IssueManagementProviderFactory.js'
 import { getLogger } from '../utils/logger-context.js'
+import { preAcceptClaudeTrust } from '../utils/claude-trust.js'
 import { installDependencies } from '../utils/package-manager.js'
 import { generateWorktreePath } from '../utils/git.js'
 import { generateAndWriteMcpConfigFile } from '../utils/mcp.js'
@@ -116,6 +117,13 @@ export class SwarmSetupService {
 					createBranch: true,
 					baseBranch: epicBranch,
 				})
+
+				// Pre-accept Claude Code trust for child worktree
+				try {
+					await preAcceptClaudeTrust(childWorktreePath)
+				} catch (error) {
+					getLogger().warn(`Failed to pre-accept Claude trust for child worktree: ${error instanceof Error ? error.message : String(error)}`)
+				}
 
 				// Write metadata with state: 'pending' and parentLoom
 				const metadataInput: WriteMetadataInput = {

--- a/src/types/cleanup.ts
+++ b/src/types/cleanup.ts
@@ -47,7 +47,7 @@ export interface CleanupResult {
  */
 export interface OperationResult {
 	/** Type of operation performed */
-	type: 'dev-server' | 'worktree' | 'branch' | 'database' | 'cli-symlinks' | 'recap' | 'metadata'
+	type: 'dev-server' | 'worktree' | 'branch' | 'database' | 'cli-symlinks' | 'recap' | 'metadata' | 'trust'
 	/** Whether operation succeeded */
 	success: boolean
 	/** Human-readable message */

--- a/src/utils/claude-trust.test.ts
+++ b/src/utils/claude-trust.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import fs from 'fs-extra'
+import lockfile from 'proper-lockfile'
+import { preAcceptClaudeTrust, removeClaudeTrust, _internal } from './claude-trust.js'
+
+vi.mock('fs-extra', () => ({
+	default: {
+		access: vi.fn(),
+		readFile: vi.fn(),
+		writeFile: vi.fn(),
+		rename: vi.fn(),
+	},
+}))
+
+vi.mock('proper-lockfile', () => ({
+	default: {
+		lock: vi.fn(),
+	},
+}))
+
+vi.mock('./logger-context.js', () => ({
+	getLogger: () => ({
+		debug: vi.fn(),
+		warn: vi.fn(),
+		info: vi.fn(),
+		error: vi.fn(),
+	}),
+}))
+
+describe('preAcceptClaudeTrust', () => {
+	beforeEach(() => {
+		// Default: file exists, lock succeeds, file has empty config
+		vi.mocked(fs.access).mockResolvedValue(undefined)
+		vi.mocked(fs.readFile).mockResolvedValue('{}')
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+		vi.mocked(fs.rename).mockResolvedValue(undefined)
+		vi.mocked(lockfile.lock).mockResolvedValue(vi.fn().mockResolvedValue(undefined))
+	})
+
+	it('should write hasTrustDialogAccepted: true for the given path to ~/.claude.json', async () => {
+		const worktreePath = '/home/user/.config/iloom-ai/worktrees/myproject-a3f2/feat-issue-42'
+
+		await preAcceptClaudeTrust(worktreePath)
+
+		// Verify the written content
+		expect(fs.writeFile).toHaveBeenCalledWith(
+			expect.stringContaining('.tmp'),
+			expect.any(String),
+			expect.objectContaining({ encoding: 'utf-8', mode: 0o600 })
+		)
+
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+		expect(parsed.projects[worktreePath]).toEqual({ hasTrustDialogAccepted: true })
+	})
+
+	it('should create ~/.claude.json if it does not exist', async () => {
+		const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+		vi.mocked(fs.access).mockRejectedValue(enoentError)
+
+		await preAcceptClaudeTrust('/some/worktree')
+
+		// Should create the file first
+		expect(fs.writeFile).toHaveBeenCalledWith(
+			_internal.CLAUDE_CONFIG_PATH,
+			'{}',
+			expect.objectContaining({ encoding: 'utf-8', mode: 0o600 })
+		)
+	})
+
+	it('should preserve existing projects entries in ~/.claude.json', async () => {
+		const existingConfig = {
+			projects: {
+				'/existing/project': { hasTrustDialogAccepted: true, someOtherSetting: 'value' },
+			},
+			someGlobalSetting: true,
+		}
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingConfig))
+
+		await preAcceptClaudeTrust('/new/worktree')
+
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+
+		// Existing entry preserved
+		expect(parsed.projects['/existing/project']).toEqual({
+			hasTrustDialogAccepted: true,
+			someOtherSetting: 'value',
+		})
+		// New entry added
+		expect(parsed.projects['/new/worktree']).toEqual({ hasTrustDialogAccepted: true })
+		// Global settings preserved
+		expect(parsed.someGlobalSetting).toBe(true)
+	})
+
+	it('should use proper-lockfile for concurrent safety', async () => {
+		const mockRelease = vi.fn().mockResolvedValue(undefined)
+		vi.mocked(lockfile.lock).mockResolvedValue(mockRelease)
+
+		await preAcceptClaudeTrust('/some/worktree')
+
+		expect(lockfile.lock).toHaveBeenCalledWith(
+			_internal.CLAUDE_CONFIG_PATH,
+			expect.objectContaining({
+				retries: expect.objectContaining({ retries: 5 }),
+			})
+		)
+		// Lock should be released after write
+		expect(mockRelease).toHaveBeenCalled()
+	})
+
+	it('should fall back to direct write if lock acquisition fails', async () => {
+		vi.mocked(lockfile.lock).mockRejectedValue(new Error('Lock failed'))
+
+		await preAcceptClaudeTrust('/some/worktree')
+
+		// Should still write the file despite lock failure
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+		expect(parsed.projects['/some/worktree']).toEqual({ hasTrustDialogAccepted: true })
+	})
+
+	it('should set file mode 0o600 on ~/.claude.json', async () => {
+		await preAcceptClaudeTrust('/some/worktree')
+
+		// The atomic write should use mode 0o600
+		const tmpWriteCall = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)
+		expect(tmpWriteCall?.[2]).toEqual(expect.objectContaining({ mode: 0o600 }))
+	})
+
+	it('should be idempotent - no error if trust already set', async () => {
+		const existingConfig = {
+			projects: {
+				'/some/worktree': { hasTrustDialogAccepted: true },
+			},
+		}
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingConfig))
+
+		// Should not throw
+		await expect(preAcceptClaudeTrust('/some/worktree')).resolves.toBeUndefined()
+
+		// Should still write (idempotent overwrite)
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+		expect(parsed.projects['/some/worktree']).toEqual({ hasTrustDialogAccepted: true })
+	})
+
+	it('should throw when the entire operation fails', async () => {
+		const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+		vi.mocked(fs.access).mockRejectedValue(enoentError)
+		// Make the creation itself fail
+		vi.mocked(fs.writeFile).mockRejectedValue(new Error('Permission denied'))
+
+		await expect(preAcceptClaudeTrust('/some/worktree')).rejects.toThrow('Permission denied')
+	})
+
+	it('should handle malformed JSON in existing ~/.claude.json', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue('not valid json{{{')
+
+		await preAcceptClaudeTrust('/some/worktree')
+
+		// Should create fresh config with just the new entry
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+		expect(parsed.projects['/some/worktree']).toEqual({ hasTrustDialogAccepted: true })
+	})
+
+	it('should release the lock even if writing fails', async () => {
+		const mockRelease = vi.fn().mockResolvedValue(undefined)
+		vi.mocked(lockfile.lock).mockResolvedValue(mockRelease)
+		vi.mocked(fs.readFile).mockResolvedValue('{}')
+		// Fail on the temp file write
+		vi.mocked(fs.writeFile).mockImplementation(async (filePath) => {
+			if (String(filePath).endsWith('.tmp')) {
+				throw new Error('Disk full')
+			}
+		})
+
+		await expect(preAcceptClaudeTrust('/some/worktree')).rejects.toThrow('Disk full')
+
+		// Lock should still be released
+		expect(mockRelease).toHaveBeenCalled()
+	})
+})
+
+describe('removeClaudeTrust', () => {
+	beforeEach(() => {
+		vi.mocked(fs.access).mockResolvedValue(undefined)
+		vi.mocked(fs.readFile).mockResolvedValue('{}')
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+		vi.mocked(fs.rename).mockResolvedValue(undefined)
+		vi.mocked(lockfile.lock).mockResolvedValue(vi.fn().mockResolvedValue(undefined))
+	})
+
+	it('should remove the trust entry for the given path from ~/.claude.json', async () => {
+		const existingConfig = {
+			projects: {
+				'/worktree/to/remove': { hasTrustDialogAccepted: true },
+				'/worktree/to/keep': { hasTrustDialogAccepted: true },
+			},
+		}
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingConfig))
+
+		await removeClaudeTrust('/worktree/to/remove')
+
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+
+		expect(parsed.projects['/worktree/to/remove']).toBeUndefined()
+		expect(parsed.projects['/worktree/to/keep']).toEqual({ hasTrustDialogAccepted: true })
+	})
+
+	it('should not throw if path does not exist in ~/.claude.json', async () => {
+		const existingConfig = {
+			projects: {
+				'/some/other/worktree': { hasTrustDialogAccepted: true },
+			},
+		}
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingConfig))
+
+		await expect(removeClaudeTrust('/nonexistent/worktree')).resolves.toBeUndefined()
+	})
+
+	it('should not throw if ~/.claude.json does not exist', async () => {
+		const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+		vi.mocked(fs.access).mockRejectedValue(enoentError)
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+		vi.mocked(fs.readFile).mockResolvedValue('{}')
+
+		await expect(removeClaudeTrust('/some/worktree')).resolves.toBeUndefined()
+	})
+
+	it('should preserve other projects entries', async () => {
+		const existingConfig = {
+			projects: {
+				'/worktree/a': { hasTrustDialogAccepted: true, custom: 'data' },
+				'/worktree/b': { hasTrustDialogAccepted: true },
+				'/worktree/c': { hasTrustDialogAccepted: true },
+			},
+			globalSetting: 'preserved',
+		}
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingConfig))
+
+		await removeClaudeTrust('/worktree/b')
+
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+
+		expect(parsed.projects['/worktree/a']).toEqual({ hasTrustDialogAccepted: true, custom: 'data' })
+		expect(parsed.projects['/worktree/b']).toBeUndefined()
+		expect(parsed.projects['/worktree/c']).toEqual({ hasTrustDialogAccepted: true })
+		expect(parsed.globalSetting).toBe('preserved')
+	})
+
+	it('should throw when the entire operation fails', async () => {
+		const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+		vi.mocked(fs.access).mockRejectedValue(enoentError)
+		// Make the creation itself fail
+		vi.mocked(fs.writeFile).mockRejectedValue(new Error('Permission denied'))
+
+		await expect(removeClaudeTrust('/some/worktree')).rejects.toThrow('Permission denied')
+	})
+
+	it('should handle config with no projects key gracefully', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue('{"someOther": "setting"}')
+
+		await removeClaudeTrust('/some/worktree')
+
+		// Should still write, just without modifying anything structurally
+		const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+			(call) => String(call[0]).endsWith('.tmp')
+		)?.[1] as string
+		const parsed = JSON.parse(writtenContent)
+		expect(parsed.someOther).toBe('setting')
+	})
+})

--- a/src/utils/claude-trust.ts
+++ b/src/utils/claude-trust.ts
@@ -1,0 +1,178 @@
+import lockfile from 'proper-lockfile'
+import fs from 'fs-extra'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+import { getLogger } from './logger-context.js'
+
+const CLAUDE_CONFIG_PATH = path.join(os.homedir(), '.claude.json')
+
+const LOCK_OPTIONS: lockfile.LockOptions = {
+	retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+	realpath: false, // ~/.claude.json may not exist yet; realpath would fail
+}
+
+/**
+ * Pre-accept Claude Code trust for a worktree path by writing to ~/.claude.json.
+ *
+ * Sets `projects.<worktreePath>.hasTrustDialogAccepted = true` so that Claude Code
+ * does not show the trust dialog when launching inside the worktree.
+ *
+ * Uses `proper-lockfile` to safely participate in Claude Code's own concurrency
+ * protocol for ~/.claude.json writes.
+ *
+ * Throws on failure - callers should handle errors appropriately.
+ */
+export async function preAcceptClaudeTrust(worktreePath: string): Promise<void> {
+	await modifyClaudeConfig((config) => {
+		if (!config.projects || typeof config.projects !== 'object' || Array.isArray(config.projects)) {
+			config.projects = {}
+		}
+		const projects = config.projects as Record<string, Record<string, unknown>>
+		if (!projects[worktreePath] || typeof projects[worktreePath] !== 'object') {
+			projects[worktreePath] = {}
+		}
+		const entry = projects[worktreePath]
+		if (entry) {
+			entry.hasTrustDialogAccepted = true
+		}
+	})
+}
+
+/**
+ * Remove the Claude Code trust entry for a worktree path from ~/.claude.json.
+ *
+ * Called during worktree cleanup to prevent ~/.claude.json from accumulating
+ * stale entries.
+ *
+ * Throws on failure - callers should handle errors appropriately.
+ */
+export async function removeClaudeTrust(worktreePath: string): Promise<void> {
+	await modifyClaudeConfig((config) => {
+		if (!config.projects || typeof config.projects !== 'object') {
+			return
+		}
+		const projects = config.projects as Record<string, unknown>
+		delete projects[worktreePath]
+	})
+}
+
+/**
+ * Shared helper that implements Claude Code's concurrency protocol:
+ * 1. Ensure the config file exists (create empty JSON if missing)
+ * 2. Acquire lock with proper-lockfile (with retries)
+ * 3. Re-read file under lock (not from cache)
+ * 4. Apply modifier function
+ * 5. Atomic write: write to temp file, rename to target, mode 0o600
+ * 6. Release lock
+ *
+ * Falls back to direct write if lock acquisition fails.
+ */
+async function modifyClaudeConfig(
+	modifier: (config: Record<string, unknown>) => void
+): Promise<void> {
+	const logger = getLogger()
+
+	// Ensure the file exists before locking (proper-lockfile requires the file to exist)
+	await ensureClaudeConfigExists()
+
+	let release: (() => Promise<void>) | null = null
+	let lockAcquired = false
+
+	try {
+		release = await lockfile.lock(CLAUDE_CONFIG_PATH, LOCK_OPTIONS)
+		lockAcquired = true
+	} catch (lockError: unknown) {
+		logger.warn(
+			`Could not acquire lock on ${CLAUDE_CONFIG_PATH}, falling back to direct write: ${lockError instanceof Error ? lockError.message : String(lockError)}`
+		)
+	}
+
+	try {
+		// Re-read under lock (or without lock in fallback mode)
+		const config = await readClaudeConfig()
+
+		// Apply modification
+		modifier(config)
+
+		// Atomic write: temp file + rename, mode 0o600
+		await atomicWriteClaudeConfig(config)
+	} finally {
+		if (lockAcquired && release) {
+			try {
+				await release()
+			} catch (unlockError: unknown) {
+				logger.debug(
+					`Failed to release lock on ${CLAUDE_CONFIG_PATH}: ${unlockError instanceof Error ? unlockError.message : String(unlockError)}`
+				)
+			}
+		}
+	}
+}
+
+/**
+ * Ensure ~/.claude.json exists. Creates an empty JSON object if missing.
+ */
+async function ensureClaudeConfigExists(): Promise<void> {
+	try {
+		await fs.access(CLAUDE_CONFIG_PATH)
+	} catch (error: unknown) {
+		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+			// File doesn't exist - create with empty object and restricted permissions
+			await fs.writeFile(CLAUDE_CONFIG_PATH, '{}', { encoding: 'utf-8', mode: 0o600 })
+		} else {
+			throw error
+		}
+	}
+}
+
+/**
+ * Read and parse ~/.claude.json. Returns empty object for missing files or malformed JSON.
+ * Re-throws other errors (e.g., permission denied).
+ */
+async function readClaudeConfig(): Promise<Record<string, unknown>> {
+	const logger = getLogger()
+	let content: string
+	try {
+		content = await fs.readFile(CLAUDE_CONFIG_PATH, 'utf-8')
+	} catch (error: unknown) {
+		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+			return {}
+		}
+		throw error
+	}
+	try {
+		const parsed: unknown = JSON.parse(content)
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>
+		}
+		return {}
+	} catch (error: unknown) {
+		if (error instanceof SyntaxError) {
+			logger.warn(`Malformed JSON in ${CLAUDE_CONFIG_PATH}, treating as empty config`)
+			return {}
+		}
+		throw error
+	}
+}
+
+/**
+ * Atomically write config to ~/.claude.json via temp file + rename.
+ * Sets file mode to 0o600 (owner read/write only).
+ */
+async function atomicWriteClaudeConfig(config: Record<string, unknown>): Promise<void> {
+	const tmpPath = `${CLAUDE_CONFIG_PATH}.${crypto.randomUUID()}.tmp`
+	const content = JSON.stringify(config, null, 2) + '\n'
+
+	await fs.writeFile(tmpPath, content, { encoding: 'utf-8', mode: 0o600 })
+	await fs.rename(tmpPath, CLAUDE_CONFIG_PATH)
+}
+
+// Exported for testing only
+export const _internal = {
+	CLAUDE_CONFIG_PATH,
+	modifyClaudeConfig,
+	ensureClaudeConfigExists,
+	readClaudeConfig,
+	atomicWriteClaudeConfig,
+}

--- a/tests/lib/LoomManager-database.test.ts
+++ b/tests/lib/LoomManager-database.test.ts
@@ -15,6 +15,9 @@ import { createMockDatabaseManager } from '../mocks/MockDatabaseProvider.js'
 // Mock all dependencies
 vi.mock('../../src/lib/GitWorktreeManager.js')
 vi.mock('../../src/lib/GitHubService.js')
+vi.mock('../../src/utils/claude-trust.js', () => ({
+  preAcceptClaudeTrust: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('../../src/lib/BranchNamingService.js')
 vi.mock('../../src/lib/EnvironmentManager.js')
 vi.mock('../../src/lib/ClaudeContextManager.js')


### PR DESCRIPTION
Fixes #804

## Move worktrees out of project tree, pre-accept Claude trust, add il switch

## Problem

PR #779 moved worktrees from sibling directories (`../myrepo-hatchboxes/`) into `.iloom/worktrees/` inside the project root, hoping Claude Code would inherit the parent project's trust grant for nested directories.

Two problems emerged:

1. **Claude Code trust dialog on every new worktree** — even though parent walk code exists in Claude Code, it's disabled when `.claude/settings.json` has allowed tools (which iloom always configures). See root cause below.
2. **Tool interference** — vitest, eslint, and other tools walk the project directory tree and pick up worktree files, tripling test runs, lint passes, etc.

Since iloom is technology-agnostic and can't configure every possible tool to exclude its worktrees, they need to move outside the project tree entirely.

## Root Cause (verified in Claude Code v2.1.58 source)

Claude Code's `checkHasTrustDialogAccepted(isNonInteractive)` has a parent directory walk, but it's called with `isNonInteractive = true` when the project has allowed tools, hooks, or MCP servers:

```javascript
// The call site:
I = checkHasTrustDialogAccepted(hasHooks || hasAllowedTools || hasPlugins || ...)

// The function:
function checkHasTrustDialogAccepted(isNonInteractive) {
  if (isPrintMode()) return true;
  if (config.projects?.[gitRoot]?.hasTrustDialogAccepted) return true;
  
  if (isNonInteractive)  // <-- When true, ONLY exact match, no parent walk
    return config.projects?.[cwd]?.hasTrustDialogAccepted === true;
  
  // Parent walk only runs when isNonInteractive=false (bare projects)
  while (true) { /* walk up parents */ }
}
```

Since iloom copies `.claude/settings.json` (with 35 allowed tool patterns) into every worktree, `hasAllowedTools` is always true, the trust check uses exact-match-only mode, and new worktree paths aren't in `~/.claude.json` → dialog appears every time.

## Requirements

1. **Move worktree location** to `~/.config/iloom-ai/worktrees/<project-slug>/` (centralized, outside any project)
2. **Pre-accept Claude Code trust** when creating worktrees by writing to `~/.claude.json` using `proper-lockfile` (same concurrency protocol Claude Code uses)
3. **Add `il switch` command** for easy navigation to worktrees (since they're no longer browsable inside the project)
4. **Migrate existing worktrees** from `.iloom/worktrees/` to the new location
5. **Auto issue detection must still work** — `il spin` with no args inside a worktree must still detect the issue

## Key Technical Details

### Git worktrees work regardless of location
Git tracks worktrees via its internal registry (`.git/worktrees/`), not by filesystem proximity. `git worktree add /any/absolute/path -b branch` works fine, and `git worktree list` will still find all worktrees. All existing discovery mechanisms continue working unchanged.

### Auto issue detection flow
`il spin` without args uses `detectWorkspaceContext()` (`src/commands/ignite.ts:647-694`) with cascading detection:
1. PR pattern in directory name (`_pr_N` suffix)
2. Issue pattern in directory name (`issue-{ID}__`)
3. Git branch name (same `extractIssueNumber()` logic)
4. Fallback to "regular" context

Directory basenames remain the same at the new location, so detection keeps working.

### Claude Code concurrency protocol (from source analysis)
Claude Code uses a 3-layer write strategy for `~/.claude.json`:
1. `proper-lockfile` with lock at `~/.claude.json.lock`
2. Re-read under lock (not from cache)
3. Atomic write via temp file + rename, file mode `0o600`
4. Fallback to direct write if locking fails

iloom should use the same protocol to safely participate in concurrent access.

### Current worktree path generation
`generateWorktreePath()` in `src/utils/git.ts:232-247`:
```typescript
return path.join(rootDir, '.iloom', 'worktrees', sanitized)
```
Needs to change to:
```typescript
return path.join(os.homedir(), '.config', 'iloom-ai', 'worktrees', projectSlug, sanitized)
```

### Migration approach
`git worktree move <old-path> <new-path>` is git's built-in worktree relocation command. Combined with updating metadata (`worktreePath` field) and Claude trust entries, this provides clean migration.

## Key Files

| File | Relevance |
|------|-----------|
| `src/utils/git.ts:232-247` | `generateWorktreePath()` — path generation to change |
| `src/utils/claude.ts` | Where trust pre-acceptance logic should go |
| `src/lib/LoomManager.ts:661-684` | `createWorktreeOnly()` — calls path generation |
| `src/commands/ignite.ts:647-694` | `detectWorkspaceContext()` — auto-detection (unchanged) |
| `src/lib/MetadataManager.ts` | Metadata at `~/.config/iloom-ai/looms/` (already centralized) |
| `src/migrations/index.ts` | Where migration from old location goes |
| `src/cli.ts` | Where `il switch` command gets added |
| `package.json` | Add `proper-lockfile` dependency |

## `il switch` Command Design

Since a subprocess can't change the parent shell's cwd:
- `il switch <issue-number>` — prints worktree path to stdout
- Usage: `cd $(il switch 42)` 
- `il switch` (no args) — interactive picker of active worktrees
- Optionally provide a shell helper: `ils() { cd "$(il switch "$@")" }`

## Verification
- [ ] `il start <issue>` creates worktree at `~/.config/iloom-ai/worktrees/<project>/<branch>`
- [ ] `il spin` (no args) inside a worktree still auto-detects the issue
- [ ] `il list` still shows all worktrees correctly
- [ ] `il finish <issue>` finds and merges the worktree
- [ ] `il switch <issue>` prints the correct worktree path
- [ ] No Claude trust dialog when launching in a new worktree
- [ ] `pnpm test` in the main repo only runs tests once (no worktree duplication)
- [ ] Existing worktrees in `.iloom/worktrees/` are migrated on first run

---
*This PR was created automatically by iloom.*