### PR TITLE
fix: match swarm child worktree branches using issue/{id} pattern

### DIFF
--- a/src/lib/GitWorktreeManager.test.ts
+++ b/src/lib/GitWorktreeManager.test.ts
@@ -1083,6 +1083,69 @@ describe('GitWorktreeManager', () => {
       expect(result).toEqual(targetWorktree)
       expect(result?.branch).toBe('feat/issue-mark-1__nextjs-vercel')
     })
+
+    it('should find worktree with issue/{id} branch pattern (swarm child worktrees)', async () => {
+      // SwarmSetupService creates child branches as issue/{id} (slash separator)
+      const targetWorktree = {
+        path: '/test/worktree-issue-random-3',
+        branch: 'issue/RANDOM-3',
+        commit: 'abc123',
+        bare: false,
+        detached: false,
+        locked: false,
+      }
+
+      const mockWorktrees = [
+        {
+          path: '/test/repo',
+          branch: 'main',
+          commit: 'def456',
+          bare: false,
+          detached: false,
+          locked: false,
+        },
+        targetWorktree,
+      ]
+
+      vi.mocked(gitUtils.executeGitCommand).mockResolvedValue('mock output')
+      vi.mocked(gitUtils.parseWorktreeList).mockReturnValue(mockWorktrees)
+
+      const result = await manager.findWorktreeForIssue('RANDOM-3')
+
+      expect(result).toEqual(targetWorktree)
+      expect(result?.branch).toBe('issue/RANDOM-3')
+    })
+
+    it('should find worktree with issue/{N} branch pattern for numeric issues', async () => {
+      const targetWorktree = {
+        path: '/test/worktree-issue-42',
+        branch: 'issue/42',
+        commit: 'abc123',
+        bare: false,
+        detached: false,
+        locked: false,
+      }
+
+      const mockWorktrees = [
+        {
+          path: '/test/repo',
+          branch: 'main',
+          commit: 'def456',
+          bare: false,
+          detached: false,
+          locked: false,
+        },
+        targetWorktree,
+      ]
+
+      vi.mocked(gitUtils.executeGitCommand).mockResolvedValue('mock output')
+      vi.mocked(gitUtils.parseWorktreeList).mockReturnValue(mockWorktrees)
+
+      const result = await manager.findWorktreeForIssue(42)
+
+      expect(result).toEqual(targetWorktree)
+      expect(result?.branch).toBe('issue/42')
+    })
   })
 
   describe('isMainWorktree', () => {

--- a/src/lib/GitWorktreeManager.ts
+++ b/src/lib/GitWorktreeManager.ts
@@ -421,9 +421,10 @@ export class GitWorktreeManager {
   async findWorktreeForIssue(issueNumber: string | number): Promise<GitWorktree | null> {
     const worktrees = await this.listWorktrees({ porcelain: true })
 
-    // Pattern: starts with 'issue-{N}' OR has '/issue-{N}', '-issue-{N}', '_issue-{N}' but not 'issue-{N}{digit}'
+    // Pattern: starts with 'issue-{N}' or 'issue/{N}' OR has '/issue-{N}', '-issue-{N}', '_issue-{N}' etc.
+    // Uses [-/] after 'issue' to match both dash (feat/issue-42__desc) and slash (issue/42) conventions
     // Case-insensitive to handle Linear IDs (MARK-1 vs mark-1)
-    const pattern = new RegExp(`(?:^|[/_-])issue-${issueNumber}(?:-|__|$)`, 'i')
+    const pattern = new RegExp(`(?:^|[/_-])issue[-/]${issueNumber}(?:-|__|$)`, 'i')
 
     return worktrees.find(wt => pattern.test(wt.branch)) ?? null
   }


### PR DESCRIPTION
## Summary
- `findWorktreeForIssue()` regex only matched `issue-{id}` (dash separator) but `SwarmSetupService` creates child branches as `issue/{id}` (slash separator)
- Changed regex from `issue-${issueNumber}` to `issue[-/]${issueNumber}` to match both conventions
- Fixes `il cleanup` failing with "No worktree found" when cleaning up swarm child worktrees

## Test plan
- [x] Existing `findWorktreeForIssue` tests still pass (9 tests)
- [x] New test: swarm-style `issue/RANDOM-3` alphanumeric branch pattern
- [x] New test: swarm-style `issue/42` numeric branch pattern
- [x] Pre-commit hooks pass (lint, compile, test, build)