### PR TITLE
Swarm performance: reduce overhead env vars + stream worker phase agent output to temp files

### DIFF
--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -1142,6 +1142,16 @@ export class IgniteCommand {
 		const effectiveSwarmPrompt = orchestratorPromptConfig.initialPromptOverride
 			?? `You are the swarm orchestrator for epic #${epicIssueNumber}. Begin by reading your system prompt instructions and executing the workflow.`
 
+		// Set env vars directly on process.env so they propagate to Claude Code
+		// and its child processes (execa's env option doesn't reliably pass them)
+		process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1'
+		process.env.ILOOM_SWARM = '1'
+		process.env.ENABLE_TOOL_SEARCH = 'auto:30'
+		process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING = '1'
+		process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '1'
+		process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = '1'
+		process.env.CLAUDE_CODE_EFFORT_LEVEL = 'medium'
+
 		await launchClaude(effectiveSwarmPrompt, {
 			model,
 			permissionMode: 'bypassPermissions',
@@ -1153,16 +1163,6 @@ export class IgniteCommand {
 			mcpConfig: mcpConfigs,
 			allowedTools,
 			...(agents && { agents }),
-			env: {
-				CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-				ILOOM_SWARM: '1',
-				ENABLE_TOOL_SEARCH: 'auto:30',
-				// Performance: reduce per-agent overhead
-				CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING: '1',
-				CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
-				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
-				CLAUDE_CODE_EFFORT_LEVEL: 'medium',
-			},
 		})
 
 		// Track swarm child completions and overall completion

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -383,7 +383,13 @@ Each `claude -p` call redirects its stream-json output to a temp file, then the 
 
 ```bash
 PHASE_OUTPUT_FILE=$(mktemp /tmp/iloom-phase-XXXXXX)
-env -u CLAUDECODE ENABLE_TOOL_SEARCH=auto:30 claude -p \
+env -u CLAUDECODE \
+  ENABLE_TOOL_SEARCH=auto:30 \
+  CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING=1 \
+  CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 \
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+  CLAUDE_CODE_EFFORT_LEVEL=medium \
+  claude -p \
   --system-prompt-file {{EPIC_WORKTREE_PATH}}/.claude/agents/<agent-file>.md \
   --mcp-config <path-from-.claude/iloom-swarm-mcp-config-path> \
   --model <model-from-metadata> \


### PR DESCRIPTION
Fixes #829

## Swarm performance: reduce overhead env vars + stream worker phase agent output to temp files

## Summary

Two changes to improve swarm mode performance:

### 1. Set overhead-reducing env vars for swarm sessions

Add these environment variables to the swarm orchestrator launch in `src/commands/ignite.ts` (line ~1152). They propagate down the full chain: orchestrator → workers → `claude -p` phase agents.

```typescript
env: {
    CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
    ILOOM_SWARM: '1',
    ENABLE_TOOL_SEARCH: 'auto:30',
    // Performance: reduce per-agent overhead
    CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING: '1',
    CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
    CLAUDE_CODE_EFFORT_LEVEL: 'medium',
},
```

These reduce disk I/O, disable auto memory, skip telemetry/updates, and use medium reasoning effort for swarm agents that are following explicit plans.

### 2. Swarm workers: redirect phase agent output to temp files with JSON stream

In swarm mode, workers invoke phase agents via `claude -p` through the Bash tool. The full text output of each `claude -p` call currently lands in the worker's context window via the Bash tool result.

Instead, workers should:
- Use `--output-format stream-json` (or `--json-stream`) on `claude -p` calls
- Redirect output to a temp file (e.g., `/tmp/iloom-phase-<issue>-<agent>.jsonl`)
- Only read the final result/summary from the temp file, not the full stream
- This keeps the worker's context lean — it only sees the extracted result, not the full agent narrative

This requires changes to:
- `templates/prompts/issue-prompt.txt` — the swarm mode `claude -p` command template and instructions
- Possibly the worker's output parsing logic

### Context

Research into Claude Code Agent Teams internals revealed:
- Inbox polling is hardcoded at 1000ms (lead) / 500ms (workers) — not configurable
- File checkpointing and auto memory add per-agent disk I/O overhead
- The "between turns only" message delivery is architectural — reducing turn duration helps
- Worker context accumulation from phase agent outputs is a known bottleneck

See also: `~/Downloads/GSD-Goal-Backward-Verification-System.md` for GSD's approach of passing paths instead of content to keep orchestrators lean.

---
*This PR was created automatically by iloom.*