### PR TITLE
feat: complete BitBucket VCS provider integration gaps

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -2065,6 +2065,55 @@ The following Jira settings can be configured in `.iloom/settings.json` under `i
 
 **Note:** Different Jira instances may use different issue type names. If issue creation fails with a 400 error, check your Jira project's available issue types and configure `defaultIssueType` and `defaultSubtaskType` accordingly.
 
+**Version Control (VCS) Provider Settings:**
+
+iloom supports multiple version control providers for PR operations. By default, GitHub is used via the `gh` CLI. For BitBucket Cloud, configure the following in `.iloom/settings.json`:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `versionControl.provider` | `"github"` \| `"bitbucket"` | `"github"` | VCS provider for PR operations |
+| `versionControl.bitbucket.username` | string | (required) | BitBucket username |
+| `versionControl.bitbucket.apiToken` | string | (required) | BitBucket API token (store in `settings.local.json`) |
+| `versionControl.bitbucket.workspace` | string | (auto-detected) | BitBucket workspace slug |
+| `versionControl.bitbucket.repoSlug` | string | (auto-detected) | Repository slug |
+| `versionControl.bitbucket.reviewers` | string[] | - | Usernames to add as PR reviewers |
+
+**Example Configuration:**
+
+`.iloom/settings.json`:
+```json
+{
+  "versionControl": {
+    "provider": "bitbucket",
+    "bitbucket": {
+      "username": "your-username",
+      "workspace": "your-workspace",
+      "reviewers": ["reviewer1", "reviewer2"]
+    }
+  }
+}
+```
+
+`.iloom/settings.local.json` (gitignored):
+```json
+{
+  "versionControl": {
+    "bitbucket": {
+      "apiToken": "your-api-token"
+    }
+  }
+}
+```
+
+**Supported Provider Combinations:**
+
+- GitHub Issues + GitHub VCS (default)
+- GitHub Issues + BitBucket VCS
+- Linear Issues + BitBucket VCS
+- Jira Issues + BitBucket VCS
+
+**Note:** Draft PR mode (`mergeBehavior.mode: "draft-pr"`) is GitHub-only. BitBucket does not support draft pull requests.
+
 ---
 
 ### il update

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -1178,7 +1178,7 @@ export class FinishCommand {
 					worktree.path
 				)
 
-				const prUrl = await vcsProvider.createPR(
+				const prResult = await vcsProvider.createPR(
 					worktree.branch,
 					prTitle,
 					prBody,
@@ -1186,13 +1186,15 @@ export class FinishCommand {
 					worktree.path
 				)
 
-				getLogger().success(`Pull request created: ${prUrl}`)
-				finishResult.prUrl = prUrl
+				getLogger().success(`Pull request created: ${prResult.url}`)
+				finishResult.prUrl = prResult.url
 				finishResult.operations.push({
 					type: 'pr-creation',
 					message: 'Pull request created',
 					success: true,
 				})
+
+				await this.generateSessionSummaryIfConfigured(parsed, worktree, options, prResult.number)
 			}
 
 			// Open in browser if configured

--- a/src/lib/VersionControlProvider.ts
+++ b/src/lib/VersionControlProvider.ts
@@ -21,6 +21,21 @@ export interface ExistingPR {
 }
 
 /**
+ * Represents an inline review comment on a pull request
+ */
+export interface ReviewComment {
+	id: string
+	body: string
+	path: string
+	line: number | null
+	side: string | null
+	author: { id: string; displayName: string } | null
+	createdAt: string
+	updatedAt: string | null
+	inReplyToId: string | null
+}
+
+/**
  * VersionControlProvider interface - abstraction for VCS providers
  * 
  * Design Philosophy:
@@ -43,14 +58,14 @@ export interface VersionControlProvider {
 		body: string,
 		baseBranch: string,
 		cwd?: string
-	): Promise<string>
+	): Promise<PRCreationResult>
 	createDraftPR?(
 		branchName: string,
 		title: string,
 		body: string,
 		baseBranch: string,
 		cwd?: string
-	): Promise<string>
+	): Promise<PRCreationResult>
 	markPRReadyForReview?(prNumber: number, cwd?: string): Promise<void>
 	
 	// PR metadata and state
@@ -58,8 +73,11 @@ export interface VersionControlProvider {
 	getPRUrl(prNumber: number, cwd?: string): Promise<string>
 	
 	// PR comments
-	createPRComment(prNumber: number, body: string, cwd?: string): Promise<void>
-	
+	createPRComment(prNumber: number, body: string, cwd?: string): Promise<{ id: string; url: string }>
+	updatePRComment?(prNumber: number, commentId: string, body: string, cwd?: string): Promise<{ id: string; url: string }>
+	getReviewComments?(prNumber: number, cwd?: string): Promise<ReviewComment[]>
+	createReviewComment?(prNumber: number, path: string, line: number, body: string, cwd?: string): Promise<{ id: string; url: string }>
+
 	// Remote and repository detection
 	detectRepository(cwd?: string): Promise<{ owner: string; repo: string } | null>
 	getTargetRemote(cwd?: string): Promise<string>

--- a/src/lib/providers/bitbucket/index.ts
+++ b/src/lib/providers/bitbucket/index.ts
@@ -1,3 +1,3 @@
 // BitBucket provider exports
-export { BitBucketApiClient, type BitBucketConfig, type BitBucketPullRequest, type BitBucketRepository } from './BitBucketApiClient.js'
+export { BitBucketApiClient, type BitBucketConfig, type BitBucketPullRequest, type BitBucketRepository, type BitBucketComment } from './BitBucketApiClient.js'
 export { BitBucketVCSProvider, type BitBucketVCSConfig } from './BitBucketVCSProvider.js'

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -29,7 +29,6 @@ export interface GetIssueInput {
 
 /**
  * Input schema for getting pull request details
- * Note: PRs only exist on GitHub, so this always uses GitHub provider regardless of configured issue tracker
  */
 export interface GetPRInput {
 	number: string // PR number
@@ -39,7 +38,6 @@ export interface GetPRInput {
 
 /**
  * Input schema for getting PR review comments (inline code comments)
- * Note: PRs only exist on GitHub, so this always uses GitHub provider
  */
 export interface GetReviewCommentsInput {
 	number: string // PR number
@@ -263,7 +261,6 @@ export interface IssueResult {
 
 /**
  * Output schema for pull request details
- * PRs only exist on GitHub, so this is GitHub-specific
  */
 export interface PRResult {
 	// Core fields


### PR DESCRIPTION
Fixes #861

## feat: complete BitBucket VCS provider integration gaps

## Context

PR #609 adds BitBucket VCS provider support. After merging the generic merge mode refactoring (epic #842), a gap analysis identified several places where BitBucket isn't fully wired in.

**Important correction:** An earlier analysis incorrectly claimed that some MCP PR operations (`get_pr`, `create_comment(type:pr)`) already routed through BitBucket. This was wrong — **all MCP PR operations have always been GitHub-only**. No BitBucket routing has ever existed in the MCP server.

## Current State

The MCP server (`src/mcp/issue-management-server.ts`) has these PR-related tools, all hardcoded to GitHub:

| Tool | Current Code | Line |
|------|-------------|------|
| `get_pr` | `new GitHubIssueManagementProvider()` | 262 |
| `get_review_comments` | `new GitHubIssueManagementProvider()` | 332 |
| `create_comment(type:pr)` | `providerType = 'github'` | 441 |
| `update_comment(type:pr)` | `providerType = 'github'` | 493 |

All have comments saying "PRs only exist on GitHub" which is no longer true with BitBucket support.

Additionally, `VersionControlProvider.createPR()` returns `Promise<string>` (URL only), which means `finish.ts` can never pass a PR number to `SessionSummaryService` for BitBucket PRs.

## Changes Required

### 1. Fix `createPR()` return type

**Files:** `src/lib/VersionControlProvider.ts`, `src/lib/providers/bitbucket/BitBucketVCSProvider.ts`, `src/commands/finish.ts`

- `createPR()` returns `Promise<string>` (line 46) but `PRCreationResult` interface already exists (lines 9-13) with `{ url, number, wasExisting }`
- Change `createPR()` return type to `Promise<PRCreationResult>`
- Update `BitBucketVCSProvider.createPR()` to return `{ url: pr.links.html.href, number: pr.id, wasExisting: false }`
- Update `finish.ts` to extract `prNumber` from the result
- This unblocks `SessionSummaryService` which already has VCS routing code but never gets a `prNumber` for BitBucket

### 2. Add BitBucket PR comment API methods to `BitBucketApiClient`

**File:** `src/lib/providers/bitbucket/BitBucketApiClient.ts`

Currently only has `addPRComment()` for general comments. Need:

a) `updatePRComment(workspace, repoSlug, prId, commentId, content)` 
   - PUT `/2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pull_request_id}/comments/{comment_id}`
   - Body: `{ "content": { "raw": "text" } }`
   - Confirmed supported by BitBucket Cloud REST API (verified from official swagger.json)

b) `listPRComments(workspace, repoSlug, prId)`
   - GET `/2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pull_request_id}/comments`
   - Returns comments including `inline` metadata (`from`, `to`, `path` fields)
   - Needs pagination (follow existing `getAllWorkspaceMembers` pattern)

c) `addInlinePRComment(workspace, repoSlug, prId, content, filePath, line)`
   - POST to same endpoint as `addPRComment` but with `inline: { to: line, path: filePath }` in body

### 3. Add VCS provider methods to `BitBucketVCSProvider`

**File:** `src/lib/providers/bitbucket/BitBucketVCSProvider.ts`

Add methods that delegate to `BitBucketApiClient`:
- `updatePRComment(prNumber, commentId, body, cwd?)` 
- `getReviewComments(prNumber, cwd?)`  — calls `listPRComments`, filters for comments with `inline` property
- `createReviewComment(prNumber, path, line, body, cwd?)` — calls `addInlinePRComment`

### 4. Update `VersionControlProvider` interface

**File:** `src/lib/VersionControlProvider.ts`

Add to the interface:
- `updatePRComment(prNumber: number, commentId: string, body: string, cwd?: string): Promise<{ id: string; url: string }>`
- `getReviewComments(prNumber: number, cwd?: string): Promise<ReviewComment[]>`
- `createReviewComment(prNumber: number, path: string, line: number, body: string, cwd?: string): Promise<{ id: string; url: string }>`

Define `ReviewComment` type to match what the MCP tool's output schema expects.

### 5. Route MCP PR operations through VCS provider

**File:** `src/mcp/issue-management-server.ts`

The MCP server needs to load the VCS provider at startup (like it does for issue provider) and route PR operations through it.

a) At startup: initialize a VCS provider from settings using `VCSProviderFactory`
b) `get_pr` (line 257-263): Use VCS provider's `fetchPR()` when BitBucket configured, fall back to GitHub
c) `create_comment(type:pr)` (line 438-443): Use VCS provider's `createPRComment()` when BitBucket configured
d) `update_comment(type:pr)` (line 490-495): Use VCS provider's `updatePRComment()` when BitBucket configured  
e) `get_review_comments` (line 327-334): Use VCS provider's `getReviewComments()` when BitBucket configured
f) Remove all "PRs only exist on GitHub" comments

### 6. Documentation

**File:** `docs/iloom-commands.md`

- Add VCS provider configuration section explaining `versionControl.provider` and `versionControl.bitbucket` settings
- Document supported provider combinations (e.g., Jira issues + BitBucket VCS, GitHub issues + BitBucket VCS)
- Note that Draft PR mode is GitHub-only

## Out of Scope

- Init wizard VCS provider step (document in docs instead)
- Draft PR operations for BitBucket (BitBucket doesn't support drafts)

## Must-Haves

- [ ] `createPR()` returns `PRCreationResult` (`{ url, number, wasExisting }`)
- [ ] `BitBucketApiClient` has `updatePRComment()`, `addInlinePRComment()`, `listPRComments()` methods
- [ ] `BitBucketVCSProvider` has `updatePRComment()`, `getReviewComments()`, `createReviewComment()` methods
- [ ] `VersionControlProvider` interface updated with new methods
- [ ] MCP server loads VCS provider at startup and routes all PR operations through it
- [ ] All "PRs only exist on GitHub" comments removed
- [ ] All new methods have tests
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes
- [ ] VCS provider configuration documented in `docs/iloom-commands.md`

---
*This PR was created automatically by iloom.*