### PR TITLE
fix(prompts): add anti-confabulation rules for cross-component values

### DIFF
--- a/templates/agents/iloom-issue-analyze-and-plan.md
+++ b/templates/agents/iloom-issue-analyze-and-plan.md
@@ -49,6 +49,9 @@ The recap panel helps users stay oriented without reading all your output. Captu
 **During planning, log:**
 - **decision**: Significant choices - "Using WebSocket instead of polling for real-time updates"
 - **assumption**: Bets you're making - "Assuming no backwards compat needed"
+  - **CRITICAL**: When your plan references a specific value (threshold, score range, enum, format) defined in another component:
+    - If verified: call `recap.add_entry({ type: 'insight', content: '[value] for [purpose] confirmed at [file:line]' })`
+    - If NOT verified: describe the intent instead of the value, and call `recap.add_entry({ type: 'assumption', content: 'Could not verify [value] for [purpose] — described intent instead of specific value' })`
 
 **Never log** workflow status, complexity classifications, or phase information.
 
@@ -227,6 +230,11 @@ With this analysis, you will:
 - [ ] Dependencies: What uses this? What does it use?
 - [ ] Similar patterns: Grep for similar implementations
 - [ ] Historical: Why is the code this way? (git blame if unclear)
+
+**4. Integration Contracts (if plan references other components)**
+- [ ] List every specific value (score ranges, enums, formats, thresholds) your plan references from another component
+- [ ] For each: verify the source with a file:line citation
+- [ ] If you cannot find the source: do NOT include the value — describe the intent instead and log a recap assumption (see Recap section)
 
 **Output**: Document findings briefly in Section 2. One sentence per finding. File:line references required.
 
@@ -689,6 +697,7 @@ When including code, configuration, or examples:
 10. **Section 1 Scannable**: <5 minutes to read - ruthlessly prioritize
 11. **Section 2 Concise**: Brief, actionable, no "AI slop"
 12. **One-Sentence Rule**: Apply throughout Section 2 for descriptions and risks
+13. **No Cross-Component Fabrication**: When your plan includes a specific value (score range, threshold, enum, format) defined in another component's source, you MUST look it up and cite file:line. If you cannot find it, do NOT include the value — describe the intent instead (e.g., "use the reviewer's critical category" not "95-100") and log a recap assumption. Writing a plausible-sounding value from memory is confabulation — treat it as a hard error equivalent to citing a nonexistent file.
 
 ## Quality Assurance
 
@@ -715,6 +724,7 @@ Before submitting your combined analysis and plan, verify (DO NOT print this che
 - No "AI slop": No time estimates, rollback plans, manual testing checklists, or redundant sections
 - One-sentence descriptions used throughout Section 2
 - **FOR CROSS-CUTTING CHANGES**: Call chain is documented, ALL interfaces in chain are identified, cross-cutting impact is noted for each file
+- **FOR CROSS-COMPONENT VALUES**: Scan plan for specific values (scores, thresholds, enums) sourced from other components. Each must have a file:line citation. Any value without a citation must be replaced with intent-based language (not a fabricated number) and have a corresponding `recap.add_entry({ type: 'assumption' })` call.
 
 ## Error Handling
 

--- a/templates/agents/iloom-issue-analyzer.md
+++ b/templates/agents/iloom-issue-analyzer.md
@@ -48,6 +48,9 @@ The recap panel helps users stay oriented without reading all your output. Captu
 **Log these:**
 - **insight**: Technical discoveries - "Auth module depends on session middleware being initialized first"
 - **risk**: Things that could go wrong - "Removing this function breaks the CLI's --verbose flag"
+- **assumption / insight**: When your analysis references a specific value (threshold, score range, enum, format) from another component:
+  - If verified: call `recap.add_entry({ type: 'insight', content: '[value] for [purpose] confirmed at [file:line]' })`
+  - If NOT verified: describe the intent instead of the value, and call `recap.add_entry({ type: 'assumption', content: 'Could not verify [value] — described intent instead' })`
 
 **Never log** workflow status, complexity classifications, or what phases you skipped.
 
@@ -314,6 +317,7 @@ Use domain-specific MCP tools when available (Figma MCP, Database MCPs, etc.) as
 - **Do NOT stop at first result** - cross-reference for critical behaviors
 - **Do NOT include irrelevant research** - this is slop
 - **Do NOT assume an operation is necessary** just because the issue describes it — verify that the system doesn't already exhibit the desired behavior without the change
+- **Do NOT fabricate cross-component values** - when documenting a specific value (score range, threshold, enum, format) from another component, you MUST look it up and cite file:line. If you cannot find it, describe the intent (e.g., "the reviewer's critical threshold") instead of writing a plausible-sounding number from memory
 
 ## If this is a web front end issue:
 - Be mindful of different responsive breakpoints
@@ -609,6 +613,7 @@ Before submitting your analysis, verify:
 - [ ] Findings are organized logically and easy to follow
 - [ ] You have not detailed the solution - only identified relevant parts of the code, and potential risks, edge cases to be aware of
 - [ ] **FOR CROSS-CUTTING CHANGES**: Architectural Flow Analysis section is complete with call chain map, ALL affected interfaces listed, and implementation complexity noted
+- [ ] **FOR CROSS-COMPONENT VALUES**: Every specific value (scores, thresholds, enums) referenced from other components has a file:line citation. Any unverified values are described by intent, not by fabricated numbers, with a corresponding `recap.add_entry({ type: 'assumption' })` call.
 
 ## Behavioral Constraints
 
@@ -617,6 +622,7 @@ Before submitting your analysis, verify:
 3. **Precise**: Use exact file paths, line numbers, and version numbers
 4. **Neutral Tone**: Present findings objectively without blame or judgment
 6. **Integration tests**: IMPORTANT: NEVER propose or explore writing integration tests that interact with git, the filesystem or 3rd party APIs.
+7. **No Cross-Component Fabrication**: When documenting a specific value (score range, threshold, enum, format) from another component's source, you MUST look it up and cite file:line. If you cannot find it, describe the intent instead of the value and log a recap assumption. Writing a plausible-sounding value from memory is confabulation — treat it as a hard error equivalent to citing a nonexistent file.
 
 ## Error Handling
 

--- a/templates/agents/iloom-issue-planner.md
+++ b/templates/agents/iloom-issue-planner.md
@@ -45,6 +45,9 @@ The recap panel helps users stay oriented without reading all your output. Captu
 **Log these:**
 - **decision**: Significant choices - "Adding new CLI flag rather than environment variable for this config"
 - **assumption**: Bets you're making - "Assuming backwards compat not needed since atomically deployed"
+  - **CRITICAL**: When your plan references a specific value (threshold, score range, enum, format) defined in another component:
+    - If verified: call `recap.add_entry({ type: 'insight', content: '[value] for [purpose] confirmed at [file:line]' })`
+    - If NOT verified: describe the intent instead of the value, and call `recap.add_entry({ type: 'assumption', content: 'Could not verify [value] for [purpose] — described intent instead of specific value' })`
 
 **Never log** workflow status, phase information, or that a plan was created.
 
@@ -504,6 +507,7 @@ This section tells the orchestrator EXACTLY how to execute the implementation st
 - All file-by-file changes, test structures, and execution details go in Section 2 (collapsible)
 - Use pseudocode and comments in Section 2 - NOT full code implementations
 - Code blocks >5 lines must be wrapped in nested `<details>` tags within Section 2
+- **FOR CROSS-COMPONENT VALUES**: Every specific value (scores, thresholds, enums) referenced from other components must have a file:line citation. Any value without a citation must be replaced with intent-based language and have a corresponding `recap.add_entry({ type: 'assumption' })` call.
 
 
 ## HOW TO UPDATE THE USER OF YOUR PROGRESS
@@ -521,6 +525,7 @@ This section tells the orchestrator EXACTLY how to execute the implementation st
 - **NO ASSUMPTIONS** - if something is unclear, note it in the plan
 - **NO ENHANCEMENTS** - stick strictly to stated requirements
 - **QUESTION NECESSITY** - if requirements describe writing values that already match the system's built-in defaults, the write may be unnecessary. Plan for the actual need, not the literal phrasing of the issue.
+- **NO CROSS-COMPONENT FABRICATION** - when your plan includes a specific value (score range, threshold, enum, format) from another component's source, look it up and cite file:line. If you cannot find it, describe the intent (e.g., "the reviewer's critical category") instead of a plausible-sounding number. Log a recap assumption. Fabricating values is a hard error.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Adds anti-confabulation rules to `iloom-issue-analyze-and-plan`, `iloom-issue-analyzer`, and `iloom-issue-planner` agents
- When referencing specific values (score ranges, thresholds, enums) from other components, agents must look them up and cite file:line
- Verified values are logged as recap `insight` entries; unverifiable values must use intent-based language with recap `assumption` entries
- Rules are added to recap sections, research checklists, behavioral constraints, and QA checklists

## Context

The analyze-and-plan agent fabricated confidence score ranges (90-100, 80-89) when writing verdict handling logic, instead of looking up the actual values from `iloom-code-reviewer.md` (Critical: 95-100, Warning: 80-94, Suggestions: <80). It did not flag these as assumptions via `recap.add_entry`.

## Test plan

- [ ] Verify agents reference cross-component values with file:line citations in future runs
- [ ] Verify recap panel shows insight entries for verified values and assumption entries for unverified ones