### PR TITLE
Move worktrees back to sibling directories (outside project tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You are in the loop at every stage. You can review the AI's analysis, edit the p
 
 Each loom is a fully isolated container for your work:
 
-*   **Git Worktree:** A separate filesystem at ~/project/.iloom/worktrees/issue-25/. No stashing, no branch switching overhead.
+*   **Git Worktree:** A separate filesystem at ~/project-worktrees/issue-25/. No stashing, no branch switching overhead.
     
 *   **Database Branch:** (Neon support) Schema changes in this loom are isolated—they won't break your main environment or your other active looms.
 
@@ -526,7 +526,7 @@ Sometimes a task spawns sub-tasks, or you get interrupted by an urgent bug while
     
 *  **Structure**
 ```
-    ~/my-project/.iloom/worktrees/
+    ~/my-project-worktrees/
     ├── feat-issue-25-auth/           # Parent Loom
     ├── fix-issue-42-bug/             # Child Loom (inherits from #25)
     └── feat-issue-43-subtask/        # Another Child Loom

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -177,7 +177,7 @@ All AI reasoning is posted as issue comments, creating a permanent record for yo
 Your loom is a fully isolated environment:
 
 ```
-~/your-project/.iloom/worktrees/feat-issue-25-dark-mode/
+~/your-project-worktrees/feat-issue-25-dark-mode/
 ```
 
 - **Unique port:** Web projects run on port `3000 + issue number` (e.g., 3025)
@@ -400,7 +400,7 @@ Sometimes you need to branch off from a branch. Child looms let you create works
 When you run `il start` from inside an existing loom, iloom prompts you to create a child loom:
 
 ```bash
-# Inside ~/your-project/.iloom/worktrees/feat-issue-25-auth/
+# Inside ~/your-project-worktrees/feat-issue-25-auth/
 il start 42
 # iloom asks: Create as child loom?
 ```

--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -530,11 +530,11 @@ il list --json
 # Active Looms:
 # ──────────────────────────────────────────────────────
 #  #25  feat-add-dark-mode
-#       ~/my-project/.iloom/worktrees/feat-issue-25-dark-mode/
+#       ~/my-project-worktrees/feat-issue-25-dark-mode/
 #       Port: 3025 | DB: br-issue-25
 #
 #  #42  fix-authentication-bug
-#       ~/my-project/.iloom/worktrees/fix-issue-42-auth/
+#       ~/my-project-worktrees/fix-issue-42-auth/
 #       Port: 3042 | DB: br-issue-42
 ```
 
@@ -798,7 +798,7 @@ il build
 il build 25
 
 # Run in specific loom workspace
-cd ~/my-project/.iloom/worktrees/feat-issue-42-feature/
+cd ~/my-project-worktrees/feat-issue-42-feature/
 il build
 ```
 
@@ -1890,7 +1890,7 @@ Swarm mode is designed to maximize throughput despite individual failures:
 During swarm mode, the following files are created:
 
 ```
-~/project/.iloom/worktrees/
+~/project-worktrees/
 ├── epic-issue-100/                    # Epic worktree
 │   └── .claude/
 │       └── agents/

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -351,7 +351,7 @@ describe('InitCommand', () => {
 
       // Mock readFile to return README content when README.md is read.
       // Check for .iloom/README.md suffix (not just .iloom anywhere in the path,
-      // since worktrees live under .iloom/worktrees/ and would false-match)
+      // since worktrees previously lived under .iloom/worktrees/ and this suffix check is still correct)
       vi.mocked(readFile).mockImplementation(async (filePath) => {
         const pathStr = filePath.toString()
         if (pathStr.endsWith('.iloom/README.md')) {

--- a/src/commands/test-prefix.ts
+++ b/src/commands/test-prefix.ts
@@ -10,7 +10,7 @@ export interface TestPrefixCommandInput {
 
 /**
  * Test command to preview worktree paths
- * Demonstrates how different branch names will be resolved under .iloom/worktrees/
+ * Demonstrates how different branch names will be resolved as sibling directories
  */
 export class TestPrefixCommand {
   /**
@@ -24,7 +24,7 @@ export class TestPrefixCommand {
       // Display the current working directory
       const rootDir = process.cwd()
       logger.info(`Repository: ${rootDir}`)
-      logger.info('Worktree location: .iloom/worktrees/ (under project root)')
+      logger.info('Worktree location: <project>-worktrees/ (sibling directory)')
       logger.info('')
       logger.info('Example Worktree Paths:\n')
 

--- a/src/lib/LoomManager.test.ts
+++ b/src/lib/LoomManager.test.ts
@@ -3639,7 +3639,7 @@ describe('LoomManager', testOptions, () => {
           type: 'issue',
           identifier: 100,
           branchName: parentBranch,
-          worktreePath: '/project/.iloom/worktrees/feat-issue-100__epic-feature',
+          worktreePath: '/project-worktrees/feat-issue-100__epic-feature',
         },
       })
       const childMetadata2 = makeMetadata({
@@ -3648,7 +3648,7 @@ describe('LoomManager', testOptions, () => {
           type: 'issue',
           identifier: 100,
           branchName: parentBranch,
-          worktreePath: '/project/.iloom/worktrees/feat-issue-100__epic-feature',
+          worktreePath: '/project-worktrees/feat-issue-100__epic-feature',
         },
       })
       const unrelatedMetadata = makeMetadata({
@@ -3657,16 +3657,16 @@ describe('LoomManager', testOptions, () => {
           type: 'issue',
           identifier: 999,
           branchName: 'feat/issue-999__other-epic',
-          worktreePath: '/project/.iloom/worktrees/feat-issue-999__other-epic',
+          worktreePath: '/project-worktrees/feat-issue-999__other-epic',
         },
       })
 
       mockListAllMetadata.mockResolvedValue([childMetadata1, childMetadata2, unrelatedMetadata])
 
       const worktrees = [
-        makeWorktree('feat/issue-101__child-one', '/project/.iloom/worktrees/feat-issue-101__child-one'),
-        makeWorktree('feat/issue-102__child-two', '/project/.iloom/worktrees/feat-issue-102__child-two'),
-        makeWorktree('feat/issue-200__unrelated', '/project/.iloom/worktrees/feat-issue-200__unrelated'),
+        makeWorktree('feat/issue-101__child-one', '/project-worktrees/feat-issue-101__child-one'),
+        makeWorktree('feat/issue-102__child-two', '/project-worktrees/feat-issue-102__child-two'),
+        makeWorktree('feat/issue-200__unrelated', '/project-worktrees/feat-issue-200__unrelated'),
         makeWorktree('main', '/project'),
       ]
 
@@ -3690,7 +3690,7 @@ describe('LoomManager', testOptions, () => {
       mockListAllMetadata.mockResolvedValue([unrelatedMetadata])
 
       const worktrees = [
-        makeWorktree('feat/issue-200__unrelated', '/project/.iloom/worktrees/feat-issue-200__unrelated'),
+        makeWorktree('feat/issue-200__unrelated', '/project-worktrees/feat-issue-200__unrelated'),
         makeWorktree('main', '/project'),
       ]
 
@@ -3709,7 +3709,7 @@ describe('LoomManager', testOptions, () => {
           type: 'issue',
           identifier: 100,
           branchName: parentBranch,
-          worktreePath: '/project/.iloom/worktrees/feat-issue-101__child-one',
+          worktreePath: '/project-worktrees/feat-issue-101__child-one',
         },
       })
 
@@ -3750,7 +3750,7 @@ describe('LoomManager', testOptions, () => {
           type: 'issue',
           identifier: 100,
           branchName: parentBranch,
-          worktreePath: '/project/.iloom/worktrees/feat-issue-100__epic-feature',
+          worktreePath: '/project-worktrees/feat-issue-100__epic-feature',
         },
       })
 

--- a/src/lib/LoomManager.ts
+++ b/src/lib/LoomManager.ts
@@ -669,7 +669,7 @@ export class LoomManager {
     getLogger().info('Ensuring repository has initial commit...')
     await ensureRepositoryHasCommits(this.gitWorktree.workingDirectory)
 
-    // Load settings (worktreePrefix is no longer used — all worktrees go under .iloom/worktrees/)
+    // Load settings (worktreePrefix is no longer used — worktrees go under <project>-worktrees/ sibling directory)
     const settingsData = await this.settings.loadSettings()
 
     // Build options object

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -323,7 +323,7 @@ export const IloomSettingsSchema = z.object({
 			},
 		)
 		.describe(
-			'DEPRECATED: Prefix for worktree directories. Worktrees now default to .iloom/worktrees/ under the project root. This setting will be removed in a future release.',
+			'DEPRECATED: Prefix for worktree directories. Worktrees now default to a sibling directory (<project>-worktrees/). This setting will be removed in a future release.',
 		),
 	protectedBranches: z
 		.array(z.string().min(1, 'Protected branch name cannot be empty'))
@@ -569,7 +569,7 @@ export const IloomSettingsSchemaNoDefaults = z.object({
 			},
 		)
 		.describe(
-			'DEPRECATED: Prefix for worktree directories. Worktrees now default to .iloom/worktrees/ under the project root. This setting will be removed in a future release.',
+			'DEPRECATED: Prefix for worktree directories. Worktrees now default to a sibling directory (<project>-worktrees/). This setting will be removed in a future release.',
 		),
 	protectedBranches: z
 		.array(z.string().min(1, 'Protected branch name cannot be empty'))

--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -3,16 +3,38 @@ import fs from 'fs-extra'
 import path from 'path'
 import os from 'os'
 import { migrations } from './index.js'
-import { ensureGlobalGitignorePatterns } from '../utils/gitignore.js'
+import { ensureGlobalGitignorePatterns, removeGlobalGitignorePattern } from '../utils/gitignore.js'
+import { executeGitCommand } from '../utils/git.js'
 
 // Mock fs-extra
 vi.mock('fs-extra')
 
-// Mock gitignore utilities used by the 0.10.3 migration
+// Mock gitignore utilities
 vi.mock('../utils/gitignore.js', () => ({
   ensureGlobalGitignorePatterns: vi.fn(),
-  // Pass through ensureWorktreeGitignore as a no-op since it's not used by migrations
-  ensureWorktreeGitignore: vi.fn(),
+  removeGlobalGitignorePattern: vi.fn(),
+}))
+
+// Mock git utilities
+vi.mock('../utils/git.js', () => ({
+  executeGitCommand: vi.fn(),
+  GitCommandError: class GitCommandError extends Error {
+    constructor(message: string, public readonly exitCode: number | undefined, public readonly stderr: string) {
+      super(message)
+      this.name = 'GitCommandError'
+    }
+  },
+}))
+
+// Mock logger-context
+vi.mock('../utils/logger-context.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    isDebugEnabled: () => false,
+  }),
 }))
 
 describe('migrations', () => {
@@ -224,7 +246,7 @@ describe('migrations', () => {
     })
   })
 
-  describe('v0.10.3 global gitignore migration for .iloom/worktrees and path remediation', () => {
+  describe('v0.10.3 global gitignore path remediation', () => {
     const migration = migrations.find(m => m.version === '0.10.3')
 
     const allIloomPatterns = [
@@ -233,16 +255,18 @@ describe('migrations', () => {
       '**/.claude/agents/iloom-*',
       '**/.claude/skills/iloom-*',
       '**/.claude/iloom-swarm-mcp-config-path',
-      '**/.iloom/worktrees',
     ]
 
     it('should exist with correct description', () => {
       expect(migration).toBeDefined()
-      expect(migration?.description).toContain('.iloom/worktrees')
       expect(migration?.description).toContain('core.excludesFile')
     })
 
-    it('calls ensureGlobalGitignorePatterns with all iloom patterns', async () => {
+    it('should not include **/.iloom/worktrees in patterns', () => {
+      expect(migration?.description).not.toContain('.iloom/worktrees')
+    })
+
+    it('calls ensureGlobalGitignorePatterns with all iloom patterns (excluding worktrees)', async () => {
       vi.mocked(ensureGlobalGitignorePatterns).mockResolvedValue(undefined)
 
       await migration?.migrate()
@@ -258,6 +282,431 @@ describe('migrations', () => {
 
       expect(ensureGlobalGitignorePatterns).toHaveBeenCalledTimes(2)
       expect(ensureGlobalGitignorePatterns).toHaveBeenCalledWith(allIloomPatterns)
+    })
+  })
+
+  describe('v0.10.4 worktree relocation migration', () => {
+    const migration = migrations.find(m => m.version === '0.10.4')
+    const loomsDir = path.join(os.homedir(), '.config', 'iloom-ai', 'looms')
+
+    it('should exist with correct description', () => {
+      expect(migration).toBeDefined()
+      expect(migration?.description).toContain('sibling directory')
+      expect(migration?.description).toContain('gitignore')
+    })
+
+    it('should be idempotent -- skip if looms directory does not exist', async () => {
+      vi.mocked(fs.pathExists).mockResolvedValue(false as never)
+
+      await migration?.migrate()
+
+      expect(fs.readdir).not.toHaveBeenCalled()
+      expect(executeGitCommand).not.toHaveBeenCalled()
+    })
+
+    it('should relocate worktrees from .iloom/worktrees/ to sibling directory using git worktree move', async () => {
+      const oldWorktreePath = '/Users/dev/project/.iloom/worktrees/feat-issue-42'
+      const newWorktreePath = '/Users/dev/project-worktrees/feat-issue-42'
+      const metadataSlug = '___Users___dev___project___-iloom___worktrees___feat-issue-42.json'
+      const newMetadataSlug = '___Users___dev___project-worktrees___feat-issue-42.json'
+
+      // Setup: looms dir exists with one metadata file
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        if (p === oldWorktreePath) return true as never
+        if (p === newWorktreePath) return false as never
+        // For project .gitignore
+        if (p === '/Users/dev/project/.gitignore') return false as never
+        // For .iloom/worktrees dir cleanup
+        if (p === '/Users/dev/project/.iloom/worktrees') return true as never
+        return false as never
+      })
+
+      // First readdir: initial scan of looms dir
+      // Second readdir: re-scan after renaming metadata files
+      // Third readdir: checking if .iloom/worktrees dir is empty
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        if (readdirCallCount === 1) return [metadataSlug] as never
+        if (readdirCallCount === 2) return [newMetadataSlug] as never
+        if (readdirCallCount === 3) return [] as never // empty dir for cleanup
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, metadataSlug)) {
+          return {
+            worktreePath: oldWorktreePath,
+            branchName: 'feat/issue-42',
+            projectPath: '/Users/dev/project',
+          }
+        }
+        // Re-scan reads the new file
+        if (p === path.join(loomsDir, newMetadataSlug)) {
+          return {
+            worktreePath: newWorktreePath,
+            branchName: 'feat/issue-42',
+            projectPath: '/Users/dev/project',
+          }
+        }
+        return {}
+      })
+
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(executeGitCommand).mockResolvedValue('')
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      // Should call git worktree move
+      expect(executeGitCommand).toHaveBeenCalledWith(
+        ['worktree', 'move', oldWorktreePath, newWorktreePath],
+        { cwd: '/Users/dev/project' }
+      )
+
+      // Should ensure parent dir exists
+      expect(fs.ensureDir).toHaveBeenCalledWith('/Users/dev/project-worktrees')
+    })
+
+    it('should rename metadata files to match new worktree paths', async () => {
+      const oldWorktreePath = '/Users/dev/project/.iloom/worktrees/feat-issue-42'
+      const metadataSlug = '___Users___dev___project___-iloom___worktrees___feat-issue-42.json'
+      const newMetadataSlug = '___Users___dev___project-worktrees___feat-issue-42.json'
+
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        if (p === oldWorktreePath) return true as never
+        if (p === '/Users/dev/project/.iloom/worktrees') return false as never
+        if (p === '/Users/dev/project/.gitignore') return false as never
+        // Old metadata file still exists (for removal)
+        if (p === path.join(loomsDir, metadataSlug)) return true as never
+        return false as never
+      })
+
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        if (readdirCallCount === 1) return [metadataSlug] as never
+        if (readdirCallCount === 2) return [newMetadataSlug] as never
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, metadataSlug)) {
+          return { worktreePath: oldWorktreePath, branchName: 'feat/issue-42' }
+        }
+        if (p === path.join(loomsDir, newMetadataSlug)) {
+          return { worktreePath: '/Users/dev/project-worktrees/feat-issue-42', branchName: 'feat/issue-42' }
+        }
+        return {}
+      })
+
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(executeGitCommand).mockResolvedValue('')
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      // Should write updated metadata to new filename
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        path.join(loomsDir, newMetadataSlug),
+        expect.objectContaining({
+          worktreePath: '/Users/dev/project-worktrees/feat-issue-42',
+        }),
+        { spaces: 2 }
+      )
+
+      // Should remove old metadata file
+      expect(fs.remove).toHaveBeenCalledWith(path.join(loomsDir, metadataSlug))
+    })
+
+    it('should update parentLoom.worktreePath in child metadata files', async () => {
+      const parentOldPath = '/Users/dev/project/.iloom/worktrees/feat-epic-10'
+      const parentNewPath = '/Users/dev/project-worktrees/feat-epic-10'
+      const childMetadataSlug = '___Users___dev___project-worktrees___fix-issue-11.json'
+
+      // No worktrees to move (parent already handled), but child has stale parentLoom
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        return false as never
+      })
+
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        // First scan: no old-style worktree metadata
+        if (readdirCallCount === 1) return [] as never
+        // Re-scan: find child metadata
+        if (readdirCallCount === 2) return [childMetadataSlug] as never
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, childMetadataSlug)) {
+          return {
+            worktreePath: '/Users/dev/project-worktrees/fix-issue-11',
+            branchName: 'fix/issue-11',
+            parentLoom: {
+              type: 'epic',
+              identifier: 10,
+              branchName: 'feat/epic-10',
+              worktreePath: parentOldPath,
+            },
+          }
+        }
+        return {}
+      })
+
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      // Should update parentLoom.worktreePath
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        path.join(loomsDir, childMetadataSlug),
+        expect.objectContaining({
+          parentLoom: expect.objectContaining({
+            worktreePath: parentNewPath,
+          }),
+        }),
+        { spaces: 2 }
+      )
+    })
+
+    it('should remove .iloom/worktrees/ from project .gitignore if present', async () => {
+      const oldWorktreePath = '/Users/dev/project/.iloom/worktrees/feat-issue-42'
+      const metadataSlug = 'old-slug.json'
+      const newMetadataSlug = '___Users___dev___project-worktrees___feat-issue-42.json'
+
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        if (p === oldWorktreePath) return true as never
+        if (p === '/Users/dev/project/.gitignore') return true as never
+        if (p === '/Users/dev/project/.iloom/worktrees') return false as never
+        if (p === path.join(loomsDir, metadataSlug)) return true as never
+        return false as never
+      })
+
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        if (readdirCallCount === 1) return [metadataSlug] as never
+        if (readdirCallCount === 2) return [newMetadataSlug] as never
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, metadataSlug)) {
+          return { worktreePath: oldWorktreePath, branchName: 'feat/issue-42' }
+        }
+        if (p === path.join(loomsDir, newMetadataSlug)) {
+          return { worktreePath: '/Users/dev/project-worktrees/feat-issue-42' }
+        }
+        return {}
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(fs.readFile).mockResolvedValue('node_modules/\n.iloom/worktrees/\ndist/\n' as any)
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(executeGitCommand).mockResolvedValue('')
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      // Should write .gitignore without .iloom/worktrees/ line
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/Users/dev/project/.gitignore',
+        'node_modules/\ndist/\n',
+        'utf-8'
+      )
+    })
+
+    it('should remove **/.iloom/worktrees from global gitignore', async () => {
+      // Minimal setup: looms dir exists but no metadata files
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        return false as never
+      })
+
+      vi.mocked(fs.readdir).mockResolvedValue([] as never)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      expect(removeGlobalGitignorePattern).toHaveBeenCalledWith('**/.iloom/worktrees')
+    })
+
+    it('should clean up empty .iloom/worktrees/ directory', async () => {
+      const oldWorktreePath = '/Users/dev/project/.iloom/worktrees/feat-issue-42'
+      const metadataSlug = 'old-slug.json'
+      const newMetadataSlug = '___Users___dev___project-worktrees___feat-issue-42.json'
+
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        if (p === oldWorktreePath) return true as never
+        if (p === '/Users/dev/project/.iloom/worktrees') return true as never
+        if (p === '/Users/dev/project/.gitignore') return false as never
+        if (p === path.join(loomsDir, metadataSlug)) return true as never
+        return false as never
+      })
+
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        if (readdirCallCount === 1) return [metadataSlug] as never
+        if (readdirCallCount === 2) return [newMetadataSlug] as never
+        // Empty dir for cleanup check
+        if (readdirCallCount === 3) return [] as never
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, metadataSlug)) {
+          return { worktreePath: oldWorktreePath, branchName: 'feat/issue-42' }
+        }
+        if (p === path.join(loomsDir, newMetadataSlug)) {
+          return { worktreePath: '/Users/dev/project-worktrees/feat-issue-42' }
+        }
+        return {}
+      })
+
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(executeGitCommand).mockResolvedValue('')
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      // Should remove the empty .iloom/worktrees/ directory
+      expect(fs.remove).toHaveBeenCalledWith('/Users/dev/project/.iloom/worktrees')
+    })
+
+    it('should handle git worktree move failure gracefully and continue with other worktrees', async () => {
+      const oldPath1 = '/Users/dev/project/.iloom/worktrees/feat-issue-42'
+      const oldPath2 = '/Users/dev/project/.iloom/worktrees/fix-issue-43'
+      const slug1 = 'slug1.json'
+      const slug2 = 'slug2.json'
+      const newSlug2 = '___Users___dev___project-worktrees___fix-issue-43.json'
+
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        if (p === oldPath1) return true as never
+        if (p === oldPath2) return true as never
+        if (p === '/Users/dev/project/.iloom/worktrees') return false as never
+        if (p === '/Users/dev/project/.gitignore') return false as never
+        if (p === path.join(loomsDir, slug1)) return true as never
+        return false as never
+      })
+
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        if (readdirCallCount === 1) return [slug1, slug2] as never
+        if (readdirCallCount === 2) return [slug1, newSlug2] as never
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, slug1)) {
+          return { worktreePath: oldPath1, branchName: 'feat/issue-42' }
+        }
+        if (p === path.join(loomsDir, slug2)) {
+          return { worktreePath: oldPath2, branchName: 'fix/issue-43' }
+        }
+        if (p === path.join(loomsDir, newSlug2)) {
+          return { worktreePath: '/Users/dev/project-worktrees/fix-issue-43' }
+        }
+        return {}
+      })
+
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      // First git worktree move fails, second succeeds
+      vi.mocked(executeGitCommand)
+        .mockRejectedValueOnce(new Error('fatal: worktree is dirty'))
+        .mockResolvedValueOnce('')
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      // Should not throw
+      await migration?.migrate()
+
+      // git worktree move should have been called twice (once for each worktree)
+      expect(executeGitCommand).toHaveBeenCalledTimes(2)
+
+      // Second worktree's metadata should still be written (the successful one)
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        path.join(loomsDir, newSlug2),
+        expect.objectContaining({
+          worktreePath: '/Users/dev/project-worktrees/fix-issue-43',
+        }),
+        { spaces: 2 }
+      )
+    })
+
+    it('should skip already-moved worktrees (idempotent)', async () => {
+      const oldWorktreePath = '/Users/dev/project/.iloom/worktrees/feat-issue-42'
+      const newWorktreePath = '/Users/dev/project-worktrees/feat-issue-42'
+      const metadataSlug = 'old-slug.json'
+      const newMetadataSlug = '___Users___dev___project-worktrees___feat-issue-42.json'
+
+      vi.mocked(fs.pathExists).mockImplementation(async (p: string) => {
+        if (p === loomsDir) return true as never
+        // New path already exists (already moved)
+        if (p === newWorktreePath) return true as never
+        if (p === oldWorktreePath) return false as never
+        if (p === '/Users/dev/project/.iloom/worktrees') return false as never
+        if (p === '/Users/dev/project/.gitignore') return false as never
+        if (p === path.join(loomsDir, metadataSlug)) return true as never
+        return false as never
+      })
+
+      let readdirCallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        readdirCallCount++
+        if (readdirCallCount === 1) return [metadataSlug] as never
+        if (readdirCallCount === 2) return [newMetadataSlug] as never
+        return [] as never
+      })
+
+      vi.mocked(fs.readJson).mockImplementation(async (p: string) => {
+        if (p === path.join(loomsDir, metadataSlug)) {
+          return { worktreePath: oldWorktreePath, branchName: 'feat/issue-42' }
+        }
+        if (p === path.join(loomsDir, newMetadataSlug)) {
+          return { worktreePath: newWorktreePath }
+        }
+        return {}
+      })
+
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(removeGlobalGitignorePattern).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      // Should NOT call git worktree move since it's already at the new location
+      expect(executeGitCommand).not.toHaveBeenCalled()
+
+      // Should still update metadata file (rename + update path)
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        path.join(loomsDir, newMetadataSlug),
+        expect.objectContaining({
+          worktreePath: newWorktreePath,
+        }),
+        { spaces: 2 }
+      )
     })
   })
 

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -2,7 +2,21 @@ import type { Migration } from '../lib/VersionMigrationManager.js'
 import fs from 'fs-extra'
 import path from 'path'
 import os from 'os'
-import { ensureGlobalGitignorePatterns } from '../utils/gitignore.js'
+import { ensureGlobalGitignorePatterns, removeGlobalGitignorePattern } from '../utils/gitignore.js'
+import { executeGitCommand } from '../utils/git.js'
+import { getLogger } from '../utils/logger-context.js'
+
+/**
+ * Slugify a worktree path into a metadata filename.
+ * Mirrors MetadataManager.slugifyPath() but kept inline so migrations
+ * remain self-contained and don't depend on the full MetadataManager class.
+ */
+function slugifyWorktreePath(worktreePath: string): string {
+  let slug = worktreePath.replace(/[/\\]+$/, '')
+  slug = slug.replace(/[/\\]/g, '___')
+  slug = slug.replace(/[^a-zA-Z0-9_-]/g, '-')
+  return `${slug}.json`
+}
 
 // Migration registry - add new migrations here in version order
 // Each migration must be idempotent (safe to run multiple times)
@@ -99,24 +113,174 @@ export const migrations: Migration[] = [
   },
   {
     version: '0.10.3',
-    description: 'Add global gitignore for .iloom/worktrees and remediate path for custom core.excludesFile',
+    description: 'Remediate global gitignore path for custom core.excludesFile',
     migrate: async (): Promise<void> => {
       // All iloom patterns from this and previous migrations
+      // Note: **/.iloom/worktrees was removed — worktrees now live outside the project
+      // tree as sibling directories, so the gitignore entry is no longer needed.
       const allIloomPatterns = [
         '**/.iloom/settings.local.json',
         '**/.iloom/package.iloom.local.json',
         '**/.claude/agents/iloom-*',
         '**/.claude/skills/iloom-*',
         '**/.claude/iloom-swarm-mcp-config-path',
-        '**/.iloom/worktrees',
       ]
 
       // Ensure all patterns exist at the correctly resolved global gitignore path.
-      // This both adds the new **/.iloom/worktrees pattern AND remediates previous
-      // migrations that hardcoded the XDG default (~/.config/git/ignore) — if the
-      // user has core.excludesFile set to a different path, this writes all iloom
-      // patterns to the correct location.
+      // This remediates previous migrations that hardcoded the XDG default
+      // (~/.config/git/ignore) — if the user has core.excludesFile set to a
+      // different path, this writes all iloom patterns to the correct location.
       await ensureGlobalGitignorePatterns(allIloomPatterns)
+    }
+  },
+  {
+    version: '0.10.4',
+    description: 'Move worktrees from .iloom/worktrees/ to sibling directory and clean up gitignore entries',
+    migrate: async (): Promise<void> => {
+      const logger = getLogger()
+
+      // 1. Discover existing worktrees via metadata files in ~/.config/iloom-ai/looms/
+      const loomsDir = path.join(os.homedir(), '.config', 'iloom-ai', 'looms')
+      if (!(await fs.pathExists(loomsDir))) return
+
+      const files = await fs.readdir(loomsDir)
+      const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+      // Collect metadata entries that reference old-style .iloom/worktrees/ paths
+      const oldPathMarker = path.join('.iloom', 'worktrees') + path.sep
+      const metadataToMigrate: Array<{ fileName: string; filePath: string; data: Record<string, unknown>; oldWorktreePath: string }> = []
+      const projectPaths = new Set<string>()
+
+      for (const fileName of jsonFiles) {
+        const filePath = path.join(loomsDir, fileName)
+        try {
+          const data = await fs.readJson(filePath)
+          const worktreePath = data.worktreePath as string | undefined
+          if (worktreePath?.includes(oldPathMarker)) {
+            metadataToMigrate.push({ fileName, filePath, data, oldWorktreePath: worktreePath })
+            // Derive project path: everything before .iloom/worktrees/
+            const iloomIdx = worktreePath.indexOf(path.join('.iloom', 'worktrees'))
+            if (iloomIdx > 0) {
+              projectPaths.add(worktreePath.substring(0, iloomIdx - 1))
+            }
+          }
+        } catch (error) {
+          logger.debug(`Failed to read metadata file ${fileName}: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+
+      // 2. Move worktrees using git worktree move
+      for (const entry of metadataToMigrate) {
+        const { oldWorktreePath, data, filePath, fileName } = entry
+
+        // Derive the project path and new worktree path
+        const iloomIdx = oldWorktreePath.indexOf(path.join('.iloom', 'worktrees'))
+        if (iloomIdx <= 0) continue
+
+        const projectPath = oldWorktreePath.substring(0, iloomIdx - 1)
+        const worktreeName = path.basename(oldWorktreePath)
+        const newWorktreePath = path.join(
+          path.dirname(projectPath),
+          `${path.basename(projectPath)}-worktrees`,
+          worktreeName
+        )
+
+        // Skip if already moved (idempotent)
+        if (await fs.pathExists(newWorktreePath)) {
+          logger.debug(`Worktree already at new location: ${newWorktreePath}`)
+        } else if (await fs.pathExists(oldWorktreePath)) {
+          // Ensure parent directory exists
+          await fs.ensureDir(path.dirname(newWorktreePath))
+
+          try {
+            await executeGitCommand(['worktree', 'move', oldWorktreePath, newWorktreePath], { cwd: projectPath })
+          } catch (error) {
+            logger.warn(`Failed to move worktree ${oldWorktreePath}: ${error instanceof Error ? error.message : String(error)}`)
+            continue // Skip this worktree but continue with others
+          }
+        } else {
+          // Old path doesn't exist and new path doesn't exist — worktree may
+          // have been removed externally. Update metadata anyway.
+          logger.debug(`Worktree not found at old or new location: ${oldWorktreePath}`)
+        }
+
+        // 3. Update metadata: change worktreePath and rename the metadata file
+        data.worktreePath = newWorktreePath
+        const newSlug = slugifyWorktreePath(newWorktreePath)
+        const newFilePath = path.join(loomsDir, newSlug)
+
+        // Write updated data to new filename
+        await fs.writeJson(newFilePath, data, { spaces: 2 })
+
+        // Remove old file if the name changed
+        if (fileName !== newSlug && await fs.pathExists(filePath)) {
+          await fs.remove(filePath)
+        }
+      }
+
+      // 4. Update parentLoom.worktreePath in ALL metadata files that reference old paths
+      // Re-scan because we just renamed files
+      const updatedFiles = await fs.readdir(loomsDir)
+      const updatedJsonFiles = updatedFiles.filter(f => f.endsWith('.json'))
+
+      for (const fileName of updatedJsonFiles) {
+        const filePath = path.join(loomsDir, fileName)
+        try {
+          const data = await fs.readJson(filePath)
+          const parentWorktreePath = data.parentLoom?.worktreePath as string | undefined
+          if (parentWorktreePath?.includes(oldPathMarker)) {
+            const iloomIdx = parentWorktreePath.indexOf(path.join('.iloom', 'worktrees'))
+            if (iloomIdx > 0) {
+              const parentProjectPath = parentWorktreePath.substring(0, iloomIdx - 1)
+              const parentWorktreeName = path.basename(parentWorktreePath)
+              data.parentLoom.worktreePath = path.join(
+                path.dirname(parentProjectPath),
+                `${path.basename(parentProjectPath)}-worktrees`,
+                parentWorktreeName
+              )
+              await fs.writeJson(filePath, data, { spaces: 2 })
+            }
+          }
+        } catch (error) {
+          logger.debug(`Failed to update parentLoom in ${fileName}: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+
+      // 5. Clean up: remove empty .iloom/worktrees/ directories for each project
+      for (const projectPath of projectPaths) {
+        const oldWorktreeDir = path.join(projectPath, '.iloom', 'worktrees')
+        try {
+          if (await fs.pathExists(oldWorktreeDir)) {
+            const remaining = await fs.readdir(oldWorktreeDir)
+            if (remaining.length === 0) {
+              await fs.remove(oldWorktreeDir)
+            }
+          }
+        } catch (error) {
+          logger.debug(`Failed to clean up ${oldWorktreeDir}: ${error instanceof Error ? error.message : String(error)}`)
+        }
+
+        // 6. Remove .iloom/worktrees/ entries from project .gitignore
+        const projectGitignore = path.join(projectPath, '.gitignore')
+        try {
+          if (await fs.pathExists(projectGitignore)) {
+            const content = await fs.readFile(projectGitignore, 'utf-8')
+            const lines = content.split('\n')
+            const filteredLines = lines.filter(line => {
+              const trimmed = line.trim()
+              return trimmed !== '.iloom/worktrees/' && trimmed !== '.iloom/worktrees'
+            })
+            if (filteredLines.length !== lines.length) {
+              await fs.writeFile(projectGitignore, filteredLines.join('\n'), 'utf-8')
+            }
+          }
+        } catch (error) {
+          logger.debug(`Failed to update .gitignore in ${projectPath}: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+
+      // 7. Remove **/.iloom/worktrees from global gitignore
+      await removeGlobalGitignorePattern('**/.iloom/worktrees')
     }
   },
 ]

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -430,6 +430,29 @@ describe('Git Utility Functions', () => {
       })
     })
 
+    it('should identify sibling worktree directory paths', () => {
+      const siblingWorktreePaths = [
+        '/Users/dev/project-worktrees/feature-branch',
+        '/Users/dev/my-app-worktrees/issue-42',
+        '/home/user/repo-worktrees/fix-bug',
+      ]
+
+      siblingWorktreePaths.forEach(path => {
+        expect(isWorktreePath(path)).toBe(true)
+      })
+    })
+
+    it('should identify old .iloom/worktrees/ paths', () => {
+      const oldWorktreePaths = [
+        '/Users/dev/project/.iloom/worktrees/feature-branch',
+        '/home/user/code/.iloom/worktrees/issue-42',
+      ]
+
+      oldWorktreePaths.forEach(path => {
+        expect(isWorktreePath(path)).toBe(true)
+      })
+    })
+
     it('should identify non-worktree paths correctly', () => {
       const normalPaths = [
         '/Users/dev/myproject',
@@ -445,22 +468,22 @@ describe('Git Utility Functions', () => {
   })
 
   describe('generateWorktreePath', () => {
-    it('should generate worktree paths under .iloom/worktrees/', () => {
+    it('should generate worktree paths as sibling directories', () => {
       const testCases = [
         {
           branch: 'feature-branch',
           root: '/Users/dev/project',
-          expected: '/Users/dev/project/.iloom/worktrees/feature-branch',
+          expected: '/Users/dev/project-worktrees/feature-branch',
         },
         {
           branch: 'pr/123',
           root: '/Users/dev/project',
-          expected: '/Users/dev/project/.iloom/worktrees/pr-123',
+          expected: '/Users/dev/project-worktrees/pr-123',
         },
         {
           branch: 'feature/complex-name',
           root: '/home/user/code',
-          expected: '/home/user/code/.iloom/worktrees/feature-complex-name',
+          expected: '/home/user/code-worktrees/feature-complex-name',
         },
       ]
 
@@ -474,17 +497,17 @@ describe('Git Utility Functions', () => {
         {
           branch: 'feature/with@special#characters',
           root: '/project',
-          expected: '/project/.iloom/worktrees/feature-with@special#characters',
+          expected: '/project-worktrees/feature-with@special#characters',
         },
         {
           branch: 'branch---with---dashes',
           root: '/project',
-          expected: '/project/.iloom/worktrees/branch---with---dashes',
+          expected: '/project-worktrees/branch---with---dashes',
         },
         {
           branch: '-leading-and-trailing-',
           root: '/project',
-          expected: '/project/.iloom/worktrees/-leading-and-trailing-',
+          expected: '/project-worktrees/-leading-and-trailing-',
         },
       ]
 
@@ -498,7 +521,7 @@ describe('Git Utility Functions', () => {
         isPR: true,
         prNumber: 123,
       })
-      expect(result).toBe('/project/.iloom/worktrees/feature-branch_pr_123')
+      expect(result).toBe('/project-worktrees/feature-branch_pr_123')
     })
 
     it('should not add PR suffix when isPR is false', () => {
@@ -506,24 +529,24 @@ describe('Git Utility Functions', () => {
         isPR: false,
         prNumber: 123,
       })
-      expect(result).toBe('/project/.iloom/worktrees/feature-branch')
+      expect(result).toBe('/project-worktrees/feature-branch')
     })
 
     it('should handle different root directories', () => {
       expect(generateWorktreePath('issue-123', '/Users/dev/my-awesome-project', {}))
-        .toBe('/Users/dev/my-awesome-project/.iloom/worktrees/issue-123')
+        .toBe('/Users/dev/my-awesome-project-worktrees/issue-123')
 
       expect(generateWorktreePath('issue-123', '/Users/dev/my-project'))
-        .toBe('/Users/dev/my-project/.iloom/worktrees/issue-123')
+        .toBe('/Users/dev/my-project-worktrees/issue-123')
 
       expect(generateWorktreePath('issue-123', '/Users/dev/my.project-v2'))
-        .toBe('/Users/dev/my.project-v2/.iloom/worktrees/issue-123')
+        .toBe('/Users/dev/my.project-v2-worktrees/issue-123')
 
       expect(generateWorktreePath('issue-123', '/Users/dev/p'))
-        .toBe('/Users/dev/p/.iloom/worktrees/issue-123')
+        .toBe('/Users/dev/p-worktrees/issue-123')
 
       expect(generateWorktreePath('issue-123', '/'))
-        .toBe('/.iloom/worktrees/issue-123')
+        .toBe('/-worktrees/issue-123')
     })
 
     it('should apply PR suffix correctly', () => {
@@ -531,12 +554,12 @@ describe('Git Utility Functions', () => {
         isPR: true,
         prNumber: 456,
       })
-      expect(result).toBe('/Users/dev/project/.iloom/worktrees/issue-123_pr_456')
+      expect(result).toBe('/Users/dev/project-worktrees/issue-123_pr_456')
     })
 
     it('should sanitize branch slashes in the path', () => {
       const result = generateWorktreePath('feature/add-login', '/Users/dev/project')
-      expect(result).toBe('/Users/dev/project/.iloom/worktrees/feature-add-login')
+      expect(result).toBe('/Users/dev/project-worktrees/feature-add-login')
     })
   })
 })

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -214,7 +214,7 @@ export function extractIssueNumber(branchName: string): string | null {
  */
 export function isWorktreePath(path: string): boolean {
   const worktreePatterns = [
-    /\/worktrees?\//i, // Contains /worktree/ or /worktrees/
+    /[-/]worktrees?\//i, // Contains /worktree/ or /worktrees/ or -worktrees/
     /\/workspace[-_]?\d+/i, // workspace123, workspace-123
     /\/issue[-_]?\d+/i, // issue123, issue-123
     /\/pr[-_]?\d+/i, // pr123, pr-123
@@ -242,8 +242,10 @@ export function generateWorktreePath(
     sanitized = `${sanitized}_pr_${options.prNumber}`
   }
 
-  // All worktrees go under .iloom/worktrees/ in the project root
-  return path.join(rootDir, '.iloom', 'worktrees', sanitized)
+  // Worktrees go in a sibling directory next to the project root
+  const parentDir = path.dirname(rootDir)
+  const baseName = path.basename(rootDir)
+  return path.join(parentDir, `${baseName}-worktrees`, sanitized)
 }
 
 /**

--- a/src/utils/gitignore.test.ts
+++ b/src/utils/gitignore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
-import { ensureWorktreeGitignore, resolveGlobalGitignorePath, ensureGlobalGitignorePatterns } from './gitignore.js'
+import { resolveGlobalGitignorePath, ensureGlobalGitignorePatterns, removeGlobalGitignorePattern } from './gitignore.js'
 import { executeGitCommand, GitCommandError } from './git.js'
 
 vi.mock('fs-extra', () => ({
@@ -35,105 +35,6 @@ vi.mock('./git.js', () => ({
 		}
 	},
 }))
-
-describe('ensureWorktreeGitignore', () => {
-	it('should add .iloom/worktrees/ to .gitignore when file exists but entry missing', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('node_modules/\ndist/\n')
-		vi.mocked(fs.writeFile).mockResolvedValue()
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		expect(fs.writeFile).toHaveBeenCalledWith(
-			'/path/to/project/.gitignore',
-			'node_modules/\ndist/\n\n# iloom worktree directory\n.iloom/worktrees/\n',
-			'utf-8'
-		)
-	})
-
-	it('should create .gitignore with entry when file does not exist', async () => {
-		const enoentError = Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
-		vi.mocked(fs.readFile).mockRejectedValue(enoentError)
-		vi.mocked(fs.writeFile).mockResolvedValue()
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		expect(fs.writeFile).toHaveBeenCalledWith(
-			'/path/to/project/.gitignore',
-			'\n# iloom worktree directory\n.iloom/worktrees/\n',
-			'utf-8'
-		)
-	})
-
-	it('should re-throw non-ENOENT errors from readFile', async () => {
-		const permError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
-		vi.mocked(fs.readFile).mockRejectedValue(permError)
-
-		await expect(ensureWorktreeGitignore('/path/to/project')).rejects.toThrow('EACCES: permission denied')
-		expect(fs.writeFile).not.toHaveBeenCalled()
-	})
-
-	it('should be idempotent -- not duplicate entry if already present', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('node_modules/\n\n# iloom worktree directory\n.iloom/worktrees/\n')
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		expect(fs.writeFile).not.toHaveBeenCalled()
-	})
-
-	it('should handle .gitignore with no trailing newline', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('node_modules/\ndist/')
-		vi.mocked(fs.writeFile).mockResolvedValue()
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		expect(fs.writeFile).toHaveBeenCalledWith(
-			'/path/to/project/.gitignore',
-			'node_modules/\ndist/\n\n# iloom worktree directory\n.iloom/worktrees/\n',
-			'utf-8'
-		)
-	})
-
-	it('should not modify .gitignore if entry already present without comment', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('.iloom/worktrees/\n')
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		expect(fs.writeFile).not.toHaveBeenCalled()
-	})
-
-	it('should not match partial entries like .iloom/worktrees/foo', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('.iloom/worktrees/foo\n')
-		vi.mocked(fs.writeFile).mockResolvedValue()
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		// The entry ".iloom/worktrees/foo" is not the same as ".iloom/worktrees/"
-		// so it should add the correct entry
-		expect(fs.writeFile).toHaveBeenCalled()
-	})
-
-	it('should handle empty .gitignore file', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('')
-		vi.mocked(fs.writeFile).mockResolvedValue()
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		expect(fs.writeFile).toHaveBeenCalledWith(
-			'/path/to/project/.gitignore',
-			'\n# iloom worktree directory\n.iloom/worktrees/\n',
-			'utf-8'
-		)
-	})
-
-	it('should handle entry with surrounding whitespace in .gitignore', async () => {
-		vi.mocked(fs.readFile).mockResolvedValue('  .iloom/worktrees/  \n')
-
-		await ensureWorktreeGitignore('/path/to/project')
-
-		// Should detect the entry even with surrounding whitespace (via trim)
-		expect(fs.writeFile).not.toHaveBeenCalled()
-	})
-})
 
 describe('resolveGlobalGitignorePath', () => {
 	const xdgDefault = path.join(os.homedir(), '.config', 'git', 'ignore')
@@ -209,12 +110,12 @@ describe('ensureGlobalGitignorePatterns', () => {
 		vi.mocked(fs.readFile).mockRejectedValue(enoentError)
 		vi.mocked(fs.writeFile).mockResolvedValue()
 
-		await ensureGlobalGitignorePatterns(['**/.iloom/worktrees'])
+		await ensureGlobalGitignorePatterns(['**/.iloom/test-pattern'])
 
 		expect(fs.ensureDir).toHaveBeenCalledWith('/Users/user')
 		expect(fs.writeFile).toHaveBeenCalledWith(
 			'/Users/user/.gitignore_global',
-			'\n# Added by iloom CLI\n**/.iloom/worktrees\n',
+			'\n# Added by iloom CLI\n**/.iloom/test-pattern\n',
 			'utf-8'
 		)
 	})
@@ -227,13 +128,13 @@ describe('ensureGlobalGitignorePatterns', () => {
 
 		await ensureGlobalGitignorePatterns([
 			'**/.iloom/settings.local.json',
-			'**/.iloom/worktrees',
+			'**/.iloom/test-pattern',
 			'**/.claude/agents/iloom-*',
 		])
 
 		expect(fs.writeFile).toHaveBeenCalledWith(
 			'/Users/user/.gitignore_global',
-			'**/.iloom/settings.local.json\n\n# Added by iloom CLI\n**/.iloom/worktrees\n**/.claude/agents/iloom-*\n',
+			'**/.iloom/settings.local.json\n\n# Added by iloom CLI\n**/.iloom/test-pattern\n**/.claude/agents/iloom-*\n',
 			'utf-8'
 		)
 	})
@@ -244,7 +145,7 @@ describe('ensureGlobalGitignorePatterns', () => {
 		vi.mocked(fs.readFile).mockResolvedValue('')
 		vi.mocked(fs.writeFile).mockResolvedValue()
 
-		await ensureGlobalGitignorePatterns(['**/.iloom/worktrees'])
+		await ensureGlobalGitignorePatterns(['**/.iloom/test-pattern'])
 
 		const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]?.[1] as string
 		expect(writtenContent).toContain('# Added by iloom CLI')
@@ -256,7 +157,7 @@ describe('ensureGlobalGitignorePatterns', () => {
 		const permError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
 		vi.mocked(fs.readFile).mockRejectedValue(permError)
 
-		await expect(ensureGlobalGitignorePatterns(['**/.iloom/worktrees'])).rejects.toThrow('EACCES: permission denied')
+		await expect(ensureGlobalGitignorePatterns(['**/.iloom/test-pattern'])).rejects.toThrow('EACCES: permission denied')
 		expect(fs.writeFile).not.toHaveBeenCalled()
 	})
 
@@ -266,11 +167,99 @@ describe('ensureGlobalGitignorePatterns', () => {
 		vi.mocked(fs.readFile).mockResolvedValue('*.log')
 		vi.mocked(fs.writeFile).mockResolvedValue()
 
-		await ensureGlobalGitignorePatterns(['**/.iloom/worktrees'])
+		await ensureGlobalGitignorePatterns(['**/.iloom/test-pattern'])
 
 		expect(fs.writeFile).toHaveBeenCalledWith(
 			'/Users/user/.gitignore_global',
-			'*.log\n\n# Added by iloom CLI\n**/.iloom/worktrees\n',
+			'*.log\n\n# Added by iloom CLI\n**/.iloom/test-pattern\n',
+			'utf-8'
+		)
+	})
+})
+
+describe('removeGlobalGitignorePattern', () => {
+	it('removes a pattern and its associated comment from the global gitignore', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		vi.mocked(fs.readFile).mockResolvedValue('*.log\n\n# Added by iloom CLI\n**/.iloom/worktrees\n')
+		vi.mocked(fs.writeFile).mockResolvedValue()
+
+		await removeGlobalGitignorePattern('**/.iloom/worktrees')
+
+		expect(fs.writeFile).toHaveBeenCalledWith(
+			'/Users/user/.gitignore_global',
+			'*.log\n',
+			'utf-8'
+		)
+	})
+
+	it('is a no-op when the pattern is not present', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		vi.mocked(fs.readFile).mockResolvedValue('*.log\n')
+
+		await removeGlobalGitignorePattern('**/.iloom/worktrees')
+
+		expect(fs.writeFile).not.toHaveBeenCalled()
+	})
+
+	it('is a no-op when the gitignore file does not exist', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+		vi.mocked(fs.readFile).mockRejectedValue(enoentError)
+
+		await removeGlobalGitignorePattern('**/.iloom/worktrees')
+
+		expect(fs.writeFile).not.toHaveBeenCalled()
+	})
+
+	it('re-throws non-ENOENT errors from readFile', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		const permError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+		vi.mocked(fs.readFile).mockRejectedValue(permError)
+
+		await expect(removeGlobalGitignorePattern('**/.iloom/worktrees')).rejects.toThrow('EACCES: permission denied')
+		expect(fs.writeFile).not.toHaveBeenCalled()
+	})
+
+	it('removes only the pattern line when no associated comment exists', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		vi.mocked(fs.readFile).mockResolvedValue('*.log\n**/.iloom/worktrees\n*.tmp\n')
+		vi.mocked(fs.writeFile).mockResolvedValue()
+
+		await removeGlobalGitignorePattern('**/.iloom/worktrees')
+
+		expect(fs.writeFile).toHaveBeenCalledWith(
+			'/Users/user/.gitignore_global',
+			'*.log\n*.tmp\n',
+			'utf-8'
+		)
+	})
+
+	it('preserves comment when other patterns follow it', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		vi.mocked(fs.readFile).mockResolvedValue(
+			'*.log\n\n# Added by iloom CLI\n**/.iloom/worktrees\n**/.iloom/settings.local.json\n'
+		)
+		vi.mocked(fs.writeFile).mockResolvedValue()
+
+		await removeGlobalGitignorePattern('**/.iloom/worktrees')
+
+		expect(fs.writeFile).toHaveBeenCalledWith(
+			'/Users/user/.gitignore_global',
+			'*.log\n\n# Added by iloom CLI\n**/.iloom/settings.local.json\n',
+			'utf-8'
+		)
+	})
+
+	it('handles pattern with surrounding whitespace in the file', async () => {
+		vi.mocked(executeGitCommand).mockResolvedValue('/Users/user/.gitignore_global\n')
+		vi.mocked(fs.readFile).mockResolvedValue('*.log\n  **/.iloom/worktrees  \n*.tmp\n')
+		vi.mocked(fs.writeFile).mockResolvedValue()
+
+		await removeGlobalGitignorePattern('**/.iloom/worktrees')
+
+		expect(fs.writeFile).toHaveBeenCalledWith(
+			'/Users/user/.gitignore_global',
+			'*.log\n*.tmp\n',
 			'utf-8'
 		)
 	})

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -4,40 +4,6 @@ import os from 'os'
 import { getLogger } from './logger-context.js'
 import { executeGitCommand, GitCommandError } from './git.js'
 
-const WORKTREE_GITIGNORE_ENTRY = '.iloom/worktrees/'
-
-/**
- * Ensure .iloom/worktrees/ is in the project's .gitignore
- * Idempotent: safe to call multiple times
- * Creates .gitignore if it doesn't exist
- */
-export async function ensureWorktreeGitignore(projectRoot: string): Promise<void> {
-	const gitignorePath = path.join(projectRoot, '.gitignore')
-
-	let content = ''
-	try {
-		content = await fs.readFile(gitignorePath, 'utf-8')
-	} catch (error: unknown) {
-		if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
-			// File doesn't exist -- will create
-		} else {
-			throw error
-		}
-	}
-
-	// Check if entry already exists (line-by-line to avoid partial matches)
-	const lines = content.split('\n')
-	if (lines.some(line => line.trim() === WORKTREE_GITIGNORE_ENTRY)) {
-		return
-	}
-
-	// Append entry with a section comment
-	const separator = content.endsWith('\n') || content === '' ? '' : '\n'
-	const newContent = content + separator + '\n# iloom worktree directory\n' + WORKTREE_GITIGNORE_ENTRY + '\n'
-	await fs.writeFile(gitignorePath, newContent, 'utf-8')
-	getLogger().debug(`Added ${WORKTREE_GITIGNORE_ENTRY} to .gitignore`)
-}
-
 /**
  * Resolve the absolute path to the global gitignore file.
  *
@@ -112,4 +78,71 @@ export async function ensureGlobalGitignorePatterns(patterns: string[]): Promise
 	const separator = content.endsWith('\n') || content === '' ? '' : '\n'
 	const newContent = content + separator + '\n# Added by iloom CLI\n' + missingPatterns.join('\n') + '\n'
 	await fs.writeFile(resolvedPath, newContent, 'utf-8')
+}
+
+/**
+ * Remove a specific pattern from the global gitignore file.
+ *
+ * - Resolves the correct global gitignore path via `resolveGlobalGitignorePath()`
+ * - Removes the line matching the pattern exactly (after trimming)
+ * - Also removes the "# Added by iloom CLI" comment line immediately before it,
+ *   if that comment is only associated with the removed pattern
+ * - No-op if the file doesn't exist or the pattern is not present
+ */
+export async function removeGlobalGitignorePattern(pattern: string): Promise<void> {
+	const resolvedPath = await resolveGlobalGitignorePath()
+
+	let content: string
+	try {
+		content = await fs.readFile(resolvedPath, 'utf-8')
+	} catch (error: unknown) {
+		if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return // File doesn't exist - nothing to remove
+		}
+		throw error
+	}
+
+	const lines = content.split('\n')
+	const patternIndex = lines.findIndex(line => line.trim() === pattern)
+	if (patternIndex === -1) {
+		return // Pattern not present
+	}
+
+	// Remove the pattern line
+	const indicesToRemove = new Set<number>([patternIndex])
+
+	// Check if the line immediately before is the "# Added by iloom CLI" comment
+	// and if removing the pattern would leave that comment orphaned (i.e., the comment
+	// is not followed by any other non-empty pattern lines besides the one being removed)
+	const prevLine = patternIndex > 0 ? lines[patternIndex - 1] : undefined
+	if (prevLine !== undefined && prevLine.trim() === '# Added by iloom CLI') {
+		const commentIndex = patternIndex - 1
+		// Check if any other non-empty, non-comment lines follow the comment
+		// (besides the line we're removing)
+		let hasOtherPatterns = false
+		for (let i = commentIndex + 1; i < lines.length; i++) {
+			if (indicesToRemove.has(i)) continue
+			const line = lines[i]
+			if (line === undefined) break
+			const trimmed = line.trim()
+			if (trimmed === '' || trimmed.startsWith('#')) break // End of this block
+			hasOtherPatterns = true
+			break
+		}
+		if (!hasOtherPatterns) {
+			indicesToRemove.add(commentIndex)
+			// Also remove the blank line before the comment if it exists
+			const lineBeforeComment = commentIndex > 0 ? lines[commentIndex - 1] : undefined
+			if (lineBeforeComment !== undefined && lineBeforeComment.trim() === '') {
+				indicesToRemove.add(commentIndex - 1)
+			}
+		}
+	}
+
+	const newLines = lines.filter((_, i) => !indicesToRemove.has(i))
+	const newContent = newLines.join('\n')
+
+	if (newContent !== content) {
+		await fs.writeFile(resolvedPath, newContent, 'utf-8')
+	}
 }


### PR DESCRIPTION
Fixes #807

## Move worktrees back to sibling directories (outside project tree)

## Problem

PR #779 moved worktrees from sibling directories (`../myrepo-worktrees/`) into `.iloom/worktrees/` inside the project root. This causes tool interference — vitest, eslint, and other tools walk the project directory tree and pick up worktree files, tripling test runs, lint passes, etc.

Since iloom is technology-agnostic and can't configure every possible tool to exclude its worktrees, they need to move outside the project tree.

## Solution

Revert the worktree location to the pre-#779 sibling directory approach. This places worktrees next to the project directory (e.g., `../myrepo-worktrees/feat-issue-42/`), which:

1. **Fixes tool interference** — worktrees are outside the project tree, so no tools will scan them
2. **Is discoverable** — users can browse the filesystem and find worktrees right next to their project
3. **Requires migration** — existing worktrees in `.iloom/worktrees/` need to be moved via `git worktree move`

## Key Files

| File | Relevance |
|------|-----------|
| `src/utils/git.ts` | `generateWorktreePath()` — path generation to change |
| `src/lib/GitWorktreeManager.ts` | Wrapper around path generation |
| `src/lib/LoomManager.ts` | `createWorktreeOnly()` — calls path generation |
| `src/lib/SwarmSetupService.ts` | Child worktree creation |
| `src/commands/ignite.ts` | Re-spin child worktree path |
| `src/migrations/index.ts` | Migration from `.iloom/worktrees/` to sibling directory |

## Notes

- The Claude trust pre-acceptance (#804) is already handled — worktrees at any location will get trust entries written to `~/.claude.json`
- The `.iloom/worktrees/` location was shipped in the current release, so a migration is needed
- Git tracks worktrees via its internal registry (`.git/worktrees/`), so `git worktree move` handles relocation cleanly

---
*This PR was created automatically by iloom.*