### PR TITLE
Agents/Subagents running in (or as children of) issue-prompt (regular or swarm mode) should not be using set_goal

### DIFF
--- a/src/mcp/recap-server.ts
+++ b/src/mcp/recap-server.ts
@@ -165,31 +165,35 @@ const server = new McpServer({
 	version: '0.1.0',
 })
 
-// Register set_goal tool
-server.registerTool(
-	'set_goal',
-	{
-		title: 'Set Goal',
-		description: 'Set the initial goal (called once at session start)',
-		inputSchema: {
-			goal: z.string().describe('The original problem statement'),
-			worktreePath: z.string().optional().describe('Optional worktree path to scope recap to a specific loom'),
+// Register set_goal tool conditionally
+// In issue/epic workflows, set_goal is disabled via RECAP_DISABLE_SET_GOAL env var
+// to prevent agents from overwriting the goal set by the PR-level prompt
+if (!process.env.RECAP_DISABLE_SET_GOAL) {
+	server.registerTool(
+		'set_goal',
+		{
+			title: 'Set Goal',
+			description: 'Set the initial goal (called once at session start)',
+			inputSchema: {
+				goal: z.string().describe('The original problem statement'),
+				worktreePath: z.string().optional().describe('Optional worktree path to scope recap to a specific loom'),
+			},
+			outputSchema: {
+				success: z.literal(true),
+			},
 		},
-		outputSchema: {
-			success: z.literal(true),
-		},
-	},
-	async ({ goal, worktreePath }) => {
-		const filePath = resolveRecapFilePath(worktreePath)
-		const recap = await readRecapFile(filePath)
-		recap.goal = goal
-		await writeRecapFile(filePath, recap)
-		return {
-			content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }],
-			structuredContent: { success: true },
+		async ({ goal, worktreePath }) => {
+			const filePath = resolveRecapFilePath(worktreePath)
+			const recap = await readRecapFile(filePath)
+			recap.goal = goal
+			await writeRecapFile(filePath, recap)
+			return {
+				content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }],
+				structuredContent: { success: true },
+			}
 		}
-	}
-)
+	)
+}
 
 // Register set_complexity tool
 server.registerTool(

--- a/src/utils/mcp.test.ts
+++ b/src/utils/mcp.test.ts
@@ -115,6 +115,66 @@ describe('generateRecapMcpConfig', () => {
 		expect(env.RECAP_FILE_PATH).toContain('___path___with-spaces___and-dots.json')
 	})
 
+	it('should set RECAP_DISABLE_SET_GOAL for issue loom type', () => {
+		const loomPath = '/Users/test/projects/my-repo'
+		const loomMetadata = createMockMetadata({ issueType: 'issue' })
+
+		const config = generateRecapMcpConfig(loomPath, loomMetadata)
+
+		const recapConfig = (config[0].mcpServers as Record<string, unknown>).recap as Record<string, unknown>
+		const env = recapConfig.env as Record<string, string>
+
+		expect(env.RECAP_DISABLE_SET_GOAL).toBe('true')
+	})
+
+	it('should set RECAP_DISABLE_SET_GOAL for epic loom type', () => {
+		const loomPath = '/Users/test/projects/my-repo'
+		const loomMetadata = createMockMetadata({ issueType: 'epic' })
+
+		const config = generateRecapMcpConfig(loomPath, loomMetadata)
+
+		const recapConfig = (config[0].mcpServers as Record<string, unknown>).recap as Record<string, unknown>
+		const env = recapConfig.env as Record<string, string>
+
+		expect(env.RECAP_DISABLE_SET_GOAL).toBe('true')
+	})
+
+	it('should not set RECAP_DISABLE_SET_GOAL for pr loom type', () => {
+		const loomPath = '/Users/test/projects/my-repo'
+		const loomMetadata = createMockMetadata({ issueType: 'pr' })
+
+		const config = generateRecapMcpConfig(loomPath, loomMetadata)
+
+		const recapConfig = (config[0].mcpServers as Record<string, unknown>).recap as Record<string, unknown>
+		const env = recapConfig.env as Record<string, string>
+
+		expect(env.RECAP_DISABLE_SET_GOAL).toBeUndefined()
+	})
+
+	it('should not set RECAP_DISABLE_SET_GOAL for branch loom type', () => {
+		const loomPath = '/Users/test/projects/my-repo'
+		const loomMetadata = createMockMetadata({ issueType: 'branch' })
+
+		const config = generateRecapMcpConfig(loomPath, loomMetadata)
+
+		const recapConfig = (config[0].mcpServers as Record<string, unknown>).recap as Record<string, unknown>
+		const env = recapConfig.env as Record<string, string>
+
+		expect(env.RECAP_DISABLE_SET_GOAL).toBeUndefined()
+	})
+
+	it('should not set RECAP_DISABLE_SET_GOAL when issueType is null', () => {
+		const loomPath = '/Users/test/projects/my-repo'
+		const loomMetadata = createMockMetadata({ issueType: null })
+
+		const config = generateRecapMcpConfig(loomPath, loomMetadata)
+
+		const recapConfig = (config[0].mcpServers as Record<string, unknown>).recap as Record<string, unknown>
+		const env = recapConfig.env as Record<string, string>
+
+		expect(env.RECAP_DISABLE_SET_GOAL).toBeUndefined()
+	})
+
 	it('should strip trailing slashes from path', () => {
 		const loomPath = '/path/to/dir/'
 		const loomMetadata = createMockMetadata()

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -221,10 +221,16 @@ export function generateRecapMcpConfig(
 	// - RECAP_FILE_PATH: where to read/write recap data
 	// - LOOM_METADATA_JSON: stringified loom metadata (parsed by MCP using LoomMetadata type)
 	// - METADATA_FILE_PATH: path to loom metadata file (for state transition tools)
-	const envVars = {
+	const envVars: Record<string, string> = {
 		RECAP_FILE_PATH: recapFilePath,
 		LOOM_METADATA_JSON: JSON.stringify(loomMetadata),
 		METADATA_FILE_PATH: metadataFilePath,
+	}
+
+	// Disable set_goal for issue and epic workflows
+	// (set_goal should only be available in PR and regular/branch workflows)
+	if (loomMetadata.issueType === 'issue' || loomMetadata.issueType === 'epic') {
+		envVars.RECAP_DISABLE_SET_GOAL = 'true'
 	}
 
 	logger.debug('Generated MCP config for recap server', {


### PR DESCRIPTION
Fixes #885

## Agents/Subagents running in (or as children of) issue-prompt (regular or swarm mode) should not be using set_goal

Only the PR prompt should be receiving that MCP tool.

---
*This PR was created automatically by iloom.*