### PR TITLE
fix(#884): treat short titles as descriptions when --body is provided

### DIFF
--- a/src/commands/start.test.ts
+++ b/src/commands/start.test.ts
@@ -486,6 +486,47 @@ describe('StartCommand', () => {
 				)
 			})
 
+			it('should detect short title as description when --body is provided (#884)', async () => {
+				// VS Code extension sends short titles with --body for new issue creation
+				const shortTitle = 'A Test Loom'
+				const body = 'As a User I want to be able to create a loom straight from the dialog'
+
+				// Mock GitHubService.createIssue to return issue data
+				vi.mocked(mockGitHubService.createIssue).mockResolvedValue({
+					number: 891,
+					url: 'https://github.com/owner/repo/issues/891',
+				})
+
+				mockGitHubService.getIssueTitle = vi.fn().mockResolvedValue('Issue title')
+
+				await expect(
+					command.execute({
+						identifier: shortTitle,
+						options: { body },
+					})
+				).resolves.not.toThrow()
+
+				// Should create issue with the short title and provided body
+				expect(mockGitHubService.createIssue).toHaveBeenCalledWith(
+					'A Test Loom',
+					body
+				)
+			})
+
+			it('should still reject short text with spaces when no --body is provided', async () => {
+				const shortText = 'A Test Loom'
+
+				// Without --body, short text with spaces should fail as invalid branch name
+				await expect(
+					command.execute({
+						identifier: shortText,
+						options: {},
+					})
+				).rejects.toThrow('Invalid branch name')
+
+				expect(mockGitHubService.createIssue).not.toHaveBeenCalled()
+			})
+
 		})
 
 		describe('validation', () => {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -169,7 +169,7 @@ export class StartCommand {
 			let parentLoom = await this.detectParentLoom(loomManager)
 
 			// Step 1: Parse and validate input (pass repo to methods)
-			const parsed = await this.parseInput(input.identifier, repo)
+			const parsed = await this.parseInput(input.identifier, repo, input.options)
 
 			// Step 2: Validate based on type
 			await this.validateInput(parsed, repo)
@@ -445,7 +445,7 @@ export class StartCommand {
 	/**
 	 * Parse input to determine type and extract relevant data
 	 */
-	private async parseInput(identifier: string, repo?: string): Promise<ParsedInput> {
+	private async parseInput(identifier: string, repo?: string, options?: StartOptions): Promise<ParsedInput> {
 		// Check if user wants to skip capitalization by prefixing with space
 		// We preserve this for description types so capitalizeFirstLetter() can handle it
 		const hasLeadingSpace = identifier.startsWith(' ')
@@ -457,9 +457,10 @@ export class StartCommand {
 		}
 
 		// Check for description: >15 chars AND has spaces (likely a natural language description)
-		// Short inputs with spaces are rejected later as invalid branch names
+		// Also treat as description if --body is provided with a multi-word input,
+		// since the VS Code extension passes short titles with a --body flag for new issue creation
 		const spaceCount = (trimmedIdentifier.match(/ /g) ?? []).length
-		if (trimmedIdentifier.length > 15 && spaceCount >= 1) {
+		if ((trimmedIdentifier.length > 15 && spaceCount >= 1) || (options?.body && spaceCount >= 1)) {
 			// Preserve leading space if present so capitalizeFirstLetter() can detect the override
 			return {
 				type: 'description',


### PR DESCRIPTION
## Summary
- When the VS Code extension creates a new loom with a short title (≤15 chars) and a `--body` flag, the CLI now correctly treats it as a new issue description instead of falling through to branch name validation and failing
- The `parseInput()` method now accepts `options` and checks for `options.body` alongside the existing length check
- Adds two tests: one for the fix (short title + body succeeds) and one confirming existing behavior (short title without body still rejects)

Closes #884

## Test plan
- [x] Existing tests pass (4855 tests)
- [x] New test: short title `"A Test Loom"` with `--body` is detected as description and creates an issue
- [x] New test: short title `"A Test Loom"` without `--body` still rejects as invalid branch name