### PR TITLE
fix(prompts): require descriptive commit messages in swarm mode

### DIFF
--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -464,7 +464,7 @@ Each `claude -p` process inherits the current working directory. Ensure you are 
 {{/if}}{{/if}}
 8. Set state to `code_review` (pass `worktreePath: "<your-worktree-path>"`), run code review via headless claude -p process (code reviewer agent)
 9. If critical/high issues found, auto-fix and optionally re-review
-10. Stage and commit all changes: `git add -A && git commit -m "fixes {{ISSUE_PREFIX}}<issue-number>"`
+10. Stage and commit all changes: `git add -A && git commit -m "feat(issue-<issue-number>): [descriptive summary of changes]"` — the commit message must summarize what was implemented (not just "fixes #NNN")
 11. Set state to `done` (pass `worktreePath: "<your-worktree-path>"`), report structured result to orchestrator
 {{else}}
 You are orchestrating a set of agents through a development process, with human review at each step. This is referred to as the "iloom workflow".
@@ -1418,7 +1418,7 @@ This is NOT optional - if the reviewer requests Claude Local Review, it must be 
 ---
 
 {{#if SWARM_MODE}}
-**MANDATORY CHECKPOINT: You MUST complete the code review before committing. After review, stage and commit all changes with `git add -A && git commit -m "fixes {{ISSUE_PREFIX}}<issue-number>"` (using your issue number from invocation arguments). Then set state to `done` and report results.**
+**MANDATORY CHECKPOINT: You MUST complete the code review before committing. After review, stage and commit all changes with `git add -A && git commit -m "feat(issue-<issue-number>): [descriptive summary]"` (using your issue number from invocation arguments). The commit message MUST describe what was implemented — do NOT use generic "fixes #NNN" messages. Then set state to `done` and report results.**
 {{else}}
 {{#if DRAFT_PR_MODE}}
 {{#if AUTO_COMMIT_PUSH}}

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -477,19 +477,21 @@ IMPORTANT: Only fix the specific issues identified in the review findings. Do NO
 
 If at least one child succeeded, create the final "Fixes" commit — but only if it doesn't already exist (idempotency).
 
-First, check whether the "Fixes" commit has already been created (this is a lightweight read, OK to do directly):
+First, check whether the final commit has already been created (this is a lightweight read, OK to do directly):
 ```bash
 cd {{EPIC_WORKTREE_PATH}}
-git log --oneline --grep="^Fixes {{ISSUE_PREFIX}}{{EPIC_ISSUE_NUMBER}}$" -1
+git log --oneline --grep="feat(epic-{{EPIC_ISSUE_NUMBER}}):" -1
 ```
 - If a matching commit is found, skip this step — the finalization commit already exists.
 
-If no "Fixes" commit exists, create it directly (no need to delegate — this is a trivial `--allow-empty` commit with no conflict risk):
+If no final commit exists, create it directly (no need to delegate — this is a trivial `--allow-empty` commit with no conflict risk). The commit message MUST have a descriptive first line summarizing what the epic accomplished, with the `Fixes` trailer in the body:
 
 ```bash
 cd {{EPIC_WORKTREE_PATH}}
 git add -A
-git commit --allow-empty -m "Fixes {{ISSUE_PREFIX}}{{EPIC_ISSUE_NUMBER}}"
+git commit --allow-empty -m "feat(epic-{{EPIC_ISSUE_NUMBER}}): [summary of what was accomplished across child issues]
+
+Fixes {{ISSUE_PREFIX}}{{EPIC_ISSUE_NUMBER}}"
 ```
 
 {{#if DRAFT_PR_MODE}}


### PR DESCRIPTION
## Summary

- Swarm workers now use `feat(issue-N): [descriptive summary]` instead of generic `fixes #NNN`
- Orchestrator final commit uses `feat(epic-N): [summary]` with `Fixes #NNN` trailer in body (GitHub still auto-closes)
- Updated idempotency check in orchestrator to match new commit format

## Test plan

- [ ] Run a swarm and verify child worker commits have descriptive messages
- [ ] Verify orchestrator final commit includes both a summary and the Fixes trailer