### PR TITLE
fix(init): use sonnet as default model for init command

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -439,7 +439,7 @@ export class InitCommand {
       ]
 
       const claudeOptions = {
-        model: 'opus',
+        model: 'sonnet',
         headless: false,
         appendSystemPrompt: prompt,
         addDir: process.cwd(),


### PR DESCRIPTION
## Summary
- Switch the default model in `il init` from `opus` to `sonnet`

## Test plan
- [x] Pre-commit hooks pass (lint, compile, tests, build)
- [ ] Run `il init` and verify it uses sonnet model