### PR TITLE
E2BIG when launching Claude on Linux — --agents JSON exceeds 128KB per-argument kernel limit

### DIFF
--- a/src/lib/AgentManager.test.ts
+++ b/src/lib/AgentManager.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { AgentManager, type AgentConfigs } from './AgentManager.js'
 import { readFile } from 'fs/promises'
 import fg from 'fast-glob'
+import fs from 'fs-extra'
+import path from 'path'
 
 vi.mock('fs/promises')
 vi.mock('fast-glob')
+vi.mock('fs-extra')
 vi.mock('../utils/logger.js', () => ({
 	logger: {
 		debug: vi.fn(),
@@ -980,6 +983,169 @@ Prompt`
 			// loadAgents without templateVariables should not throw
 			const result = await manager.loadAgents(settings as never)
 			expect(result['test-agent']).toBeDefined()
+		})
+	})
+
+	describe('renderAgentsToDisk', () => {
+		const targetDir = '/workspace/.claude/agents'
+
+		beforeEach(() => {
+			vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+			vi.mocked(fs.remove).mockResolvedValue(undefined)
+			vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+			// Default: no existing files to clean
+			vi.mocked(fg).mockResolvedValue([])
+		})
+
+		it('should write agent files with YAML frontmatter to target directory', async () => {
+			const agents: AgentConfigs = {
+				'iloom-issue-analyzer': {
+					description: 'Analyzer agent',
+					prompt: 'You are an analyzer',
+					tools: ['Read', 'Grep'],
+					model: 'sonnet',
+					color: 'pink',
+				},
+			}
+
+			await manager.renderAgentsToDisk(agents, targetDir)
+
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				path.join(targetDir, 'iloom-issue-analyzer.md'),
+				[
+					'---',
+					'name: iloom-issue-analyzer',
+					'description: Analyzer agent',
+					'tools: Read, Grep',
+					'model: sonnet',
+					'color: pink',
+					'---',
+					'',
+					'You are an analyzer',
+					'',
+				].join('\n'),
+				'utf-8',
+			)
+		})
+
+		it('should handle agents without tools field (tools omitted from frontmatter)', async () => {
+			const agents: AgentConfigs = {
+				'iloom-no-tools': {
+					description: 'No tools agent',
+					prompt: 'Do stuff',
+					model: 'opus',
+				},
+			}
+
+			await manager.renderAgentsToDisk(agents, targetDir)
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string
+			expect(writtenContent).not.toContain('tools:')
+			expect(writtenContent).toContain('name: iloom-no-tools')
+			expect(writtenContent).toContain('model: opus')
+		})
+
+		it('should handle agents without color field (color omitted from frontmatter)', async () => {
+			const agents: AgentConfigs = {
+				'iloom-no-color': {
+					description: 'No color agent',
+					prompt: 'Do stuff',
+					tools: ['Read'],
+					model: 'sonnet',
+				},
+			}
+
+			await manager.renderAgentsToDisk(agents, targetDir)
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string
+			expect(writtenContent).not.toContain('color:')
+		})
+
+		it('should create target directory if it does not exist', async () => {
+			const agents: AgentConfigs = {
+				'iloom-test': {
+					description: 'Test',
+					prompt: 'Test prompt',
+					model: 'sonnet',
+				},
+			}
+
+			await manager.renderAgentsToDisk(agents, targetDir)
+
+			expect(fs.ensureDir).toHaveBeenCalledWith(targetDir)
+		})
+
+		it('should clean existing iloom-* agent files before writing', async () => {
+			// Simulate existing stale files
+			vi.mocked(fg).mockResolvedValueOnce(['iloom-old-agent.md', 'iloom-stale.md'])
+
+			const agents: AgentConfigs = {
+				'iloom-new-agent': {
+					description: 'New',
+					prompt: 'New prompt',
+					model: 'sonnet',
+				},
+			}
+
+			await manager.renderAgentsToDisk(agents, targetDir)
+
+			// Verify old files were removed
+			expect(fs.remove).toHaveBeenCalledWith(path.join(targetDir, 'iloom-old-agent.md'))
+			expect(fs.remove).toHaveBeenCalledWith(path.join(targetDir, 'iloom-stale.md'))
+
+			// Verify new file was written
+			expect(fs.writeFile).toHaveBeenCalledTimes(1)
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				path.join(targetDir, 'iloom-new-agent.md'),
+				expect.stringContaining('name: iloom-new-agent'),
+				'utf-8',
+			)
+		})
+
+		it('should return list of rendered filenames', async () => {
+			const agents: AgentConfigs = {
+				'iloom-issue-analyzer': {
+					description: 'Analyzer',
+					prompt: 'Analyze',
+					tools: ['Read'],
+					model: 'sonnet',
+				},
+				'iloom-issue-planner': {
+					description: 'Planner',
+					prompt: 'Plan',
+					tools: ['Write'],
+					model: 'sonnet',
+				},
+			}
+
+			const result = await manager.renderAgentsToDisk(agents, targetDir)
+
+			expect(result).toEqual(['iloom-issue-analyzer.md', 'iloom-issue-planner.md'])
+		})
+
+		it('should reconstruct tools as comma-separated string in frontmatter', async () => {
+			const agents: AgentConfigs = {
+				'iloom-tools-agent': {
+					description: 'Tools test',
+					prompt: 'Test',
+					tools: ['Read', 'Write', 'Edit'],
+					model: 'sonnet',
+				},
+			}
+
+			await manager.renderAgentsToDisk(agents, targetDir)
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string
+			expect(writtenContent).toContain('tools: Read, Write, Edit')
+		})
+
+		it('should handle empty agents object', async () => {
+			const agents: AgentConfigs = {}
+
+			const result = await manager.renderAgentsToDisk(agents, targetDir)
+
+			expect(result).toEqual([])
+			expect(fs.writeFile).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -66,6 +66,7 @@ export interface ClaudeCliOptions {
 	allowedTools?: string[] // Tools to allow via --allowed-tools flag
 	disallowedTools?: string[] // Tools to disallow via --disallowed-tools flag
 	agents?: Record<string, unknown> // Agent configurations for --agents flag
+	pluginDir?: string // Path to plugin directory for --plugin-dir flag
 	oneShot?: import('../types/index.js').OneShotMode // One-shot automation mode
 	setArguments?: string[] // Raw --set arguments to forward (e.g., ['workflows.issue.startIde=false'])
 	executablePath?: string // Executable path to use for spin command (e.g., 'il', 'il-125', or '/path/to/dist/cli.js')
@@ -149,7 +150,7 @@ export async function launchClaude(
 	prompt: string,
 	options: ClaudeCliOptions = {}
 ): Promise<string | void> {
-	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, mcpConfig, allowedTools, disallowedTools, agents, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, env: extraEnv, signal } = options
+	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, env: extraEnv, signal } = options
 	const log = getLogger()
 
 	// Build command arguments
@@ -182,7 +183,7 @@ export async function launchClaude(
 
 	args.push('--add-dir', '/tmp') //TODO: Won't work on Windows
 
-	// Add --append-system-prompt flag if provided
+	// Add system prompt flag
 	if (appendSystemPrompt) {
 		args.push('--append-system-prompt', appendSystemPrompt)
 	}
@@ -207,6 +208,11 @@ export async function launchClaude(
 	// Add --agents flag if provided
 	if (agents) {
 		args.push('--agents', JSON.stringify(agents))
+	}
+
+	// Add --plugin-dir flag if provided
+	if (pluginDir) {
+		args.push('--plugin-dir', pluginDir)
 	}
 
 	// Add --session-id flag if provided (enables Claude Code session resume)

--- a/src/utils/system-prompt-writer.test.ts
+++ b/src/utils/system-prompt-writer.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest'
+import path from 'path'
+import fs from 'fs-extra'
+import { prepareSystemPromptForPlatform, createSessionStartPlugin } from './system-prompt-writer.js'
+
+vi.mock('fs-extra')
+
+const mockFs = vi.mocked(fs)
+
+describe('system-prompt-writer', () => {
+	describe('prepareSystemPromptForPlatform', () => {
+		const systemPrompt = 'You are a helpful assistant.\nFollow these instructions.'
+		const workspacePath = '/home/user/project'
+
+		it('should return inline appendSystemPrompt on darwin', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'darwin')
+
+			expect(result).toEqual({ appendSystemPrompt: systemPrompt })
+			expect(mockFs.ensureDir).not.toHaveBeenCalled()
+			expect(mockFs.writeFile).not.toHaveBeenCalled()
+		})
+
+		it('should return inline appendSystemPrompt on linux', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'linux')
+
+			expect(result).toEqual({ appendSystemPrompt: systemPrompt })
+			expect(mockFs.ensureDir).not.toHaveBeenCalled()
+			expect(mockFs.writeFile).not.toHaveBeenCalled()
+		})
+
+		it('should write prompt file and return plugin config on win32', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'win32')
+
+			const claudeDir = path.join(workspacePath, '.claude')
+			const promptFilePath = path.join(claudeDir, 'iloom-system-prompt.md')
+			const pluginDir = path.join(claudeDir, 'iloom-plugin')
+
+			// Should create .claude directory and write prompt file
+			expect(mockFs.ensureDir).toHaveBeenCalledWith(claudeDir)
+			expect(mockFs.writeFile).toHaveBeenCalledWith(promptFilePath, systemPrompt, 'utf-8')
+
+			// Should create plugin directory with hooks.json
+			expect(mockFs.ensureDir).toHaveBeenCalledWith(pluginDir)
+
+			// Should return plugin config with /clear override
+			expect(result).toEqual({
+				pluginDir,
+				initialPromptOverride: '/clear',
+			})
+		})
+
+		it('should not include appendSystemPrompt in win32 result', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'win32')
+
+			expect(result.appendSystemPrompt).toBeUndefined()
+		})
+
+		it('should not include pluginDir or initialPromptOverride for darwin', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'darwin')
+
+			expect(result.pluginDir).toBeUndefined()
+			expect(result.initialPromptOverride).toBeUndefined()
+		})
+
+		it('should not include pluginDir or initialPromptOverride for linux', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'linux')
+
+			expect(result.pluginDir).toBeUndefined()
+			expect(result.initialPromptOverride).toBeUndefined()
+		})
+
+		it('should treat unknown platforms like win32 (non-darwin, non-linux)', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'freebsd')
+
+			// Should fall through to Windows-style file-based approach
+			expect(result.pluginDir).toBeDefined()
+			expect(result.initialPromptOverride).toBe('/clear')
+			expect(result.appendSystemPrompt).toBeUndefined()
+		})
+
+		it('should default to process.platform when no platform argument given', async () => {
+			// On macOS (where tests run), this should return inline prompt
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath)
+
+			// process.platform is 'darwin' in test environment
+			expect(result.appendSystemPrompt).toBe(systemPrompt)
+		})
+	})
+
+	describe('createSessionStartPlugin', () => {
+		it('should write runner.js and hooks.json with node command for system prompt file', async () => {
+			const pluginDir = '/workspace/.claude/iloom-plugin'
+			const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+
+			await createSessionStartPlugin(pluginDir, promptFilePath)
+
+			// Should create plugin directory
+			expect(mockFs.ensureDir).toHaveBeenCalledWith(pluginDir)
+
+			// Should write runner.js with JSON-safe embedded path
+			const runnerCall = mockFs.writeFile.mock.calls.find(
+				(call) => typeof call[0] === 'string' && call[0].endsWith('runner.js'),
+			)
+			expect(runnerCall).toBeDefined()
+			const runnerContent = runnerCall![1] as string
+			expect(runnerContent).toBe(
+				`process.stdout.write(require('fs').readFileSync(${JSON.stringify(promptFilePath)}, 'utf-8'));`
+			)
+
+			// Should write hooks.json that invokes runner.js
+			const hooksCall = mockFs.writeFile.mock.calls.find(
+				(call) => typeof call[0] === 'string' && call[0].endsWith('hooks.json'),
+			)
+			expect(hooksCall).toBeDefined()
+			const writtenJson = JSON.parse(hooksCall![1] as string)
+
+			const runnerPath = path.join(pluginDir, 'runner.js').replace(/\\/g, '/')
+			expect(writtenJson).toEqual({
+				hooks: {
+					SessionStart: [
+						{
+							matcher: '*',
+							hooks: [
+								{
+									type: 'command',
+									command: `node "${runnerPath}"`,
+								},
+							],
+						},
+					],
+				},
+			})
+		})
+
+		it('should normalize Windows backslashes in runner.js path used by hooks.json', async () => {
+			const pluginDir = 'C:/Users/dev/.claude/iloom-plugin'
+			const promptFilePath = 'C:\\Users\\dev\\.claude\\iloom-system-prompt.md'
+
+			await createSessionStartPlugin(pluginDir, promptFilePath)
+
+			// runner.js should embed the path via JSON.stringify (handles backslashes safely)
+			const runnerCall = mockFs.writeFile.mock.calls.find(
+				(call) => typeof call[0] === 'string' && call[0].endsWith('runner.js'),
+			)
+			expect(runnerCall).toBeDefined()
+			const runnerContent = runnerCall![1] as string
+			// JSON.stringify preserves the backslashes as escaped sequences
+			expect(runnerContent).toBe(
+				`process.stdout.write(require('fs').readFileSync(${JSON.stringify(promptFilePath)}, 'utf-8'));`
+			)
+
+			// hooks.json command should reference runner.js with forward slashes
+			const hooksCall = mockFs.writeFile.mock.calls.find(
+				(call) => typeof call[0] === 'string' && call[0].endsWith('hooks.json'),
+			)
+			expect(hooksCall).toBeDefined()
+			const writtenJson = JSON.parse(hooksCall![1] as string)
+			const command = writtenJson.hooks.SessionStart[0].hooks[0].command
+			expect(command).not.toContain('\\')
+			expect(command).toContain('runner.js')
+		})
+
+		it('should create plugin directory structure with runner.js and hooks.json', async () => {
+			const pluginDir = '/workspace/.claude/iloom-plugin'
+			const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+
+			await createSessionStartPlugin(pluginDir, promptFilePath)
+
+			expect(mockFs.ensureDir).toHaveBeenCalledWith(pluginDir)
+			// Should write both runner.js and hooks.json
+			expect(mockFs.writeFile).toHaveBeenCalledTimes(2)
+		})
+
+		it('should use runner.js instead of node -e or cat for cross-platform safety', async () => {
+			const pluginDir = '/workspace/.claude/iloom-plugin'
+			const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+
+			await createSessionStartPlugin(pluginDir, promptFilePath)
+
+			const hooksCall = mockFs.writeFile.mock.calls.find(
+				(call) => typeof call[0] === 'string' && call[0].endsWith('hooks.json'),
+			)
+			const writtenJson = JSON.parse(hooksCall![1] as string)
+			const command = writtenJson.hooks.SessionStart[0].hooks[0].command
+
+			// Should use runner.js file, not inline node -e or cat
+			expect(command).toMatch(/^node ".*runner\.js"$/)
+			expect(command).not.toContain('-e')
+			expect(command).not.toMatch(/^cat /)
+		})
+	})
+})

--- a/src/utils/system-prompt-writer.ts
+++ b/src/utils/system-prompt-writer.ts
@@ -1,0 +1,95 @@
+import path from 'path'
+import fs from 'fs-extra'
+
+/**
+ * Result of preparing the system prompt for a specific platform.
+ * Exactly one of these strategies will be populated.
+ */
+export interface SystemPromptConfig {
+	/** Inline system prompt (macOS + Linux) */
+	appendSystemPrompt?: string
+	/** Plugin directory for --plugin-dir (Windows) */
+	pluginDir?: string
+	/** Override the initial user prompt (Windows: '/clear' to trigger SessionStart) */
+	initialPromptOverride?: string
+}
+
+/**
+ * Prepare the system prompt for the current platform.
+ *
+ * - darwin: inline via --append-system-prompt (unchanged)
+ * - linux: inline via --append-system-prompt (80KB < 128KB limit)
+ * - win32: write to file, create SessionStart plugin, pass /clear
+ */
+export async function prepareSystemPromptForPlatform(
+	systemPrompt: string,
+	workspacePath: string,
+	platform: string = process.platform,
+): Promise<SystemPromptConfig> {
+	if (platform === 'darwin' || platform === 'linux') {
+		// macOS and Linux: inline system prompt
+		return { appendSystemPrompt: systemPrompt }
+	}
+
+	// Windows: write system prompt to file, create SessionStart hook plugin
+	const claudeDir = path.join(workspacePath, '.claude')
+	const promptFilePath = path.join(claudeDir, 'iloom-system-prompt.md')
+	const pluginDir = path.join(claudeDir, 'iloom-plugin')
+
+	await fs.ensureDir(claudeDir)
+	await fs.writeFile(promptFilePath, systemPrompt, 'utf-8')
+
+	// Create plugin directory with SessionStart hook
+	await createSessionStartPlugin(pluginDir, promptFilePath)
+
+	return {
+		pluginDir,
+		initialPromptOverride: '/clear',
+	}
+}
+
+/**
+ * Create a SessionStart hook plugin that injects the system prompt file content.
+ *
+ * Writes a small runner.js script that reads and outputs the prompt file,
+ * since `cat` is not available natively on Windows and Node.js is guaranteed
+ * to be present (Claude Code requires it).
+ *
+ * Uses a runner file instead of `node -e` to avoid command injection when
+ * the workspace path contains quotes or special characters.
+ */
+export async function createSessionStartPlugin(
+	pluginDir: string,
+	promptFilePath: string,
+): Promise<void> {
+	await fs.ensureDir(pluginDir)
+
+	// Write a small runner script that safely embeds the file path via JSON.stringify
+	const runnerScript = `process.stdout.write(require('fs').readFileSync(${JSON.stringify(promptFilePath)}, 'utf-8'));`
+	await fs.writeFile(path.join(pluginDir, 'runner.js'), runnerScript, 'utf-8')
+
+	// Use forward slashes in the hooks command for cross-platform portability
+	const portableRunnerPath = path.join(pluginDir, 'runner.js').replace(/\\/g, '/')
+
+	const hooksConfig = {
+		hooks: {
+			SessionStart: [
+				{
+					matcher: '*',
+					hooks: [
+						{
+							type: 'command' as const,
+							command: `node "${portableRunnerPath}"`,
+						},
+					],
+				},
+			],
+		},
+	}
+
+	await fs.writeFile(
+		path.join(pluginDir, 'hooks.json'),
+		JSON.stringify(hooksConfig, null, 2),
+		'utf-8',
+	)
+}


### PR DESCRIPTION
Fixes #797

## E2BIG when launching Claude on Linux — --agents JSON exceeds 128KB per-argument kernel limit

## Description

`il spin` fails with `spawn E2BIG` on Linux when launching Claude because the total command-line arguments to `claude` exceed the kernel's `ARG_MAX` limit (2MB on Linux).

The `launchClaude()` function in `src/utils/claude.ts` passes the system prompt, MCP configs, agents JSON, and allowed tools list as CLI arguments via `--append-system-prompt`, `--mcp-config`, `--agents`, and `--allowed-tools`. When the system prompt is large (which is common with iloom's template system), the combined argument + environment size exceeds `execve()`'s limit.

## Reproduction

1. Set up a project with iloom on Linux
2. Run `il start <issue-number>` or `il spin` from a worktree
3. Observe `spawn E2BIG` error when Claude is launched

```
❌ Failed to spin up loom: Claude CLI error: Command failed with E2BIG: claude --model opus --permission-mode bypassPermissions --add-dir /path/to/worktree --add-dir /tmp --append-system-prompt <massive system prompt>...
```

This reproduces regardless of terminal backend (tested with tmux and direct invocation).

## Root Cause

Linux `execve()` enforces `ARG_MAX` (typically 2MB) as the combined limit for arguments + environment. The system prompt alone can be very large, and combined with MCP configs, agents JSON, and tool lists, the total easily exceeds this limit.

On macOS, `ARG_MAX` is 1MB but the effective limit is `stack_size/4` which is typically much larger (~16MB), so this issue may not manifest there.

## Possible Solutions

1. **Write system prompt to a temp file**: Use `--append-system-prompt-file <path>` (if Claude CLI supports it) instead of inline
2. **Pass large args via stdin**: Pipe the configuration to Claude as JSON on stdin instead of CLI args
3. **Use environment variables**: Store the system prompt in an env var (though this counts toward the same limit)
4. **Write a wrapper script**: Generate a temp script with the full command and execute that

## Environment

- Linux 6.8.0-90-generic (Ubuntu)
- iloom-cli v0.10.2
- Node.js v22.12.0
- `ARG_MAX`: 2097152

## Related

- PR #796 (Linux terminal backend support) — this issue was discovered while testing Linux terminal backends
- Issue #795 (Linux support tracking)

---
*This PR was created automatically by iloom.*