### PR TITLE
feat: show full agent routing table after swarm completes

### DIFF
--- a/templates/hooks/iloom-hook.js
+++ b/templates/hooks/iloom-hook.js
@@ -308,8 +308,46 @@ async function main() {
 
     // Special handling for UserPromptSubmit - output JSON additionalContext instead of broadcasting
     if (status === 'user_prompt_submit') {
-      // In swarm mode, agents handle their own workflow — only remind about code reviewer
+      // In swarm mode, check if swarm has completed to show appropriate reminder
       if (process.env.ILOOM_SWARM === '1') {
+        // Read epic metadata to check if swarm has finished
+        let swarmCompleted = false;
+        try {
+          const metadataPath = getMetadataFilePath(cwd);
+          if (fs.existsSync(metadataPath)) {
+            const content = fs.readFileSync(metadataPath, 'utf8');
+            const metadata = JSON.parse(content);
+            swarmCompleted = metadata.state === 'done' || metadata.state === 'failed';
+          }
+        } catch {
+          // If we can't read metadata, assume swarm is still running → use minimal reminder
+        }
+
+        if (swarmCompleted) {
+          // Swarm finished — show full routing table with swarm-prefixed agents
+          const reminder = `**REMINDER**: You MUST USE subagents to preserve your context window for ongoing conversation.
+
+| Request Type | Action |
+|--------------|--------|
+| Trivial (quick answer, single-line fix) | Handle directly |
+| Bug investigation / analysis - ESPECIALLY INVOLVING 3rd PARTY APIs/LIBRARIES | \`@agent-iloom-swarm-issue-analyzer\` → present findings → offer to fix |
+| Code changes | \`@agent-iloom-swarm-issue-implementer\` - TELL THE AGENT NOT TO MAKE/UPDATE ISSUE COMMENTS TO AVOID POLLUTION |
+| On 3rd repeated attempt at fixing the same problem | \`@agent-iloom-swarm-issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm-issue-implementer\` - DO NOT PROVIDE ADDITIONAL GUIDANCE ABOUT ISSUE COMMENTS |
+| New features / complex changes | \`@agent-iloom-swarm-issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm-issue-implementer\` - IN THIS CASE IT'S OK TO CREATE/UPDATE ISSUE COMMENTS |
+| Deep questions (how/why something works) | \`@agent-iloom-swarm-issue-analyzer\` |
+| Code review request | \`@agent-iloom-swarm-code-reviewer\` |`;
+          const output = {
+            hookSpecificOutput: {
+              hookEventName: 'UserPromptSubmit',
+              additionalContext: reminder
+            }
+          };
+          console.log(JSON.stringify(output));
+          debug('UserPromptSubmit: swarm completed, output full swarm routing reminder');
+          process.exit(0);
+        }
+
+        // Swarm still in progress — agents handle their own workflow, only remind about code reviewer
         const swarmReminder = `**REMINDER**: When the user requests a code review, use \`@agent-iloom-code-reviewer\`.`;
         const output = {
           hookSpecificOutput: {
@@ -318,7 +356,7 @@ async function main() {
           }
         };
         console.log(JSON.stringify(output));
-        debug('UserPromptSubmit: swarm mode, output code reviewer reminder');
+        debug('UserPromptSubmit: swarm in progress, output code reviewer reminder');
         process.exit(0);
       }
 

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -199,7 +199,16 @@ If both fail, mark the child as `failed` with the error and skip spawning.
 
 **Do NOT use `il start` to create worktrees. Worktrees are created by this orchestrator via `git worktree add`.**
 
-#### Step 2.2b: Spawn the Child Agent
+#### Step 2.2b: Capture Pre-Wave Commit and Spawn the Child Agent
+
+**Before spawning this wave**, capture the current epic branch HEAD so the wave verifier can diff only the changes introduced by this wave:
+
+```bash
+cd "{{EPIC_WORKTREE_PATH}}"
+PRE_WAVE_COMMIT=$(git rev-parse HEAD)
+```
+
+Save `PRE_WAVE_COMMIT` — you will pass it to any verification agents spawned for this wave.
 
 **Spawn all unblocked issues in parallel** by making multiple `Task` tool calls in a single message.
 
@@ -242,6 +251,8 @@ The prompt for each verification agent should be exactly:
 ```
 Issue: #<child-number>
 Worktree: <child-worktree-path>
+Epic Worktree: {{EPIC_WORKTREE_PATH}}
+Pre-wave commit: <PRE_WAVE_COMMIT>
 
 IMPORTANT: Your working directory is <child-worktree-path>. Run `cd <child-worktree-path>` as your FIRST action before doing ANY work.
 ```
@@ -397,7 +408,9 @@ If the `il cleanup` command fails, log the error but continue with the orchestra
 After a child completes:
 1. Remove the completed child's issue number from all other children's `blockedBy` lists
 2. Check if any previously blocked children are now unblocked (empty `blockedBy` list)
-3. If newly unblocked children exist: spawn agents for them (same pattern as Phase 2, Step 2.2)
+3. If newly unblocked children exist:
+   - Capture a fresh `PRE_WAVE_COMMIT` before spawning (same as Step 2.2b)
+   - Spawn agents for them (same pattern as Phase 2, Step 2.2)
 
 {{#if DRAFT_PR_MODE}}
 {{#if AUTO_COMMIT_PUSH}}
@@ -476,7 +489,7 @@ git log --oneline -5
 ```
 Run a full code review of the integrated epic branch.
 
-You are in the epic worktree at `{{EPIC_WORKTREE_PATH}}`. All child agents' work has been merged into this branch.
+You are in the epic worktree at `{{EPIC_WORKTREE_PATH}}`. All child agents' work has been merged into this branch. Individual file changes have already been reviewed per-wave. Focus on cross-wave integration concerns: duplicate implementations across child issues, inconsistent patterns where children touched the same areas, conflicts introduced by combining waves.
 
 Report the full review results, including all findings with their confidence scores, file locations, and recommendations.
 - If no issues found, report "No issues found."
@@ -635,3 +648,7 @@ Mark todo #9, #10, #11, and #12 as completed.
 Mark todo #9, #10, and #11 as completed.
 {{/if}}
 {{/if}}
+
+### Step 5.5: Mark Epic as Complete
+
+Call `mcp__recap__set_loom_state` with `{ "state": "done" }` (omit `worktreePath` — this targets the epic loom itself). This lets the iloom hook detect swarm completion and show appropriate agent guidance for follow-up questions.


### PR DESCRIPTION
## Summary

- Hook reads epic loom `state` from metadata on `UserPromptSubmit` events when `ILOOM_SWARM=1`
- If state is `done` or `failed` (swarm finished), injects full agent routing table with `iloom-swarm-*` prefixed agents
- If swarm is still running, shows existing minimal code reviewer reminder
- Orchestrator prompt adds Step 5.5 to call `set_loom_state` with `done` on the epic after printing the swarm summary

## Test plan

- [ ] Run a swarm to completion and verify follow-up prompts show the full routing table
- [ ] Verify prompts during an active swarm still show only the minimal reminder