### PR TITLE
fix(prompts): add anti-parroting rules for recap assumptions

### DIFF
--- a/templates/agents/iloom-issue-analyzer.md
+++ b/templates/agents/iloom-issue-analyzer.md
@@ -52,6 +52,13 @@ The recap panel helps users stay oriented without reading all your output. Captu
   - If verified: call `recap.add_entry({ type: 'insight', content: '[value] for [purpose] confirmed at [file:line]' })`
   - If NOT verified: describe the intent instead of the value, and call `recap.add_entry({ type: 'assumption', content: 'Could not verify [value] — described intent instead' })`
 
+**CRITICAL: Assumption quality rules:**
+- **NEVER restate information from the issue title or description as an assumption.** If the issue already states something, logging it as an "assumption" adds zero value.
+- Assumptions must be about genuinely **unknown or ambiguous** technical details that you're inferring from evidence.
+- Good assumption: "Assuming the dropdown uses CSS position:relative based on the described layout shift behavior" - infers something NOT stated.
+- Bad assumption: "Assuming the issue affects components X and Y" when the issue explicitly mentions both.
+- If you have no genuine assumptions to log, **don't log any**.
+
 **Never log** workflow status, complexity classifications, or what phases you skipped.
 
 ## Core Workflow

--- a/templates/agents/iloom-issue-complexity-evaluator.md
+++ b/templates/agents/iloom-issue-complexity-evaluator.md
@@ -54,7 +54,14 @@ recap.set_complexity({ complexity: 'simple', reason: 'Few files, low risk' })
 **Log these with add_entry:**
 - **insight**: Complexity factor discoveries - "Change requires coordinating updates across 5 TypeScript interfaces"
 - **risk**: Implementation concerns - "Large god-object file (2000+ LOC) will make changes error-prone"
-- **assumption**: Scope estimates - "Assuming existing test patterns can be followed without new test infrastructure"
+- **assumption**: Genuinely unknown information you're inferring that affects complexity - "Assuming existing test patterns can be followed without new test infrastructure"
+
+**CRITICAL: Assumption quality rules:**
+- **NEVER restate information from the issue title or description as an assumption.** If the issue says "search results push content down in Create New Loom and Child Loom modals", logging "Assuming the issue affects both modals" is worthless - the issue already says that.
+- Assumptions must be about genuinely **unknown or ambiguous** aspects that you are choosing to interpret a certain way for your assessment.
+- Good assumption: "Assuming the dropdown uses CSS position:relative (not absolute) based on the described layout shift behavior" - this infers something NOT stated in the issue.
+- Bad assumption: "Assuming this affects component X and component Y" when the issue explicitly mentions both X and Y.
+- If you have no genuine assumptions to log, **don't log any** - zero assumptions is better than low-quality ones.
 
 **Never log** workflow status or routine metric observations.
 

--- a/templates/agents/iloom-issue-enhancer.md
+++ b/templates/agents/iloom-issue-enhancer.md
@@ -52,7 +52,14 @@ The recap panel helps users stay oriented without reading all your output. Captu
 **Log these:**
 - **insight**: User need discoveries - "Users need to configure multiple environments per project"
 - **risk**: User impact concerns - "Current behavior causes data loss when session expires mid-edit"
-- **assumption**: Interpretations of user intent - "Assuming user wants this to work across all browsers, not just Chrome"
+- **assumption**: Interpretations of genuinely ambiguous user intent - "Assuming user wants this to work across all browsers, not just Chrome"
+
+**CRITICAL: Assumption quality rules:**
+- **NEVER restate information from the issue title or description as an assumption.** If the issue already states something, logging it as an "assumption" adds zero value.
+- Assumptions must be about genuinely **unknown or ambiguous** aspects where you're making an interpretive choice.
+- Good assumption: "Assuming the user wants keyboard navigation support in addition to mouse interaction" - the issue didn't mention this.
+- Bad assumption: "Assuming this affects the Create New Loom modal" when the issue title literally says "Create New Loom modal."
+- If you have no genuine assumptions to log, **don't log any** - zero assumptions is better than restating the obvious.
 
 **Never log** workflow status, that enhancement was completed, or quality assessment results.
 {{/unless}}


### PR DESCRIPTION
## Summary
- Adds explicit quality rules to assumption logging guidance in complexity evaluator, enhancer, and analyzer agent templates
- Prevents agents from restating issue title/description content as "assumptions" (zero-value output)
- Includes good/bad examples and explicitly permits logging zero assumptions when none are genuine

## Test plan
- [ ] Run complexity evaluation on an issue and verify assumptions are genuinely novel (not restating issue content)
- [ ] Verify enhancer and analyzer follow the same quality bar