### PR TITLE
Claude now supports the --append-system-prompt-file flag on interactive mode!

### DIFF
--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -13,6 +13,17 @@ import { TelemetryService } from '../lib/TelemetryService.js'
 import * as languageDetector from '../utils/language-detector.js'
 import * as systemPromptWriter from '../utils/system-prompt-writer.js'
 
+// Mock system-prompt-writer to avoid filesystem writes in tests
+vi.mock('../utils/system-prompt-writer.js', async (importOriginal) => {
+	const original = await importOriginal<typeof systemPromptWriter>()
+	return {
+		...original,
+		prepareSystemPromptForPlatform: vi.fn(async (_systemPrompt: string, workspacePath: string) => ({
+			appendSystemPromptFile: path.join(workspacePath, '.claude', 'iloom-system-prompt.md'),
+		})),
+	}
+})
+
 // Mock TelemetryService
 vi.mock('../lib/TelemetryService.js', () => {
 	const mockTrack = vi.fn()
@@ -817,8 +828,8 @@ describe('IgniteCommand', () => {
 		})
 	})
 
-	describe('appendSystemPrompt usage in il ignite', () => {
-		it('should pass template content as appendSystemPrompt for issue workflows', async () => {
+	describe('appendSystemPromptFile usage in il ignite', () => {
+		it('should pass appendSystemPromptFile for issue workflows', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 
 			const originalCwd = process.cwd
@@ -830,14 +841,14 @@ describe('IgniteCommand', () => {
 			try {
 				await command.execute()
 
-				// Verify launchClaude was called with appendSystemPrompt
+				// Verify launchClaude was called with appendSystemPromptFile
 				expect(launchClaudeSpy).toHaveBeenCalledWith(
 					'Guide the user through the iloom workflow!', // User prompt
 					expect.objectContaining({
 						headless: false,
 						model: 'opus',
 						permissionMode: 'acceptEdits',
-						appendSystemPrompt: 'System instructions for issue workflow',
+						appendSystemPromptFile: '/path/to/feat/issue-82__test/.claude/iloom-system-prompt.md',
 					})
 				)
 			} finally {
@@ -846,7 +857,7 @@ describe('IgniteCommand', () => {
 			}
 		})
 
-		it('should pass template content as appendSystemPrompt for PR workflows', async () => {
+		it('should pass appendSystemPromptFile for PR workflows', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 
 			const originalCwd = process.cwd
@@ -861,7 +872,7 @@ describe('IgniteCommand', () => {
 					'Guide the user through the iloom workflow!',
 					expect.objectContaining({
 						headless: false,
-						appendSystemPrompt: 'System instructions for PR workflow',
+						appendSystemPromptFile: '/path/to/feature_pr_123/.claude/iloom-system-prompt.md',
 					})
 				)
 			} finally {
@@ -870,7 +881,7 @@ describe('IgniteCommand', () => {
 			}
 		})
 
-		it('should pass template content as appendSystemPrompt for regular workflows', async () => {
+		it('should pass appendSystemPromptFile for regular workflows', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 
 			const originalCwd = process.cwd
@@ -889,7 +900,7 @@ describe('IgniteCommand', () => {
 					'Guide the user through the iloom workflow!',
 					expect.objectContaining({
 						headless: false,
-						appendSystemPrompt: 'System instructions for regular workflow',
+						appendSystemPromptFile: '/path/to/main/.claude/iloom-system-prompt.md',
 					})
 				)
 			} finally {
@@ -1580,8 +1591,8 @@ describe('IgniteCommand', () => {
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1].agents).toBeUndefined()
 
-				// Verify system prompt is still passed inline (Linux uses appendSystemPrompt)
-				expect(launchClaudeCall[1].appendSystemPrompt).toBeDefined()
+				// Verify system prompt is passed via file
+				expect(launchClaudeCall[1].appendSystemPromptFile).toBeDefined()
 			} finally {
 				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
 				process.cwd = originalCwd
@@ -1590,17 +1601,11 @@ describe('IgniteCommand', () => {
 			}
 		})
 
-		it('should use plugin-dir and /clear prompt on Windows', async () => {
+		it('should use appendSystemPromptFile on all platforms (no plugin-dir workaround)', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 			const getRepoInfoSpy = vi.spyOn(githubUtils, 'getRepoInfo').mockResolvedValue({
 				owner: 'testowner',
 				name: 'testrepo',
-			})
-
-			// Mock prepareSystemPromptForPlatform to return Windows-style config
-			const prepareSystemPromptSpy = vi.spyOn(systemPromptWriter, 'prepareSystemPromptForPlatform').mockResolvedValue({
-				pluginDir: '/path/to/feat/issue-123__test/.claude/iloom-plugin',
-				initialPromptOverride: '/clear',
 			})
 
 			const mockAgentManager = {
@@ -1635,10 +1640,11 @@ describe('IgniteCommand', () => {
 				expect(mockAgentManager.renderAgentsToDisk).toHaveBeenCalled()
 				expect(mockAgentManager.formatForCli).not.toHaveBeenCalled()
 
-				// Verify launchClaude uses plugin-dir and /clear prompt
+				// Verify launchClaude uses appendSystemPromptFile (not plugin-dir or /clear)
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
-				expect(launchClaudeCall[0]).toBe('/clear') // initial prompt override
-				expect(launchClaudeCall[1].pluginDir).toBe('/path/to/feat/issue-123__test/.claude/iloom-plugin')
+				expect(launchClaudeCall[0]).not.toBe('/clear') // No initial prompt override
+				expect(launchClaudeCall[1].appendSystemPromptFile).toBeDefined()
+				expect(launchClaudeCall[1].pluginDir).toBeUndefined()
 				expect(launchClaudeCall[1].appendSystemPrompt).toBeUndefined()
 				expect(launchClaudeCall[1].agents).toBeUndefined()
 			} finally {
@@ -1646,7 +1652,6 @@ describe('IgniteCommand', () => {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
 				getRepoInfoSpy.mockRestore()
-				prepareSystemPromptSpy.mockRestore()
 			}
 		})
 
@@ -1693,7 +1698,7 @@ describe('IgniteCommand', () => {
 				// Verify agents ARE passed to launchClaude
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1].agents).toBeDefined()
-				expect(launchClaudeCall[1].appendSystemPrompt).toBeDefined()
+				expect(launchClaudeCall[1].appendSystemPromptFile).toBeDefined()
 			} finally {
 				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
 				process.cwd = originalCwd
@@ -2128,9 +2133,9 @@ describe('IgniteCommand', () => {
 					})
 				)
 
-				// Verify answer table instructions are included in appendSystemPrompt
-				const callOptions = launchClaudeSpy.mock.calls[0][1]
-				expect(callOptions.appendSystemPrompt).toContain('instructing them to add their own answers to any questions')
+				// Verify answer table instructions are passed to prepareSystemPromptForPlatform
+				const prepareCall = vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mock.calls[0]
+				expect(prepareCall[0]).toContain('instructing them to add their own answers to any questions')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -2158,9 +2163,9 @@ describe('IgniteCommand', () => {
 					})
 				)
 
-				// Verify answer table instructions are included in appendSystemPrompt
-				const callOptions = launchClaudeSpy.mock.calls[0][1]
-				expect(callOptions.appendSystemPrompt).toContain('instructing them to add their own answers to any questions')
+				// Verify answer table instructions are passed to prepareSystemPromptForPlatform
+				const prepareCall = vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mock.calls[0]
+				expect(prepareCall[0]).toContain('instructing them to add their own answers to any questions')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -2184,9 +2189,9 @@ describe('IgniteCommand', () => {
 				const templateCall = vi.mocked(mockTemplateManager.getPrompt).mock.calls[0]
 				expect(templateCall[1].ONE_SHOT_MODE).toBeUndefined()
 
-				// Verify answer table instructions are STILL included in appendSystemPrompt (proving unconditional behavior)
-				const callOptions = launchClaudeSpy.mock.calls[0][1]
-				expect(callOptions.appendSystemPrompt).toContain('instructing them to add their own answers to any questions')
+				// Verify answer table instructions are STILL passed to prepareSystemPromptForPlatform (proving unconditional behavior)
+				const prepareCall = vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mock.calls[0]
+				expect(prepareCall[0]).toContain('instructing them to add their own answers to any questions')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -2415,9 +2420,9 @@ describe('IgniteCommand', () => {
 			try {
 				await command.execute('default')
 
-				// Verify appendSystemPrompt contains answer table instruction text
-				const callOptions = launchClaudeSpy.mock.calls[0][1]
-				expect(callOptions.appendSystemPrompt).toContain('instructing them to add their own answers to any questions')
+				// Verify prompt content with answer table instructions was passed to prepareSystemPromptForPlatform
+				const prepareCall = vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mock.calls[0]
+				expect(prepareCall[0]).toContain('instructing them to add their own answers to any questions')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -2437,9 +2442,9 @@ describe('IgniteCommand', () => {
 			try {
 				await command.execute('noReview')
 
-				// Verify appendSystemPrompt contains answer table instruction text
-				const callOptions = launchClaudeSpy.mock.calls[0][1]
-				expect(callOptions.appendSystemPrompt).toContain('instructing them to add their own answers to any questions')
+				// Verify prompt content with answer table instructions was passed to prepareSystemPromptForPlatform
+				const prepareCall = vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mock.calls[0]
+				expect(prepareCall[0]).toContain('instructing them to add their own answers to any questions')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()
@@ -2459,9 +2464,9 @@ describe('IgniteCommand', () => {
 			try {
 				await command.execute('bypassPermissions')
 
-				// Verify appendSystemPrompt contains answer table instruction text
-				const callOptions = launchClaudeSpy.mock.calls[0][1]
-				expect(callOptions.appendSystemPrompt).toContain('instructing them to add their own answers to any questions')
+				// Verify prompt content with answer table instructions was passed to prepareSystemPromptForPlatform
+				const prepareCall = vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mock.calls[0]
+				expect(prepareCall[0]).toContain('instructing them to add their own answers to any questions')
 			} finally {
 				process.cwd = originalCwd
 				launchClaudeSpy.mockRestore()

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -515,20 +515,16 @@ export class IgniteCommand {
 
 			logger.info(isHeadless ? '✨ Launching Claude in headless mode...' : '✨ Launching Claude in current terminal...')
 
-			// Prepare system prompt based on platform
+			// Prepare system prompt by writing to file
 			const systemPromptConfig = await prepareSystemPromptForPlatform(
 				systemInstructions,
 				context.workspacePath,
 			)
 
-			// Determine the initial user prompt (Windows overrides with /clear)
-			const effectiveUserPrompt = systemPromptConfig.initialPromptOverride ?? userPrompt
-
-			// Step 5: Launch Claude with system instructions appended and user prompt
-			const claudeResult = await launchClaude(effectiveUserPrompt, {
+			// Step 5: Launch Claude with system instructions file and user prompt
+			const claudeResult = await launchClaude(userPrompt, {
 				...claudeOptions,
-				...(systemPromptConfig.appendSystemPrompt && { appendSystemPrompt: systemPromptConfig.appendSystemPrompt }),
-				...(systemPromptConfig.pluginDir && { pluginDir: systemPromptConfig.pluginDir }),
+				appendSystemPromptFile: systemPromptConfig.appendSystemPromptFile,
 				...(mcpConfig && { mcpConfig }),
 				...(allowedTools && { allowedTools }),
 				...(disallowedTools && { disallowedTools }),
@@ -1141,14 +1137,13 @@ export class IgniteCommand {
 			logger.debug(`Telemetry swarm.started tracking failed: ${error instanceof Error ? error.message : error}`)
 		}
 
-		// Prepare orchestrator prompt based on platform
+		// Prepare orchestrator prompt by writing to file
 		const orchestratorPromptConfig = await prepareSystemPromptForPlatform(
 			orchestratorPrompt,
 			epicWorktreePath,
 		)
 
-		const effectiveSwarmPrompt = orchestratorPromptConfig.initialPromptOverride
-			?? `You are the swarm orchestrator for epic #${epicIssueNumber}. Begin by reading your system prompt instructions and executing the workflow.`
+		const swarmUserPrompt = `You are the swarm orchestrator for epic #${epicIssueNumber}. Begin by reading your system prompt instructions and executing the workflow.`
 
 		// Set env vars directly on process.env so they propagate to Claude Code
 		// and its child processes (execa's env option doesn't reliably pass them)
@@ -1160,14 +1155,13 @@ export class IgniteCommand {
 		process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = '1'
 		process.env.CLAUDE_CODE_EFFORT_LEVEL = 'medium'
 
-		await launchClaude(effectiveSwarmPrompt, {
+		await launchClaude(swarmUserPrompt, {
 			model,
 			permissionMode: 'bypassPermissions',
 			addDir: epicWorktreePath,
 			headless: false,
 			...(metadata.sessionId && { sessionId: metadata.sessionId }),
-			...(orchestratorPromptConfig.appendSystemPrompt && { appendSystemPrompt: orchestratorPromptConfig.appendSystemPrompt }),
-			...(orchestratorPromptConfig.pluginDir && { pluginDir: orchestratorPromptConfig.pluginDir }),
+			appendSystemPromptFile: orchestratorPromptConfig.appendSystemPromptFile,
 			mcpConfig: mcpConfigs,
 			allowedTools,
 			...(agents && { agents }),

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -882,6 +882,106 @@ describe('claude utils', () => {
 			})
 		})
 
+		describe('appendSystemPromptFile parameter', () => {
+			it('should use --append-system-prompt-file flag when provided in interactive mode', async () => {
+				const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+				const userPrompt = 'Go!'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: '',
+					exitCode: 0,
+				})
+
+				await launchClaude(userPrompt, {
+					headless: false,
+					appendSystemPromptFile: promptFilePath,
+				})
+
+				expect(execa).toHaveBeenCalledWith(
+					'claude',
+					['--add-dir', '/tmp', '--append-system-prompt-file', promptFilePath, '--', userPrompt],
+					expect.objectContaining({
+						stdio: ['inherit', 'inherit', 'pipe'],
+						timeout: 0,
+					})
+				)
+			})
+
+			it('should use --append-system-prompt-file flag in headless mode', async () => {
+				const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+				const userPrompt = 'Execute plan'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'done',
+					exitCode: 0,
+				})
+
+				const result = await launchClaude(userPrompt, {
+					headless: true,
+					appendSystemPromptFile: promptFilePath,
+				})
+
+				expect(result).toBe('done')
+				expect(execa).toHaveBeenCalledWith(
+					'claude',
+					[
+						'-p',
+						'--output-format',
+						'stream-json',
+						'--verbose',
+						'--add-dir', '/tmp',
+						'--append-system-prompt-file', promptFilePath,
+					],
+					expect.objectContaining({
+						input: userPrompt,
+						timeout: 0,
+					})
+				)
+			})
+
+			it('should be combinable with appendSystemPrompt (inline)', async () => {
+				const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+				const inlinePrompt = 'Additional inline instructions'
+				const userPrompt = 'Go!'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: '',
+					exitCode: 0,
+				})
+
+				await launchClaude(userPrompt, {
+					headless: false,
+					appendSystemPrompt: inlinePrompt,
+					appendSystemPromptFile: promptFilePath,
+				})
+
+				expect(execa).toHaveBeenCalledWith(
+					'claude',
+					[
+						'--add-dir', '/tmp',
+						'--append-system-prompt', inlinePrompt,
+						'--append-system-prompt-file', promptFilePath,
+						'--', userPrompt,
+					],
+					expect.any(Object)
+				)
+			})
+
+			it('should omit --append-system-prompt-file when not provided', async () => {
+				const prompt = 'Test prompt'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'output',
+					exitCode: 0,
+				})
+
+				await launchClaude(prompt, { headless: true })
+
+				const execaCall = mockExeca().mock.calls[0] as unknown as [string, string[], Record<string, unknown>]
+				expect(execaCall[1]).not.toContain('--append-system-prompt-file')
+			})
+		})
+
 		describe('mcpConfig parameter', () => {
 			it('should add --mcp-config flags for each config in array', async () => {
 				const prompt = 'Test prompt'

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -62,6 +62,7 @@ export interface ClaudeCliOptions {
 	port?: number // Optional port for terminal window export
 	timeout?: number // Timeout in milliseconds
 	appendSystemPrompt?: string // System instructions to append to system prompt
+	appendSystemPromptFile?: string // Path to file containing system instructions
 	mcpConfig?: Record<string, unknown>[] // Array of MCP server configurations
 	allowedTools?: string[] // Tools to allow via --allowed-tools flag
 	disallowedTools?: string[] // Tools to disallow via --disallowed-tools flag
@@ -150,7 +151,7 @@ export async function launchClaude(
 	prompt: string,
 	options: ClaudeCliOptions = {}
 ): Promise<string | void> {
-	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, env: extraEnv, signal } = options
+	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, env: extraEnv, signal } = options
 	const log = getLogger()
 
 	// Build command arguments
@@ -186,6 +187,11 @@ export async function launchClaude(
 	// Add system prompt flag
 	if (appendSystemPrompt) {
 		args.push('--append-system-prompt', appendSystemPrompt)
+	}
+
+	// Add system prompt file flag
+	if (appendSystemPromptFile) {
+		args.push('--append-system-prompt-file', appendSystemPromptFile)
 	}
 
 	// Add --mcp-config flags for each MCP server configuration

--- a/src/utils/system-prompt-writer.test.ts
+++ b/src/utils/system-prompt-writer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import path from 'path'
 import fs from 'fs-extra'
-import { prepareSystemPromptForPlatform, createSessionStartPlugin } from './system-prompt-writer.js'
+import { prepareSystemPromptForPlatform } from './system-prompt-writer.js'
 
 vi.mock('fs-extra')
 
@@ -12,181 +12,51 @@ describe('system-prompt-writer', () => {
 		const systemPrompt = 'You are a helpful assistant.\nFollow these instructions.'
 		const workspacePath = '/home/user/project'
 
-		it('should return inline appendSystemPrompt on darwin', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'darwin')
-
-			expect(result).toEqual({ appendSystemPrompt: systemPrompt })
-			expect(mockFs.ensureDir).not.toHaveBeenCalled()
-			expect(mockFs.writeFile).not.toHaveBeenCalled()
-		})
-
-		it('should return inline appendSystemPrompt on linux', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'linux')
-
-			expect(result).toEqual({ appendSystemPrompt: systemPrompt })
-			expect(mockFs.ensureDir).not.toHaveBeenCalled()
-			expect(mockFs.writeFile).not.toHaveBeenCalled()
-		})
-
-		it('should write prompt file and return plugin config on win32', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'win32')
+		it('should write prompt to file and return appendSystemPromptFile path', async () => {
+			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath)
 
 			const claudeDir = path.join(workspacePath, '.claude')
 			const promptFilePath = path.join(claudeDir, 'iloom-system-prompt.md')
-			const pluginDir = path.join(claudeDir, 'iloom-plugin')
 
-			// Should create .claude directory and write prompt file
+			// Should create .claude directory
 			expect(mockFs.ensureDir).toHaveBeenCalledWith(claudeDir)
+
+			// Should write prompt to file
 			expect(mockFs.writeFile).toHaveBeenCalledWith(promptFilePath, systemPrompt, 'utf-8')
 
-			// Should create plugin directory with hooks.json
-			expect(mockFs.ensureDir).toHaveBeenCalledWith(pluginDir)
-
-			// Should return plugin config with /clear override
-			expect(result).toEqual({
-				pluginDir,
-				initialPromptOverride: '/clear',
-			})
+			// Should return file path
+			expect(result).toEqual({ appendSystemPromptFile: promptFilePath })
 		})
 
-		it('should not include appendSystemPrompt in win32 result', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'win32')
-
-			expect(result.appendSystemPrompt).toBeUndefined()
-		})
-
-		it('should not include pluginDir or initialPromptOverride for darwin', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'darwin')
-
-			expect(result.pluginDir).toBeUndefined()
-			expect(result.initialPromptOverride).toBeUndefined()
-		})
-
-		it('should not include pluginDir or initialPromptOverride for linux', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'linux')
-
-			expect(result.pluginDir).toBeUndefined()
-			expect(result.initialPromptOverride).toBeUndefined()
-		})
-
-		it('should treat unknown platforms like win32 (non-darwin, non-linux)', async () => {
-			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath, 'freebsd')
-
-			// Should fall through to Windows-style file-based approach
-			expect(result.pluginDir).toBeDefined()
-			expect(result.initialPromptOverride).toBe('/clear')
-			expect(result.appendSystemPrompt).toBeUndefined()
-		})
-
-		it('should default to process.platform when no platform argument given', async () => {
-			// On macOS (where tests run), this should return inline prompt
+		it('should NOT return appendSystemPrompt, pluginDir, or initialPromptOverride', async () => {
 			const result = await prepareSystemPromptForPlatform(systemPrompt, workspacePath)
 
-			// process.platform is 'darwin' in test environment
-			expect(result.appendSystemPrompt).toBe(systemPrompt)
-		})
-	})
-
-	describe('createSessionStartPlugin', () => {
-		it('should write runner.js and hooks.json with node command for system prompt file', async () => {
-			const pluginDir = '/workspace/.claude/iloom-plugin'
-			const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
-
-			await createSessionStartPlugin(pluginDir, promptFilePath)
-
-			// Should create plugin directory
-			expect(mockFs.ensureDir).toHaveBeenCalledWith(pluginDir)
-
-			// Should write runner.js with JSON-safe embedded path
-			const runnerCall = mockFs.writeFile.mock.calls.find(
-				(call) => typeof call[0] === 'string' && call[0].endsWith('runner.js'),
-			)
-			expect(runnerCall).toBeDefined()
-			const runnerContent = runnerCall![1] as string
-			expect(runnerContent).toBe(
-				`process.stdout.write(require('fs').readFileSync(${JSON.stringify(promptFilePath)}, 'utf-8'));`
-			)
-
-			// Should write hooks.json that invokes runner.js
-			const hooksCall = mockFs.writeFile.mock.calls.find(
-				(call) => typeof call[0] === 'string' && call[0].endsWith('hooks.json'),
-			)
-			expect(hooksCall).toBeDefined()
-			const writtenJson = JSON.parse(hooksCall![1] as string)
-
-			const runnerPath = path.join(pluginDir, 'runner.js').replace(/\\/g, '/')
-			expect(writtenJson).toEqual({
-				hooks: {
-					SessionStart: [
-						{
-							matcher: '*',
-							hooks: [
-								{
-									type: 'command',
-									command: `node "${runnerPath}"`,
-								},
-							],
-						},
-					],
-				},
-			})
+			expect(result).not.toHaveProperty('appendSystemPrompt')
+			expect(result).not.toHaveProperty('pluginDir')
+			expect(result).not.toHaveProperty('initialPromptOverride')
 		})
 
-		it('should normalize Windows backslashes in runner.js path used by hooks.json', async () => {
-			const pluginDir = 'C:/Users/dev/.claude/iloom-plugin'
-			const promptFilePath = 'C:\\Users\\dev\\.claude\\iloom-system-prompt.md'
+		it('should work identically regardless of platform', async () => {
+			// The function no longer accepts a platform parameter - it always writes to file.
+			// Run it twice to confirm consistent behavior.
+			const result1 = await prepareSystemPromptForPlatform(systemPrompt, workspacePath)
+			const result2 = await prepareSystemPromptForPlatform(systemPrompt, '/other/workspace')
 
-			await createSessionStartPlugin(pluginDir, promptFilePath)
-
-			// runner.js should embed the path via JSON.stringify (handles backslashes safely)
-			const runnerCall = mockFs.writeFile.mock.calls.find(
-				(call) => typeof call[0] === 'string' && call[0].endsWith('runner.js'),
+			expect(result1.appendSystemPromptFile).toBe(
+				path.join(workspacePath, '.claude', 'iloom-system-prompt.md'),
 			)
-			expect(runnerCall).toBeDefined()
-			const runnerContent = runnerCall![1] as string
-			// JSON.stringify preserves the backslashes as escaped sequences
-			expect(runnerContent).toBe(
-				`process.stdout.write(require('fs').readFileSync(${JSON.stringify(promptFilePath)}, 'utf-8'));`
+			expect(result2.appendSystemPromptFile).toBe(
+				path.join('/other/workspace', '.claude', 'iloom-system-prompt.md'),
 			)
-
-			// hooks.json command should reference runner.js with forward slashes
-			const hooksCall = mockFs.writeFile.mock.calls.find(
-				(call) => typeof call[0] === 'string' && call[0].endsWith('hooks.json'),
-			)
-			expect(hooksCall).toBeDefined()
-			const writtenJson = JSON.parse(hooksCall![1] as string)
-			const command = writtenJson.hooks.SessionStart[0].hooks[0].command
-			expect(command).not.toContain('\\')
-			expect(command).toContain('runner.js')
 		})
 
-		it('should create plugin directory structure with runner.js and hooks.json', async () => {
-			const pluginDir = '/workspace/.claude/iloom-plugin'
-			const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
+		it('should ensure .claude directory exists before writing', async () => {
+			await prepareSystemPromptForPlatform(systemPrompt, workspacePath)
 
-			await createSessionStartPlugin(pluginDir, promptFilePath)
-
-			expect(mockFs.ensureDir).toHaveBeenCalledWith(pluginDir)
-			// Should write both runner.js and hooks.json
-			expect(mockFs.writeFile).toHaveBeenCalledTimes(2)
-		})
-
-		it('should use runner.js instead of node -e or cat for cross-platform safety', async () => {
-			const pluginDir = '/workspace/.claude/iloom-plugin'
-			const promptFilePath = '/workspace/.claude/iloom-system-prompt.md'
-
-			await createSessionStartPlugin(pluginDir, promptFilePath)
-
-			const hooksCall = mockFs.writeFile.mock.calls.find(
-				(call) => typeof call[0] === 'string' && call[0].endsWith('hooks.json'),
-			)
-			const writtenJson = JSON.parse(hooksCall![1] as string)
-			const command = writtenJson.hooks.SessionStart[0].hooks[0].command
-
-			// Should use runner.js file, not inline node -e or cat
-			expect(command).toMatch(/^node ".*runner\.js"$/)
-			expect(command).not.toContain('-e')
-			expect(command).not.toMatch(/^cat /)
+			// ensureDir should be called before writeFile
+			const ensureDirOrder = mockFs.ensureDir.mock.invocationCallOrder[0]
+			const writeFileOrder = mockFs.writeFile.mock.invocationCallOrder[0]
+			expect(ensureDirOrder).toBeLessThan(writeFileOrder!)
 		})
 	})
 })

--- a/src/utils/system-prompt-writer.ts
+++ b/src/utils/system-prompt-writer.ts
@@ -2,94 +2,32 @@ import path from 'path'
 import fs from 'fs-extra'
 
 /**
- * Result of preparing the system prompt for a specific platform.
- * Exactly one of these strategies will be populated.
+ * Result of preparing the system prompt.
+ * Always uses file-based delivery via --append-system-prompt-file.
  */
 export interface SystemPromptConfig {
-	/** Inline system prompt (macOS + Linux) */
-	appendSystemPrompt?: string
-	/** Plugin directory for --plugin-dir (Windows) */
-	pluginDir?: string
-	/** Override the initial user prompt (Windows: '/clear' to trigger SessionStart) */
-	initialPromptOverride?: string
+	/** Path to the file containing the system prompt */
+	appendSystemPromptFile: string
 }
 
 /**
- * Prepare the system prompt for the current platform.
+ * Prepare the system prompt by writing it to a file.
  *
- * - darwin: inline via --append-system-prompt (unchanged)
- * - linux: inline via --append-system-prompt (80KB < 128KB limit)
- * - win32: write to file, create SessionStart plugin, pass /clear
+ * Writes the prompt to `workspacePath/.claude/iloom-system-prompt.md`
+ * and returns the file path for use with `--append-system-prompt-file`.
+ *
+ * This works on all platforms now that Claude CLI supports
+ * `--append-system-prompt-file` in interactive mode.
  */
 export async function prepareSystemPromptForPlatform(
 	systemPrompt: string,
 	workspacePath: string,
-	platform: string = process.platform,
 ): Promise<SystemPromptConfig> {
-	if (platform === 'darwin' || platform === 'linux') {
-		// macOS and Linux: inline system prompt
-		return { appendSystemPrompt: systemPrompt }
-	}
-
-	// Windows: write system prompt to file, create SessionStart hook plugin
 	const claudeDir = path.join(workspacePath, '.claude')
 	const promptFilePath = path.join(claudeDir, 'iloom-system-prompt.md')
-	const pluginDir = path.join(claudeDir, 'iloom-plugin')
 
 	await fs.ensureDir(claudeDir)
 	await fs.writeFile(promptFilePath, systemPrompt, 'utf-8')
 
-	// Create plugin directory with SessionStart hook
-	await createSessionStartPlugin(pluginDir, promptFilePath)
-
-	return {
-		pluginDir,
-		initialPromptOverride: '/clear',
-	}
-}
-
-/**
- * Create a SessionStart hook plugin that injects the system prompt file content.
- *
- * Writes a small runner.js script that reads and outputs the prompt file,
- * since `cat` is not available natively on Windows and Node.js is guaranteed
- * to be present (Claude Code requires it).
- *
- * Uses a runner file instead of `node -e` to avoid command injection when
- * the workspace path contains quotes or special characters.
- */
-export async function createSessionStartPlugin(
-	pluginDir: string,
-	promptFilePath: string,
-): Promise<void> {
-	await fs.ensureDir(pluginDir)
-
-	// Write a small runner script that safely embeds the file path via JSON.stringify
-	const runnerScript = `process.stdout.write(require('fs').readFileSync(${JSON.stringify(promptFilePath)}, 'utf-8'));`
-	await fs.writeFile(path.join(pluginDir, 'runner.js'), runnerScript, 'utf-8')
-
-	// Use forward slashes in the hooks command for cross-platform portability
-	const portableRunnerPath = path.join(pluginDir, 'runner.js').replace(/\\/g, '/')
-
-	const hooksConfig = {
-		hooks: {
-			SessionStart: [
-				{
-					matcher: '*',
-					hooks: [
-						{
-							type: 'command' as const,
-							command: `node "${portableRunnerPath}"`,
-						},
-					],
-				},
-			],
-		},
-	}
-
-	await fs.writeFile(
-		path.join(pluginDir, 'hooks.json'),
-		JSON.stringify(hooksConfig, null, 2),
-		'utf-8',
-	)
+	return { appendSystemPromptFile: promptFilePath }
 }


### PR DESCRIPTION
Fixes #832

## Claude now supports the --append-system-prompt-file flag on interactive mode!

Which means we can save the system prompts to a temp file and use that for non-swarm mode!

---
*This PR was created automatically by iloom.*