### PR TITLE
chore(settings): disable plan review for planner agents

### DIFF
--- a/.iloom/settings.json
+++ b/.iloom/settings.json
@@ -11,8 +11,8 @@
   },
   "agents": {
     "iloom-issue-analyzer": { "model": "opus" },
-    "iloom-issue-planner": { "model": "opus", "review": true },
-    "iloom-issue-analyze-and-plan": { "model": "opus", "review": true },
+    "iloom-issue-planner": { "model": "opus" },
+    "iloom-issue-analyze-and-plan": { "model": "opus" },
     "iloom-issue-implementer": { "model": "opus" },
     "iloom-code-reviewer": { "providers": { "gemini": "gemini-3.1-pro-preview" } },
     "iloom-artifact-reviewer": { "enabled": true, "providers": { "gemini": "gemini-3.1-pro-preview" } }


### PR DESCRIPTION
## Summary
- Remove `"review": true` from `iloom-issue-planner` and `iloom-issue-analyze-and-plan` agent configs in `.iloom/settings.json`

## Test plan
- [x] Settings file change only, no code impact