### PR TITLE
Plan mode should leverage the Analyze agent's research framework

### DIFF
--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -1308,17 +1308,17 @@ describe('IgniteCommand', () => {
 				name: 'testrepo',
 			})
 
+			const agentsResult = {
+				'test-agent': {
+					description: 'Test agent',
+					prompt: 'Test prompt',
+					tools: ['Read'],
+					model: 'sonnet',
+				},
+			}
+
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
-					'test-agent': {
-						description: 'Test agent',
-						prompt: 'Test prompt',
-						tools: ['Read'],
-						model: 'sonnet',
-					},
-				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue(agentsResult),
 			}
 
 			const originalCwd = process.cwd
@@ -1336,20 +1336,12 @@ describe('IgniteCommand', () => {
 			try {
 				await commandWithAgents.execute()
 
-				// Verify agents were loaded and passed to launchClaude
-				expect(mockAgentManager.loadAgents).toHaveBeenCalled()
-				expect(mockAgentManager.formatForCli).toHaveBeenCalled()
+				// Verify loadAndPrepare was called and agents passed to launchClaude
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalled()
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('agents')
-				expect(launchClaudeCall[1].agents).toEqual({
-					'test-agent': {
-						description: 'Test agent',
-						prompt: 'Test prompt',
-						tools: ['Read'],
-						model: 'sonnet',
-					},
-				})
+				expect(launchClaudeCall[1].agents).toEqual(agentsResult)
 			} finally {
 				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
 				process.cwd = originalCwd
@@ -1366,7 +1358,7 @@ describe('IgniteCommand', () => {
 			})
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'pr-agent': {
 						description: 'PR agent',
 						prompt: 'PR prompt',
@@ -1374,8 +1366,6 @@ describe('IgniteCommand', () => {
 						model: 'sonnet',
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1392,8 +1382,7 @@ describe('IgniteCommand', () => {
 			try {
 				await commandWithAgents.execute()
 
-				expect(mockAgentManager.loadAgents).toHaveBeenCalled()
-				expect(mockAgentManager.formatForCli).toHaveBeenCalled()
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalled()
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('agents')
@@ -1409,7 +1398,7 @@ describe('IgniteCommand', () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'regular-agent': {
 						description: 'Regular agent',
 						prompt: 'Regular prompt',
@@ -1417,8 +1406,6 @@ describe('IgniteCommand', () => {
 						model: 'sonnet',
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1435,8 +1422,7 @@ describe('IgniteCommand', () => {
 			try {
 				await commandWithAgents.execute()
 
-				expect(mockAgentManager.loadAgents).toHaveBeenCalled()
-				expect(mockAgentManager.formatForCli).toHaveBeenCalled()
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalled()
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('agents')
@@ -1452,9 +1438,7 @@ describe('IgniteCommand', () => {
 			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockRejectedValue(new Error('Failed to load agents')),
-				formatForCli: vi.fn(),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockRejectedValue(new Error('Failed to load agents')),
 			}
 
 			const originalCwd = process.cwd
@@ -1470,8 +1454,7 @@ describe('IgniteCommand', () => {
 				// Should not throw - execution continues without agents
 				await commandWithAgents.execute()
 
-				expect(mockAgentManager.loadAgents).toHaveBeenCalled()
-				expect(mockAgentManager.formatForCli).not.toHaveBeenCalled()
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalled()
 
 				// Verify Claude was still launched (without agents)
 				expect(launchClaudeSpy).toHaveBeenCalled()
@@ -1492,7 +1475,7 @@ describe('IgniteCommand', () => {
 			})
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'combined-agent': {
 						description: 'Combined test agent',
 						prompt: 'Combined prompt',
@@ -1500,8 +1483,6 @@ describe('IgniteCommand', () => {
 						model: 'sonnet',
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1550,17 +1531,9 @@ describe('IgniteCommand', () => {
 				name: 'testrepo',
 			})
 
+			// On Linux, loadAndPrepare renders to disk and returns undefined
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
-					'test-agent': {
-						description: 'Test agent',
-						prompt: 'Test prompt',
-						tools: ['Read'],
-						model: 'sonnet',
-					},
-				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue(['test-agent.md']),
+				loadAndPrepare: vi.fn().mockResolvedValue(undefined),
 			}
 
 			const originalCwd = process.cwd
@@ -1578,14 +1551,15 @@ describe('IgniteCommand', () => {
 			try {
 				await commandWithAgents.execute()
 
-				// Verify renderAgentsToDisk was called instead of formatForCli
-				expect(mockAgentManager.renderAgentsToDisk).toHaveBeenCalledWith(
-					expect.objectContaining({ 'test-agent': expect.any(Object) }),
+				// Verify loadAndPrepare was called with correct args including targetDir
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalledWith(
+					expect.anything(), // settings
+					expect.anything(), // template variables
+					['*.md', '!iloom-framework-detector.md'],
 					'/path/to/feat/issue-123__test/.claude/agents',
 				)
-				expect(mockAgentManager.formatForCli).not.toHaveBeenCalled()
 
-				// Verify agents is NOT passed to launchClaude
+				// Verify agents is NOT passed to launchClaude (loadAndPrepare returned undefined)
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1].agents).toBeUndefined()
 
@@ -1606,17 +1580,9 @@ describe('IgniteCommand', () => {
 				name: 'testrepo',
 			})
 
+			// On win32, loadAndPrepare renders to disk and returns undefined
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
-					'test-agent': {
-						description: 'Test agent',
-						prompt: 'Test prompt',
-						tools: ['Read'],
-						model: 'sonnet',
-					},
-				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue(['test-agent.md']),
+				loadAndPrepare: vi.fn().mockResolvedValue(undefined),
 			}
 
 			const originalCwd = process.cwd
@@ -1634,9 +1600,8 @@ describe('IgniteCommand', () => {
 			try {
 				await commandWithAgents.execute()
 
-				// Verify renderAgentsToDisk was called (non-darwin platform)
-				expect(mockAgentManager.renderAgentsToDisk).toHaveBeenCalled()
-				expect(mockAgentManager.formatForCli).not.toHaveBeenCalled()
+				// Verify loadAndPrepare was called (non-darwin platform)
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalled()
 
 				// Verify launchClaude uses appendSystemPromptFile (not plugin-dir or /clear)
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
@@ -1653,15 +1618,16 @@ describe('IgniteCommand', () => {
 			}
 		})
 
-		it('should use formatForCli and inline agents on macOS (unchanged behavior)', async () => {
+		it('should use loadAndPrepare and inline agents on macOS (unchanged behavior)', async () => {
 			const launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
 			const getRepoInfoSpy = vi.spyOn(githubUtils, 'getRepoInfo').mockResolvedValue({
 				owner: 'testowner',
 				name: 'testrepo',
 			})
 
+			// On macOS, loadAndPrepare returns the agents object
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'test-agent': {
 						description: 'Test agent',
 						prompt: 'Test prompt',
@@ -1669,8 +1635,6 @@ describe('IgniteCommand', () => {
 						model: 'sonnet',
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1689,9 +1653,8 @@ describe('IgniteCommand', () => {
 			try {
 				await commandWithAgents.execute()
 
-				// Verify formatForCli was called (darwin path)
-				expect(mockAgentManager.formatForCli).toHaveBeenCalled()
-				expect(mockAgentManager.renderAgentsToDisk).not.toHaveBeenCalled()
+				// Verify loadAndPrepare was called (darwin path)
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalled()
 
 				// Verify agents ARE passed to launchClaude
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
@@ -1728,7 +1691,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'test-agent': {
 						description: 'Test agent',
 						prompt: 'Test prompt',
@@ -1736,8 +1699,6 @@ describe('IgniteCommand', () => {
 						model: 'haiku', // Should be overridden
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1756,14 +1717,15 @@ describe('IgniteCommand', () => {
 				// Verify settings were loaded
 				expect(mockSettingsManager.loadSettings).toHaveBeenCalled()
 
-				// Verify settings and template variables were passed to loadAgents
-				expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
+				// Verify settings and template variables were passed to loadAndPrepare
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalledWith(
 					mockSettings,
 					expect.objectContaining({
 						ISSUE_NUMBER: '123',
 						WORKSPACE_PATH: '/path/to/feat/issue-123__test',
 					}),
-					['*.md', '!iloom-framework-detector.md']
+					['*.md', '!iloom-framework-detector.md'],
+					'/path/to/feat/issue-123__test/.claude/agents'
 				)
 			} finally {
 				process.cwd = originalCwd
@@ -1785,7 +1747,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'test-agent': {
 						description: 'Test agent',
 						prompt: 'Test prompt',
@@ -1793,8 +1755,6 @@ describe('IgniteCommand', () => {
 						model: 'sonnet',
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1812,14 +1772,15 @@ describe('IgniteCommand', () => {
 
 				// Should still execute successfully
 				expect(mockSettingsManager.loadSettings).toHaveBeenCalled()
-				// loadAgents receives empty settings and template variables
-				expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
+				// loadAndPrepare receives empty settings and template variables
+				expect(mockAgentManager.loadAndPrepare).toHaveBeenCalledWith(
 					{},
 					expect.objectContaining({
 						ISSUE_NUMBER: '123',
 						WORKSPACE_PATH: '/path/to/feat/issue-123__test',
 					}),
-					['*.md', '!iloom-framework-detector.md']
+					['*.md', '!iloom-framework-detector.md'],
+					'/path/to/feat/issue-123__test/.claude/agents'
 				)
 				expect(launchClaudeSpy).toHaveBeenCalled()
 			} finally {
@@ -1841,7 +1802,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
+				loadAndPrepare: vi.fn().mockResolvedValue({
 					'test-agent': {
 						description: 'Test agent',
 						prompt: 'Test prompt',
@@ -1849,8 +1810,6 @@ describe('IgniteCommand', () => {
 						model: 'sonnet',
 					},
 				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
 			}
 
 			const originalCwd = process.cwd
@@ -1868,8 +1827,8 @@ describe('IgniteCommand', () => {
 				await expect(commandWithSettings.execute()).rejects.toThrow('Failed to load settings')
 
 				expect(mockSettingsManager.loadSettings).toHaveBeenCalled()
-				// loadAgents should not be called since settings loading failed
-				expect(mockAgentManager.loadAgents).not.toHaveBeenCalled()
+				// loadAndPrepare should not be called since settings loading failed
+				expect(mockAgentManager.loadAndPrepare).not.toHaveBeenCalled()
 				expect(launchClaudeSpy).not.toHaveBeenCalled()
 			} finally {
 				process.cwd = originalCwd
@@ -1898,17 +1857,17 @@ describe('IgniteCommand', () => {
 				getSpinModel: vi.fn().mockReturnValue('opus'),
 			}
 
+			const agentsResult = {
+				'test-agent': {
+					description: 'Test agent',
+					prompt: 'Test prompt',
+					tools: ['Read'],
+					model: 'haiku', // Overridden by settings
+				},
+			}
+
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({
-					'test-agent': {
-						description: 'Test agent',
-						prompt: 'Test prompt',
-						tools: ['Read'],
-						model: 'haiku', // Overridden by settings
-					},
-				}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue(agentsResult),
 			}
 
 			const originalCwd = process.cwd
@@ -1928,14 +1887,7 @@ describe('IgniteCommand', () => {
 
 				const launchClaudeCall = launchClaudeSpy.mock.calls[0]
 				expect(launchClaudeCall[1]).toHaveProperty('agents')
-				expect(launchClaudeCall[1].agents).toEqual({
-					'test-agent': {
-						description: 'Test agent',
-						prompt: 'Test prompt',
-						tools: ['Read'],
-						model: 'haiku', // Should reflect the override
-					},
-				})
+				expect(launchClaudeCall[1].agents).toEqual(agentsResult)
 			} finally {
 				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
 				process.cwd = originalCwd
@@ -1971,9 +1923,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const originalCwd = process.cwd
@@ -2767,9 +2717,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandWithDraftPr = new IgniteCommand(
@@ -2831,9 +2779,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandWithDraftPr = new IgniteCommand(
@@ -2895,9 +2841,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandStandard = new IgniteCommand(
@@ -2956,9 +2900,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandWithValidRemote = new IgniteCommand(
@@ -3017,9 +2959,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandWithInvalidRemote = new IgniteCommand(
@@ -3075,9 +3015,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandWithSpaceRemote = new IgniteCommand(
@@ -3133,9 +3071,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn((agents) => agents),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const commandWithDefaultRemote = new IgniteCommand(
@@ -3379,9 +3315,7 @@ describe('IgniteCommand', () => {
 					}),
 				} as unknown as GitWorktreeManager,
 				{
-					loadAgents: vi.fn().mockResolvedValue([]),
-					formatForCli: vi.fn().mockReturnValue({}),
-					renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+					loadAndPrepare: vi.fn().mockResolvedValue({}),
 				} as never,
 				{
 					loadSettings: vi.fn().mockResolvedValue({
@@ -3487,9 +3421,7 @@ describe('IgniteCommand', () => {
 					}),
 				} as unknown as GitWorktreeManager,
 				{
-					loadAgents: vi.fn().mockResolvedValue([]),
-					formatForCli: vi.fn().mockReturnValue({}),
-					renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+					loadAndPrepare: vi.fn().mockResolvedValue({}),
 				} as never,
 				{
 					loadSettings: vi.fn().mockResolvedValue({
@@ -3703,9 +3635,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue([]),
-				formatForCli: vi.fn().mockReturnValue({}),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			return new IgniteCommand(
@@ -4145,9 +4075,7 @@ describe('IgniteCommand', () => {
 					}),
 				} as unknown as GitWorktreeManager,
 				{
-					loadAgents: vi.fn().mockResolvedValue([]),
-					formatForCli: vi.fn().mockReturnValue({}),
-					renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+					loadAndPrepare: vi.fn().mockResolvedValue({}),
 				} as never,
 				{
 					loadSettings: vi.fn().mockResolvedValue({
@@ -4366,9 +4294,7 @@ describe('IgniteCommand', () => {
 			}
 
 			const mockAgentManager = {
-				loadAgents: vi.fn().mockResolvedValue({}),
-				formatForCli: vi.fn().mockReturnValue({}),
-				renderAgentsToDisk: vi.fn().mockResolvedValue([]),
+				loadAndPrepare: vi.fn().mockResolvedValue({}),
 			}
 
 			const mockFirstRunManager = {

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -460,41 +460,20 @@ export class IgniteCommand {
 			// Step 4.6: Load agent configurations using cached settings
 			let agents: Record<string, unknown> | undefined
 			try {
-				// Use cached settings from Step 2.5
 				if (this.settings?.agents && Object.keys(this.settings.agents).length > 0) {
 					logger.debug('Loaded project settings', {
 						agentOverrides: Object.keys(this.settings.agents),
 					})
 				}
 
-				// Load agents with settings overrides and template variables for substitution
 				// Exclude init-only agents (e.g., framework-detector which is only for il init)
-				const loadedAgents = await this.agentManager.loadAgents(
+				agents = await this.agentManager.loadAndPrepare(
 					this.settings,
 					variables,
-					['*.md', '!iloom-framework-detector.md']
+					['*.md', '!iloom-framework-detector.md'],
+					path.join(context.workspacePath, '.claude', 'agents')
 				)
-
-				if (process.platform === 'darwin') {
-					// macOS: pass agents inline via --agents flag (unchanged behavior)
-					agents = this.agentManager.formatForCli(loadedAgents)
-					logger.debug('Loaded agent configurations for CLI', {
-						agentCount: Object.keys(agents).length,
-						agentNames: Object.keys(agents),
-					})
-				} else {
-					// Linux/Windows: render agents to .claude/agents/ for auto-discovery
-					const agentsDir = path.join(context.workspacePath, '.claude', 'agents')
-					const rendered = await this.agentManager.renderAgentsToDisk(loadedAgents, agentsDir)
-					logger.debug('Rendered agent files to disk for auto-discovery', {
-						agentCount: rendered.length,
-						agentNames: rendered,
-						targetDir: agentsDir,
-					})
-					// agents remains undefined - not passed to launchClaude
-				}
 			} catch (error) {
-				// Log warning but continue without agents
 				logger.warn(`Failed to load agents: ${error instanceof Error ? error.message : 'Unknown error'}`)
 			}
 
@@ -1153,18 +1132,12 @@ export class IgniteCommand {
 		// Load agents for the orchestrator
 		let agents: Record<string, unknown> | undefined
 		try {
-			const loadedAgents = await this.agentManager.loadAgents(
+			agents = await this.agentManager.loadAndPrepare(
 				settings,
 				variables,
-				['*.md', '!iloom-framework-detector.md']
+				['*.md', '!iloom-framework-detector.md'],
+				path.join(epicWorktreePath, '.claude', 'agents')
 			)
-
-			if (process.platform === 'darwin') {
-				agents = this.agentManager.formatForCli(loadedAgents)
-			} else {
-				const agentsDir = path.join(epicWorktreePath, '.claude', 'agents')
-				await this.agentManager.renderAgentsToDisk(loadedAgents, agentsDir)
-			}
 		} catch (error) {
 			logger.warn(`Failed to load agents: ${error instanceof Error ? error.message : 'Unknown error'}`)
 		}

--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { PlanCommand } from './plan.js'
 import type { PromptTemplateManager } from '../lib/PromptTemplateManager.js'
+import type { AgentManager } from '../lib/AgentManager.js'
 import * as claudeUtils from '../utils/claude.js'
 import * as claudeTrust from '../utils/claude-trust.js'
 import * as mcpUtils from '../utils/mcp.js'
@@ -72,6 +73,9 @@ vi.mock('../utils/logger.js', () => ({
 describe('PlanCommand', () => {
 	let command: PlanCommand
 	let mockTemplateManager: PromptTemplateManager
+	let mockAgentManager: {
+		loadAndPrepare: ReturnType<typeof vi.fn>
+	}
 
 	beforeEach(() => {
 		// Create mock template manager
@@ -79,8 +83,19 @@ describe('PlanCommand', () => {
 			getPrompt: vi.fn().mockResolvedValue('mocked plan prompt content'),
 		} as unknown as PromptTemplateManager
 
+		// Create mock agent manager
+		mockAgentManager = {
+			loadAndPrepare: vi.fn().mockResolvedValue({
+				'iloom-issue-analyzer': {
+					description: 'Issue analyzer agent',
+					prompt: 'Analyze issues',
+					model: 'opus',
+				},
+			}),
+		}
+
 		// Create command with mocked dependencies
-		command = new PlanCommand(mockTemplateManager)
+		command = new PlanCommand(mockTemplateManager, mockAgentManager as unknown as AgentManager)
 
 		// Setup default mocks
 		vi.mocked(claudeTrust.preAcceptClaudeTrust).mockResolvedValue(undefined)
@@ -270,22 +285,42 @@ describe('PlanCommand', () => {
 			expect(claudeTrust.preAcceptClaudeTrust).toHaveBeenCalledWith(process.cwd())
 		})
 
-		it('should pass allowedTools configuration', async () => {
+		it('should not restrict allowedTools', async () => {
 			await command.execute()
 
-			expect(claudeUtils.launchClaude).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.objectContaining({
-					allowedTools: expect.arrayContaining([
-						'mcp__issue_management__create_issue',
-						'mcp__issue_management__create_child_issue',
-						'mcp__issue_management__get_issue',
-						'Read',
-						'Glob',
-						'Grep',
-					]),
-				})
+			const call = vi.mocked(claudeUtils.launchClaude).mock.calls[0]
+			const options = call[1] as Record<string, unknown>
+			expect(options.allowedTools).toBeUndefined()
+		})
+
+		it('should load analyzer agent and pass to launchClaude', async () => {
+			await command.execute()
+
+			expect(mockAgentManager.loadAndPrepare).toHaveBeenCalledWith(
+				undefined,
+				expect.objectContaining({ PLANNER: 'claude' }),
+				['iloom-issue-analyzer.md']
 			)
+
+			const call = vi.mocked(claudeUtils.launchClaude).mock.calls[0]
+			const options = call[1] as Record<string, unknown>
+			expect(options.agents).toEqual({
+				'iloom-issue-analyzer': expect.objectContaining({
+					description: 'Issue analyzer agent',
+					model: 'opus',
+				}),
+			})
+		})
+
+		it('should continue without agents if loading fails', async () => {
+			mockAgentManager.loadAndPrepare.mockRejectedValue(new Error('Agent loading failed'))
+
+			await command.execute()
+
+			expect(claudeUtils.launchClaude).toHaveBeenCalled()
+			const call = vi.mocked(claudeUtils.launchClaude).mock.calls[0]
+			const options = call[1] as Record<string, unknown>
+			expect(options.agents).toBeUndefined()
 		})
 	})
 
@@ -651,15 +686,12 @@ describe('PlanCommand', () => {
 			)
 		})
 
-		it('adds mcp__harness__signal to allowed tools', async () => {
+		it('does not restrict allowedTools in autoSwarm mode', async () => {
 			await command.execute('plan my epic', undefined, undefined, undefined, undefined, undefined, true)
 
-			expect(claudeUtils.launchClaude).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.objectContaining({
-					allowedTools: expect.arrayContaining(['mcp__harness__signal']),
-				})
-			)
+			const call = vi.mocked(claudeUtils.launchClaude).mock.calls[0]
+			const options = call[1] as Record<string, unknown>
+			expect(options.allowedTools).toBeUndefined()
 		})
 
 		it('sets AUTO_SWARM_MODE: true in template variables', async () => {

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk'
 import { detectClaudeCli, launchClaude } from '../utils/claude.js'
 import { preAcceptClaudeTrust } from '../utils/claude-trust.js'
 import { PromptTemplateManager, type TemplateVariables } from '../lib/PromptTemplateManager.js'
+import { AgentManager } from '../lib/AgentManager.js'
 import { generateIssueManagementMcpConfig, generateHarnessMcpConfig } from '../utils/mcp.js'
 import { HarnessServer } from '../lib/HarnessServer.js'
 import { SettingsManager, PlanCommandSettingsSchema } from '../lib/SettingsManager.js'
@@ -70,9 +71,11 @@ function formatDependencies(dependencies: DependenciesResult, issuePrefix: strin
  */
 export class PlanCommand {
 	private readonly templateManager: PromptTemplateManager
+	private readonly agentManager: AgentManager
 
-	constructor(templateManager?: PromptTemplateManager) {
+	constructor(templateManager?: PromptTemplateManager, agentManager?: AgentManager) {
 		this.templateManager = templateManager ?? new PromptTemplateManager()
+		this.agentManager = agentManager ?? new AgentManager()
 	}
 
 	/**
@@ -465,43 +468,16 @@ export class PlanCommand {
 			mode: decompositionContext ? 'decomposition' : 'fresh',
 		})
 
-		// Define allowed tools for the Architect persona
-		const allowedTools = [
-			// Issue management tools
-			'mcp__issue_management__create_issue',
-			'mcp__issue_management__create_child_issue',
-			'mcp__issue_management__get_issue',
-			'mcp__issue_management__get_child_issues',
-			'mcp__issue_management__get_comment',
-			'mcp__issue_management__create_comment',
-			// Dependency management tools
-			'mcp__issue_management__create_dependency',
-			'mcp__issue_management__get_dependencies',
-			'mcp__issue_management__remove_dependency',
-			// Codebase exploration tools (read-only)
-			'Read',
-			'Glob',
-			'Grep',
-			'Task',
-			// Web research tools
-			'WebFetch',
-			'WebSearch',
-			// Context7 research tools (available if user has Context7 configured)
-			'mcp__context7__resolve-library-id',
-			'mcp__context7__get-library-docs',
-			// Tool discovery
-			'ToolSearch',
-			// Git commands for understanding repo state
-			'Bash(git status:*)',
-			'Bash(git log:*)',
-			'Bash(git branch:*)',
-			'Bash(git remote:*)',
-			'Bash(git diff:*)',
-			'Bash(git show:*)',
-		]
-
-		if (autoSwarm) {
-			allowedTools.push('mcp__harness__signal')
+		// Load analyzer agent for research delegation
+		let agents: Record<string, unknown> | undefined
+		try {
+			agents = await this.agentManager.loadAndPrepare(
+				settings ?? undefined,
+				templateVariables,
+				['iloom-issue-analyzer.md']
+			)
+		} catch (error) {
+			logger.warn(`Failed to load agents: ${error instanceof Error ? error.message : 'Unknown error'}`)
 		}
 
 		// Determine if we're in print/headless mode
@@ -514,7 +490,7 @@ export class PlanCommand {
 			appendSystemPrompt: architectPrompt,
 			mcpConfig,
 			addDir: process.cwd(),
-			allowedTools,
+			...(agents && { agents }),
 		}
 
 		// Add output format and verbose options if provided (print mode only)

--- a/src/lib/AgentManager.ts
+++ b/src/lib/AgentManager.ts
@@ -236,6 +236,44 @@ export class AgentManager {
 	}
 
 	/**
+	 * Load agents and prepare them for the current platform.
+	 * On macOS, returns agents formatted for the --agents CLI flag.
+	 * On Linux/Windows, renders agents to disk for auto-discovery and returns undefined.
+	 *
+	 * @param settings - Project settings for model overrides
+	 * @param templateVariables - Variables to substitute in agent prompts
+	 * @param patterns - Glob patterns for which agent files to load
+	 * @param targetDir - Directory for disk rendering (Linux/Windows). Defaults to cwd/.claude/agents/
+	 * @returns Agents object for CLI flag (macOS) or undefined (Linux/Windows, agents on disk)
+	 */
+	async loadAndPrepare(
+		settings: IloomSettings | undefined,
+		templateVariables: TemplateVariables,
+		patterns: string[],
+		targetDir?: string
+	): Promise<Record<string, unknown> | undefined> {
+		const loadedAgents = await this.loadAgents(settings, templateVariables, patterns)
+
+		if (process.platform === 'darwin') {
+			const agents = this.formatForCli(loadedAgents)
+			logger.debug('Loaded agent configurations for CLI', {
+				agentCount: Object.keys(agents).length,
+				agentNames: Object.keys(agents),
+			})
+			return agents
+		}
+
+		const dir = targetDir ?? path.join(process.cwd(), '.claude', 'agents')
+		const rendered = await this.renderAgentsToDisk(loadedAgents, dir)
+		logger.debug('Rendered agent files to disk for auto-discovery', {
+			agentCount: rendered.length,
+			agentNames: rendered,
+			targetDir: dir,
+		})
+		return undefined
+	}
+
+	/**
 	 * Render loaded agents to disk as markdown files with YAML frontmatter.
 	 * Claude Code auto-discovers agents from .claude/agents/ directory.
 	 *

--- a/templates/prompts/plan-prompt.txt
+++ b/templates/prompts/plan-prompt.txt
@@ -14,7 +14,7 @@ Look for available Gemini MCP tools (typically named with "gemini" in the tool n
 - Brainstorming and creative exploration
 - Targeted queries and analysis
 
-**Workflow**: Use these tools during Phase 1 (Understanding) and Phase 2 (Design Exploration) to gather multiple perspectives. Follow the Structured Research Framework in Phase 1 to ensure thorough problem space, third-party, and codebase understanding before decomposing work. Synthesize Gemini's responses into your plan.
+**Workflow**: Use these tools during Phase 1 (Understanding) and Phase 2 (Design Exploration) to gather multiple perspectives. Delegate deep research to the `iloom-issue-analyzer` agent (see Phase 1) and use Gemini for supplementary brainstorming. Synthesize findings into your plan.
 
 **Fallback**: If Gemini MCP tools are unavailable (error responses), continue using your own capabilities for planning.
 {{/if}}
@@ -26,7 +26,7 @@ You have access to Codex AI through MCP tools for code-aware planning.
 Look for available Codex MCP tools (typically named with "codex" in the tool name) for:
 - Code-focused analysis and implementation suggestions
 
-**Workflow**: Use this tool during Phase 1 (Understanding) for code-aware research, and during Phase 2 (Design Exploration) and Phase 3 (Issue Decomposition) to get code-specific insights. Follow the Structured Research Framework in Phase 1 to ensure thorough understanding before decomposing work.
+**Workflow**: Use this tool during Phase 2 (Design Exploration) and Phase 3 (Issue Decomposition) for code-specific insights. Delegate deep research to the `iloom-issue-analyzer` agent (see Phase 1) and use Codex for supplementary code analysis.
 
 **Fallback**: If Codex MCP tool is unavailable (error response), continue using your own capabilities for planning.
 {{/if}}
@@ -35,10 +35,8 @@ Look for available Codex MCP tools (typically named with "codex" in the tool nam
 ### Default Planning (Claude)
 
 You are the primary planner for this session. Use your capabilities to:
-- Conduct structured research across problem space, third-party dependencies, and codebase (see the Structured Research Framework in Phase 1)
-- Use Context7 tools (`mcp__context7__resolve-library-id`, `mcp__context7__get-library-docs`) for third-party library documentation, with WebSearch as fallback
-- Use ToolSearch to discover additional MCP tools that may be available for specialized research
-- Use Task subagents to delegate research tasks, keeping the main conversation focused on planning decisions
+- Delegate deep research to the `iloom-issue-analyzer` agent (see Phase 1 Research Phase) for thorough problem space, codebase, and third-party dependency understanding
+- Use Task subagents for supplementary research tasks, keeping the main conversation focused on planning decisions
 - Synthesize findings into a coherent implementation plan
 {{/unless}}{{/unless}}
 
@@ -158,108 +156,26 @@ Each issue you help create should represent a single, focused unit of work that:
 
 Before asking questions, conduct structured research to build a thorough understanding. Research informs better questions and prevents decomposition errors later.
 
-#### Structured Research Framework
+#### Research Phase
 
-**PURPOSE**: Ensure thorough understanding of the problem space, external dependencies, and codebase before decomposing work into issues. Incomplete research leads to missed cross-cutting concerns, misjudged complexity, and contracts that conflict with existing architecture.
+**Delegate research to the `iloom-issue-analyzer` agent** to build thorough understanding before decomposing work.
 
-**Delegate research to Task subagents** to keep the main conversation focused on planning decisions with the user. Launch subagents in foreground mode (wait for completion) since you need the results before proceeding.
+Launch the analyzer as a Task subagent in foreground mode (wait for completion since you need the results before proceeding):
 
-##### Domain 1: Problem Space Research
+```
+Task(
+  subagent_type: "iloom-issue-analyzer",
+  prompt: "Analyze [issue description/context]. Focus on: problem space understanding, third-party dependencies, codebase entry points and patterns, cross-cutting concerns, and edge cases. Do NOT create issue comments - just return your findings."
+)
+```
 
-**WHEN**: Always. This is mandatory before decomposition.
+The analyzer agent has a comprehensive research framework covering:
+- Problem space and domain understanding
+- Third-party dependency research (Context7, WebSearch, ToolSearch)
+- Systematic codebase exploration (entry points, dependency mapping, pattern recognition)
+- Cross-cutting concern analysis
 
-**What to Research:**
-1. **Problem Domain Understanding**
-   - What problem is this feature/fix trying to solve?
-   - Who are the users and what are their needs?
-   - What constraints exist (performance, compatibility, UX)?
-
-2. **Architectural Context**
-   - Where does this fit in the overall system?
-   - What architectural principles should guide the solution?
-   - Are there ADRs, design docs, README, or CLAUDE.md guidance?
-
-3. **Edge Cases & Failure Modes**
-   - What can go wrong?
-   - What edge cases need consideration?
-   - What assumptions are we making?
-
-**Research Methods:**
-- Review existing documentation in the repo (README, CLAUDE.md, docs/)
-- Check for related issues/PRs that provide context
-- WebSearch for common patterns/solutions in the problem domain
-
-##### Domain 2: Third-Party Research (External Dependencies)
-
-**WHEN**: When external libraries, CLI tools, APIs, or frameworks are involved.
-
-**Detection Triggers:**
-- External libraries/packages mentioned in issue description or code
-- CLI tools beyond basic usage
-- APIs or services
-- Frameworks or their specific features
-
-**Research Hierarchy (in order):**
-
-1. **Context7** (Primary External Documentation)
-   - Use `mcp__context7__resolve-library-id` to find the library
-   - Use `mcp__context7__get-library-docs` with relevant topic
-   - If insufficient, try different topics or increase page count
-   - Document findings with specific API references and version notes
-
-2. **WebSearch** (When Context7 Insufficient)
-   - Trigger when Context7 returns no results, lacks examples, or misses version-specific information
-   - Effective queries: `"[library] [feature] [version]"`, `"[library] breaking changes"`
-
-3. **ToolSearch** (Specialized Domain Tools)
-   - Use ToolSearch to discover additional MCP tools that may be available (e.g., Figma MCP, database MCPs)
-   - Use discovered tools as supplementary research sources
-
-**Fallback**: If Context7 tools are not configured, use WebSearch directly. The research hierarchy adapts to available tools.
-
-**Document for each dependency:**
-- API signatures, expected inputs/outputs
-- Version-specific notes (breaking changes, deprecations)
-- Common patterns for this use case
-
-##### Domain 3: Codebase Research
-
-**WHEN**: Always. This is mandatory before decomposition.
-
-**Systematic Exploration:**
-
-1. **Entry Point Identification**
-   - Identify where the feature/fix will manifest (file:line references)
-   - Trace backwards to understand context
-
-2. **Dependency Mapping**
-   - What does the affected code depend on?
-   - What depends on the affected code?
-   - Use Grep to find all usages/references
-
-3. **Pattern Recognition**
-   - Search for similar implementations elsewhere in codebase
-   - Identify established patterns the solution should follow
-   - Note conventions that child issues should adhere to
-
-4. **Historical Context** (when unclear)
-   - Check git blame for affected lines
-   - Review recent commits touching these files
-
-**Depth Requirements:**
-- Trace at least 2 levels of dependencies
-- Search for similar patterns using Grep before assuming uniqueness
-- Document file:line references for key findings
-
-##### Research Quality Checklist
-
-Before moving to clarifying questions, verify:
-- [ ] Problem domain is understood (who benefits, what constraints exist)
-- [ ] Architectural context is mapped (where this fits, what principles apply)
-- [ ] All external dependencies are researched with API references
-- [ ] Codebase entry points and dependencies are identified
-- [ ] Existing patterns that child issues should follow are documented
-- [ ] Edge cases and failure modes are noted
+Wait for the analyzer to complete, then use its findings to inform sharper clarifying questions and better decomposition decisions.
 
 ---
 


### PR DESCRIPTION
Fixes #879

## Plan mode should leverage the Analyze agent's research framework

## Summary

The plan command (`il plan`) runs a single Claude session with `plan-prompt.txt` but performs no structured codebase or problem space research before decomposing work into child issues. The Analyze agent (`iloom-issue-analyzer.md`) has a comprehensive research framework that would significantly improve planning quality if leveraged during the planning phase.

## Problem

The plan prompt focuses heavily on **decomposition methodology** (DAG shape, contracts, SIMPLE sizing, wave verification) but has almost no guidance on how to **understand the codebase** before decomposing. The current state:

| Aspect | Analyzer Agent | Plan Prompt |
|--------|---------------|-------------|
| Problem Space Research | Structured framework: domain understanding, alternative approaches, architectural context, edge cases | Nothing explicit — relies on clarifying questions to the user |
| Third-Party Research | 4-tier hierarchy: Skills → Context7 → WebSearch → MCP | Not mentioned |
| Codebase Research | Systematic: entry points, dependency mapping, pattern recognition, historical context, git blame | One line: "explore the codebase with Read, Glob, Grep tools" |
| Cross-Cutting Analysis | Full call-chain mapping with affected interfaces | Not present |
| Research Quality Gates | Detailed failure modes to avoid, quality checklist | None |

The quality of issue decomposition depends heavily on understanding the existing codebase. Without structured research, the architect may:
- Miss cross-cutting concerns that should influence how work is split
- Misjudge complexity of child issues
- Overlook existing patterns that child issues should follow
- Create contracts that conflict with existing architecture

## Desired Outcome

Plan mode should incorporate the Analyze agent's structured research capabilities so that the architect has thorough codebase and problem space understanding before decomposing work into child issues.

## Scope Boundaries

- This is about improving the planning phase's research quality, not changing the decomposition methodology itself
- The analyzer's documentation format (Section 1/Section 2, comment routing) is specific to swarm execution and should NOT be carried over — only the research framework

---
*This PR was created automatically by iloom.*