### PR TITLE
When I ctrl-c out of 'il dev-server' and probably some other commands my input gets captured and appears corrupted

### DIFF
--- a/src/lib/DockerDevServerStrategy.ts
+++ b/src/lib/DockerDevServerStrategy.ts
@@ -1,6 +1,7 @@
 import { execa } from 'execa'
 import net from 'net'
 import { logger } from '../utils/logger.js'
+import { restoreTerminalState } from '../utils/terminal.js'
 
 /**
  * Docker configuration shape consumed by DockerDevServerStrategy.
@@ -314,6 +315,7 @@ export class DockerDevServerStrategy {
 			// Clean up signal handlers to avoid leaks
 			process.removeListener('SIGINT', onSigint)
 			process.removeListener('SIGTERM', onSigterm)
+			restoreTerminalState()
 		}
 
 		return {}

--- a/src/lib/DockerManager.ts
+++ b/src/lib/DockerManager.ts
@@ -1,5 +1,6 @@
 import { execa } from 'execa'
 import { logger } from '../utils/logger.js'
+import { restoreTerminalState } from '../utils/terminal.js'
 import {
 	isDockerInstalled,
 	isDockerRunning,
@@ -217,6 +218,7 @@ export class DockerManager {
 			// Clean up signal handlers to avoid leaks
 			process.removeListener('SIGINT', onSigint)
 			process.removeListener('SIGTERM', onSigterm)
+			restoreTerminalState()
 		}
 	}
 

--- a/src/lib/NativeDevServerStrategy.ts
+++ b/src/lib/NativeDevServerStrategy.ts
@@ -1,10 +1,11 @@
-import { execa, type ExecaChildProcess } from 'execa'
+import { execa, type ExecaChildProcess, type ExecaError } from 'execa'
 import { setTimeout } from 'timers/promises'
 import { ProcessManager } from './process/ProcessManager.js'
 import { buildDevServerCommand } from '../utils/dev-server.js'
 import { runScript } from '../utils/package-manager.js'
 import { getPackageScripts } from '../utils/package-json.js'
 import { logger } from '../utils/logger.js'
+import { restoreTerminalState } from '../utils/terminal.js'
 import type { DevServerStrategy, ForegroundOpts } from './DevServerStrategy.js'
 
 /**
@@ -117,7 +118,24 @@ export class NativeDevServerStrategy implements DevServerStrategy {
 				onProcessStarted(processInfo.pid)
 			}
 
-			await serverProcess
+			// Register no-op SIGINT handler to prevent signal-exit from re-raising SIGINT
+			// before finally blocks can run, ensuring terminal state is restored on Ctrl+C.
+			const onSigint = (): void => {}
+			process.on('SIGINT', onSigint)
+
+			try {
+				await serverProcess
+			} catch (error) {
+				const execaError = error as ExecaError
+				// If killed by SIGINT, the user intentionally cancelled — return silently
+				if (execaError.signal !== 'SIGINT') {
+					throw error
+				}
+			} finally {
+				process.removeListener('SIGINT', onSigint)
+				restoreTerminalState()
+			}
+
 			return processInfo
 		}
 

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -1,6 +1,7 @@
 import { execa, type ExecaError } from 'execa'
 import { getLogger } from './logger-context.js'
 import { getPackageScripts } from './package-json.js'
+import { restoreTerminalState } from './terminal.js'
 import fs from 'fs-extra'
 import path from 'path'
 
@@ -206,6 +207,14 @@ export async function runScript(
   // Determine stdio mode
   const stdio = options.foreground ? 'inherit' : (options.quiet ? 'pipe' : 'inherit')
 
+  // For foreground mode, register a no-op SIGINT handler to prevent signal-exit
+  // (used internally by execa) from re-raising SIGINT and killing the process
+  // before finally blocks can run. This ensures terminal state is restored on Ctrl+C.
+  const onSigint = (): void => {}
+  if (options.foreground) {
+    process.on('SIGINT', onSigint)
+  }
+
   try {
     let execaProcess
 
@@ -252,7 +261,16 @@ export async function runScript(
     return result
   } catch (error) {
     const execaError = error as ExecaError
+    // If the process was killed by SIGINT, the user intentionally cancelled — return silently
+    if (options.foreground && execaError.signal === 'SIGINT') {
+      return {}
+    }
     const stderr = execaError.stderr ?? execaError.message ?? 'Unknown error'
     throw new Error(`Failed to run script '${scriptName}': ${stderr}`)
+  } finally {
+    if (options.foreground) {
+      process.removeListener('SIGINT', onSigint)
+      restoreTerminalState()
+    }
   }
 }

--- a/src/utils/terminal.test.ts
+++ b/src/utils/terminal.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { detectPlatform, detectDarkMode, openTerminalWindow, openDualTerminalWindow } from './terminal.js'
+import { detectPlatform, detectDarkMode, openTerminalWindow, openDualTerminalWindow, restoreTerminalState } from './terminal.js'
 import { execa } from 'execa'
+import { execSync } from 'child_process'
 import { existsSync } from 'node:fs'
 
 // Mock execa
 vi.mock('execa')
+// Mock child_process
+vi.mock('child_process', () => ({
+	execSync: vi.fn(),
+}))
 // Mock fs
 vi.mock('node:fs', () => ({
 	existsSync: vi.fn(),
@@ -603,5 +608,50 @@ describe('openDualTerminalWindow', () => {
 		// Should include source commands for all dotenv-flow files in both tabs (4 files × 2 tabs = 8 occurrences)
 		const envCount = (applescript.match(/source \.env/g) || []).length
 		expect(envCount).toBe(8)
+	})
+})
+
+describe('restoreTerminalState', () => {
+	const originalIsTTY = process.stdin.isTTY
+
+	afterEach(() => {
+		Object.defineProperty(process.stdin, 'isTTY', {
+			value: originalIsTTY,
+			configurable: true,
+		})
+	})
+
+	it('should call stty sane when stdin is a TTY', () => {
+		Object.defineProperty(process.stdin, 'isTTY', {
+			value: true,
+			configurable: true,
+		})
+
+		restoreTerminalState()
+
+		expect(execSync).toHaveBeenCalledWith('stty sane', { stdio: 'ignore' })
+	})
+
+	it('should not call stty sane when stdin is not a TTY', () => {
+		Object.defineProperty(process.stdin, 'isTTY', {
+			value: false,
+			configurable: true,
+		})
+
+		restoreTerminalState()
+
+		expect(execSync).not.toHaveBeenCalled()
+	})
+
+	it('should not throw when execSync throws', () => {
+		Object.defineProperty(process.stdin, 'isTTY', {
+			value: true,
+			configurable: true,
+		})
+		vi.mocked(execSync).mockImplementation(() => {
+			throw new Error('stty: command not found')
+		})
+
+		expect(() => restoreTerminalState()).not.toThrow()
 	})
 })

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process'
 import { execa } from 'execa'
 import type { Platform } from '../types/index.js'
 import { getTerminalBackend } from './terminal-backends/index.js'
@@ -104,4 +105,25 @@ export async function openDualTerminalWindow(
 	options2: TerminalWindowOptions
 ): Promise<void> {
 	await openMultipleTerminalWindows([options1, options2])
+}
+
+/**
+ * Restore terminal state after a child process may have left it in a bad state.
+ *
+ * Uses `stty sane` which resets terminal line settings to reasonable defaults.
+ * This is more reliable than Node's `setRawMode(false)` because child processes
+ * (e.g., dev servers) may change tty settings directly on the shared fd, and
+ * Node's API doesn't reliably undo those changes.
+ *
+ * This function never throws — terminal restoration is best-effort.
+ */
+export function restoreTerminalState(): void {
+	if (!process.stdin.isTTY) {
+		return
+	}
+	try {
+		execSync('stty sane', { stdio: 'ignore' })
+	} catch {
+		// Best-effort: if stty fails, there's nothing more we can do
+	}
 }


### PR DESCRIPTION
Fixes #882

## When I ctrl-c out of 'il dev-server' and probably some other commands my input gets captured and appears corrupted

POST /api/video/frames 200 in 57s (compile: 6ms, render: 57s)
 POST /api/video/frames 200 in 57s (compile: 1260µs, render: 57s)

adam@MacBook-Pro feat-issue-60 % 
^[[A^C
adam@MacBook-Pro feat-issue-60 % 

Note the '^[[A' at the end - until I ctrl-c again, input is captured and converted to escape chars

---
*This PR was created automatically by iloom.*