### PR TITLE
fix: support alphanumeric identifiers in cleanup --issue flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1033,7 +1033,7 @@ program
   .argument('[identifier]', 'Branch name or issue number to cleanup (auto-detected)')
   .option('-l, --list', 'List all worktrees')
   .option('-a, --all', 'Remove all worktrees (interactive confirmation)')
-  .option('-i, --issue <number>', 'Cleanup by issue number', parseInt)
+  .option('-i, --issue <number>', 'Cleanup by issue number', parseIssueIdentifier)
   .option('-f, --force', 'Skip confirmations and force removal')
   .option('--dry-run', 'Show what would be done without doing it')
   .option('--json', 'Output result as JSON')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -205,8 +205,8 @@ export interface CleanupOptions {
   list?: boolean
   /** Remove all worktrees (interactive confirmation required unless --force) */
   all?: boolean
-  /** Cleanup by specific issue number */
-  issue?: number
+  /** Cleanup by specific issue identifier (numeric or alphanumeric like RANDOM-13) */
+  issue?: string | number
   /** Skip confirmations and force removal */
   force?: boolean
   /** Show what would be done without actually doing it */


### PR DESCRIPTION
## Summary
- `il cleanup --issue RANDOM-13` produced NaN because the flag used `parseInt`
- Switched to existing `parseIssueIdentifier` helper which preserves strings for Linear/Jira-style IDs
- Updated `CleanupOptions.issue` type from `number` to `string | number`

## Test plan
- [x] All 89 cleanup tests pass
- [x] TypeScript compiles cleanly
- [x] Pre-commit hooks pass (lint, compile, test, build)