### PR TITLE
feat: pre-approve issue management tools for plan agent

### DIFF
--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -285,12 +285,21 @@ describe('PlanCommand', () => {
 			expect(claudeTrust.preAcceptClaudeTrust).toHaveBeenCalledWith(process.cwd())
 		})
 
-		it('should not restrict allowedTools', async () => {
+		it('should pre-approve issue management tools', async () => {
 			await command.execute()
 
 			const call = vi.mocked(claudeUtils.launchClaude).mock.calls[0]
 			const options = call[1] as Record<string, unknown>
-			expect(options.allowedTools).toBeUndefined()
+			expect(options.allowedTools).toEqual([
+				'mcp__issue_management__get_issue',
+				'mcp__issue_management__get_child_issues',
+				'mcp__issue_management__create_issue',
+				'mcp__issue_management__create_child_issue',
+				'mcp__issue_management__create_comment',
+				'mcp__issue_management__create_dependency',
+				'mcp__issue_management__get_dependencies',
+				'mcp__issue_management__remove_dependency',
+			])
 		})
 
 		it('should load analyzer agent and pass to launchClaude', async () => {
@@ -686,12 +695,22 @@ describe('PlanCommand', () => {
 			)
 		})
 
-		it('does not restrict allowedTools in autoSwarm mode', async () => {
+		it('includes harness signal tool in allowedTools for autoSwarm mode', async () => {
 			await command.execute('plan my epic', undefined, undefined, undefined, undefined, undefined, true)
 
 			const call = vi.mocked(claudeUtils.launchClaude).mock.calls[0]
 			const options = call[1] as Record<string, unknown>
-			expect(options.allowedTools).toBeUndefined()
+			expect(options.allowedTools).toEqual([
+				'mcp__issue_management__get_issue',
+				'mcp__issue_management__get_child_issues',
+				'mcp__issue_management__create_issue',
+				'mcp__issue_management__create_child_issue',
+				'mcp__issue_management__create_comment',
+				'mcp__issue_management__create_dependency',
+				'mcp__issue_management__get_dependencies',
+				'mcp__issue_management__remove_dependency',
+				'mcp__harness__signal',
+			])
 		})
 
 		it('sets AUTO_SWARM_MODE: true in template variables', async () => {

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -483,6 +483,19 @@ export class PlanCommand {
 		// Determine if we're in print/headless mode
 		const isHeadless = printOptions?.print ?? false
 
+		// Pre-approve issue management tools so the plan agent can use them without prompting
+		const allowedTools = [
+			'mcp__issue_management__get_issue',
+			'mcp__issue_management__get_child_issues',
+			'mcp__issue_management__create_issue',
+			'mcp__issue_management__create_child_issue',
+			'mcp__issue_management__create_comment',
+			'mcp__issue_management__create_dependency',
+			'mcp__issue_management__get_dependencies',
+			'mcp__issue_management__remove_dependency',
+			...(autoSwarm ? ['mcp__harness__signal'] : []),
+		]
+
 		// Build Claude options
 		const claudeOptions: Parameters<typeof launchClaude>[1] = {
 			model: effectiveModel,
@@ -490,6 +503,7 @@ export class PlanCommand {
 			appendSystemPrompt: architectPrompt,
 			mcpConfig,
 			addDir: process.cwd(),
+			allowedTools,
 			...(agents && { agents }),
 		}
 

--- a/templates/agents/iloom-wave-verifier.md
+++ b/templates/agents/iloom-wave-verifier.md
@@ -220,9 +220,10 @@ Return the verification report in this exact format:
 
 *(If no fix skills were invoked: "None — all must-haves passed on initial verification.")*
 
-### Overall Status: [ALL_PASSED | PARTIALLY_FIXED | FAILURES_REMAIN]
+### Overall Status: [ALL_PASSED | ALL_FIXED | PARTIALLY_FIXED | FAILURES_REMAIN]
 
 - **ALL_PASSED**: All must-haves passed initial verification (no fix skills needed)
+- **ALL_FIXED**: Some must-haves failed initially but ALL were fixed after re-verification
 - **PARTIALLY_FIXED**: Some failures were fixed but others remain
 - **FAILURES_REMAIN**: One or more must-haves are still failing after re-verification
 

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -468,23 +468,19 @@ git log --oneline -5
 
 #### Step 5.2.5a: Run Code Review
 
-**Delegate this to a subagent.** Spawn a Task subagent to invoke the code reviewer:
+**Delegate this to a subagent.** Spawn a Task subagent using the code reviewer agent directly:
 
-- `subagent_type`: `"general-purpose"`
+- `subagent_type`: `"iloom-swarm-code-reviewer"`
 - Prompt:
 
 ```
 Run a full code review of the integrated epic branch.
 
-## Instructions
-
 You are in the epic worktree at `{{EPIC_WORKTREE_PATH}}`. All child agents' work has been merged into this branch.
 
-1. Execute: @agent-iloom-code-reviewer with prompt "Run code review."
-2. Wait for the review to complete.
-3. Report back with the full review results, including all findings with their confidence scores, file locations, and recommendations.
-   - If no issues found, report "No issues found."
-   - If issues found, include the full structured report (Critical issues 95-100, Warnings 80-94).
+Report the full review results, including all findings with their confidence scores, file locations, and recommendations.
+- If no issues found, report "No issues found."
+- If issues found, include the full structured report (Critical issues 95-100, Warnings 80-94).
 ```
 
 **Handle the subagent result:**


### PR DESCRIPTION
## Summary

- Pre-approve all issue management MCP tools (`get_issue`, `create_issue`, `create_child_issue`, `create_comment`, `create_dependency`, `get_dependencies`, `remove_dependency`, `get_child_issues`) for the plan agent so they don't require user confirmation on each call
- Include `mcp__harness__signal` in allowed tools when auto-swarm mode is active
- Add `ALL_FIXED` status to wave verifier for cases where all must-haves failed initially but were fixed after re-verification
- Simplify swarm code review delegation to use `iloom-swarm-code-reviewer` agent type directly instead of nesting via general-purpose subagent

## Test plan

- [x] Updated existing tests to verify `allowedTools` are passed correctly
- [x] Verified harness signal tool is only included in auto-swarm mode
- [x] All 4858 tests pass