### PR TITLE
feat(wave-verifier): add code review step to wave verification

### DIFF
--- a/src/lib/SwarmSetupService.test.ts
+++ b/src/lib/SwarmSetupService.test.ts
@@ -701,6 +701,153 @@ describe('SwarmSetupService', () => {
 
 	})
 
+	describe('renderSwarmWaveVerifierAgent', () => {
+		it('passes review template variables to loadAgents', async () => {
+			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
+				agents: {
+					'iloom-code-reviewer': {
+						enabled: true,
+						providers: { claude: 'opus', gemini: 'pro', codex: 'o3' },
+					},
+				},
+			} as unknown as IloomSettings)
+
+			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
+				'iloom-wave-verifier': {
+					description: 'Wave verifier',
+					prompt: 'Verify things',
+					model: 'sonnet',
+				},
+			})
+
+			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({
+					SWARM_MODE: true,
+					EPIC_WORKTREE_PATH: '/Users/dev/project-epic-610',
+					REVIEW_ENABLED: true,
+					REVIEW_CLAUDE_MODEL: 'opus',
+					HAS_REVIEW_CLAUDE: true,
+					REVIEW_GEMINI_MODEL: 'pro',
+					HAS_REVIEW_GEMINI: true,
+					REVIEW_CODEX_MODEL: 'o3',
+					HAS_REVIEW_CODEX: true,
+				}),
+				['iloom-wave-verifier.md'],
+			)
+		})
+
+		it('writes agent file with frontmatter and prompt body', async () => {
+			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
+				'iloom-wave-verifier': {
+					description: 'Wave verification agent',
+					prompt: 'Verify the wave integration',
+					model: 'sonnet',
+				},
+			})
+
+			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+				(call) => (call[0] as string).endsWith('iloom-swarm-wave-verifier.md'),
+			)?.[1] as string
+
+			expect(writtenContent).toContain('name: iloom-swarm-wave-verifier')
+			expect(writtenContent).toContain('description: Wave verification agent')
+			expect(writtenContent).toContain('model: sonnet')
+			expect(writtenContent).toContain('Verify the wave integration')
+		})
+
+		it('uses model from settings when configured', async () => {
+			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce({
+				agents: {
+					'iloom-wave-verifier': { model: 'opus' },
+				},
+			} as unknown as IloomSettings)
+
+			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
+				'iloom-wave-verifier': {
+					description: 'Wave verifier',
+					prompt: 'Verify things',
+					model: 'sonnet',
+				},
+			})
+
+			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+				(call) => (call[0] as string).endsWith('iloom-swarm-wave-verifier.md'),
+			)?.[1] as string
+
+			expect(writtenContent).toContain('model: opus')
+		})
+
+		it('includes tools in frontmatter when agent defines them', async () => {
+			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
+				'iloom-wave-verifier': {
+					description: 'Wave verifier',
+					prompt: 'Verify things',
+					model: 'sonnet',
+					tools: ['Bash', 'Read', 'Grep'],
+				},
+			})
+
+			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+				(call) => (call[0] as string).endsWith('iloom-swarm-wave-verifier.md'),
+			)?.[1] as string
+
+			expect(writtenContent).toContain('tools: Bash, Read, Grep')
+		})
+
+		it('returns false when wave verifier template is not found', async () => {
+			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({})
+
+			const result = await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			expect(result).toBe(false)
+		})
+
+		it('returns false and logs warning when loadAgents fails', async () => {
+			vi.mocked(mockAgentManager.loadAgents).mockRejectedValueOnce(
+				new Error('Failed to load agents'),
+			)
+
+			const result = await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			expect(result).toBe(false)
+		})
+
+		it('defaults review variables when no agent settings configured', async () => {
+			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValueOnce(null)
+
+			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({
+				'iloom-wave-verifier': {
+					description: 'Wave verifier',
+					prompt: 'Verify things',
+					model: 'sonnet',
+				},
+			})
+
+			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+
+			expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
+				null,
+				expect.objectContaining({
+					REVIEW_ENABLED: true,
+					HAS_REVIEW_CLAUDE: true,
+					REVIEW_CLAUDE_MODEL: 'sonnet',
+					HAS_REVIEW_GEMINI: false,
+					HAS_REVIEW_CODEX: false,
+				}),
+				['iloom-wave-verifier.md'],
+			)
+		})
+	})
+
 	describe('copyAgentsAndSkillsToChildWorktrees', () => {
 		it('copies both .claude/agents/ and .claude/skills/ from epic to each successful child worktree', async () => {
 			const childWorktrees = [

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -412,6 +412,7 @@ export class SwarmSetupService {
 			const templateVariables: TemplateVariables = {
 				SWARM_MODE: true,
 				EPIC_WORKTREE_PATH: epicWorktreePath,
+				...buildReviewTemplateVariables(true, settings?.agents),
 			}
 
 			const agents = await this.agentManager.loadAgents(settings, templateVariables, ['iloom-wave-verifier.md'])

--- a/templates/agents/iloom-code-reviewer.md
+++ b/templates/agents/iloom-code-reviewer.md
@@ -55,6 +55,13 @@ Codex review configured with model: {{REVIEW_CODEX_MODEL}}
 {{#if HAS_REVIEW_CLAUDE}}
 {{#unless HAS_REVIEW_GEMINI}}
 {{#unless HAS_REVIEW_CODEX}}
+### Pre-provided Diff Check
+
+**FIRST**: Check whether the invocation prompt contains a `## Pre-gathered Diff` section.
+
+- **If yes**: Use that diff directly as your working diff. Skip all of Step 0 (diff gathering) and Step 1 (context gathering from git). The diff and CLAUDE.md content have already been provided. Proceed directly to the review execution (Gemini/Codex tool calls or Claude agent instructions).
+- **If no**: Proceed with normal flow below.
+
 ## Claude-Only Configuration Detected
 
 **IMPORTANT: You are a SUBAGENT. You were spawned by an orchestrator (the main Claude session). The orchestrator has the Task tool and can spawn sub-agents - you cannot.**
@@ -264,6 +271,13 @@ Summary: X critical, Y warnings, Z suggestions
 {{!-- GEMINI/CODEX PATH: Agent gathers context and executes reviews --}}
 {{#if HAS_REVIEW_GEMINI}}
 ## Review Process
+
+### Pre-provided Diff Check
+
+**FIRST**: Check whether the invocation prompt contains a `## Pre-gathered Diff` section.
+
+- **If yes**: Use that diff directly as your working diff. Skip all of Step 0 (diff gathering) and Step 1 (context gathering from git). The diff and CLAUDE.md content have already been provided. Proceed directly to the review execution (Gemini/Codex tool calls or Claude agent instructions).
+- **If no**: Proceed with normal Step 0 diff gathering below.
 
 ### Step 0 - Determine What to Review
 
@@ -522,6 +536,13 @@ If ANY critical issues (95-100 confidence) are found from Gemini review:
 {{else}}
 {{#if HAS_REVIEW_CODEX}}
 ## Review Process
+
+### Pre-provided Diff Check
+
+**FIRST**: Check whether the invocation prompt contains a `## Pre-gathered Diff` section.
+
+- **If yes**: Use that diff directly as your working diff. Skip all of Step 0 (diff gathering) and Step 1 (context gathering from git). The diff and CLAUDE.md content have already been provided. Proceed directly to the review execution (Gemini/Codex tool calls or Claude agent instructions).
+- **If no**: Proceed with normal Step 0 diff gathering below.
 
 ### Step 0 - Determine What to Review
 

--- a/templates/agents/iloom-wave-verifier.md
+++ b/templates/agents/iloom-wave-verifier.md
@@ -19,11 +19,16 @@ color: red
 
 You are a wave verification agent. Your job is to check must-have criteria from completed child issues against the codebase, fix failures by invoking the implementer skill, and return a structured pass/fail report.
 
+## Context
+
+- **Epic Worktree Path:** `{{EPIC_WORKTREE_PATH}}`
+
 ## MANDATORY FIRST STEP
 
 1. `cd` to your assigned worktree path (from your invocation prompt)
 2. Call `recap.set_loom_state({ state: "in_progress", worktreePath: "<your-worktree-path>" })`
 3. Parse the child issue numbers from your invocation prompt
+4. Extract the `Epic Worktree` path and `Pre-wave commit` SHA from your invocation prompt (needed for code review in Steps 5-7)
 
 ## Core Workflow
 
@@ -87,7 +92,7 @@ Record each result as:
 
 After verifying all must-haves, post the initial results as a comment on the verifier's own issue:
 
-1. Construct a markdown report using the same format as Step 5, but with only the "Initial" column populated (no "After Fix" column yet since fixes haven't been attempted):
+1. Construct a markdown report using the same format as Step 8, but with only the "Initial" column populated (no "After Fix" column yet since fixes haven't been attempted):
 
 ```markdown
 ## Wave Verification Report
@@ -123,7 +128,7 @@ After verifying all must-haves, post the initial results as a comment on the ver
    - Call `recap.add_artifact` with `type: 'comment'`, `primaryUrl`: the returned comment URL, and `description`: `"Wave verification report"`
    - If in swarm mode, include `worktreePath` in the recap call
 
-**If all must-haves passed** (no failures), the initial report is already the final report. Skip Steps 3 and 4 entirely and proceed to Step 5. The comment does not need updating.
+**If all must-haves passed** (no failures), the initial report is already the final report. Skip Steps 3 and 4 entirely and proceed to Step 5 (code review). The comment does not need updating.
 
 ### Step 3: Fix Failures (if any)
 
@@ -171,7 +176,7 @@ After ALL fix skill invocations have completed:
 
 **Update the verification report comment:**
 
-5. Construct the full report in the Step 5 format (with "After Fix" column populated for previously-failed criteria)
+5. Construct the full report in the Step 8 format (with "After Fix" column populated for previously-failed criteria)
 6. Call `mcp__issue_management__update_comment` with:
    - `commentId`: the ID saved from Step 2.5
    - `number`: your own issue number
@@ -179,7 +184,90 @@ After ALL fix skill invocations have completed:
    - `markupLanguage`: `"GFM"`
 7. Update the recap artifact by calling `recap.add_artifact` again with the same `primaryUrl` (this replaces the existing entry)
 
-### Step 5: Return Structured Report
+### Step 5: Gather Wave Diff for Code Review
+
+1. From the invocation prompt, extract:
+   - `Epic Worktree` path
+   - `Pre-wave commit` SHA
+2. Run: `cd <epic-worktree> && git diff <pre-wave-commit>..HEAD`
+3. Save the diff output
+4. Also gather CLAUDE.md files from the epic worktree for project guidelines (use Glob tool to find all CLAUDE.md files, read them)
+5. **IMPORTANT:** `git diff` does NOT show untracked files. Run `git status --short` in the epic worktree and for any new untracked files added since the pre-wave commit, read them directly using the Read tool
+6. If the diff is empty (no changes since pre-wave commit), skip Steps 6 and 7 entirely — note "No code changes to review" in the report
+
+### Step 6: Run Code Review on Wave Changes
+
+{{#if HAS_REVIEW_GEMINI}}{{else}}{{#if HAS_REVIEW_CODEX}}{{else}}
+*No review providers configured — skipping code review. Configure providers in `.iloom/settings.json` under `agents.iloom-code-reviewer.providers` to enable.*
+{{/if}}{{/if}}
+
+{{#if HAS_REVIEW_GEMINI}}
+Invoke the code reviewer skill with the pre-gathered diff:
+
+/iloom-swarm-code-reviewer "
+## Pre-gathered Diff
+
+The following diff contains all changes made in this wave (from pre-wave commit to current epic branch HEAD). Use this diff directly — do NOT run git commands to gather your own diff.
+
+\`\`\`diff
+<insert full diff from Step 5 here>
+\`\`\`
+
+## CLAUDE.md Guidelines
+
+<insert CLAUDE.md content from Step 5 here>
+
+Run a full code review of these wave changes. You are in swarm mode — do NOT ask the user about findings, return all results directly."
+
+Collect the skill output as the code review findings.
+{{else}}
+{{#if HAS_REVIEW_CODEX}}
+Invoke the code reviewer skill with the pre-gathered diff:
+
+/iloom-swarm-code-reviewer "
+## Pre-gathered Diff
+
+The following diff contains all changes made in this wave (from pre-wave commit to current epic branch HEAD). Use this diff directly — do NOT run git commands to gather your own diff.
+
+\`\`\`diff
+<insert full diff from Step 5 here>
+\`\`\`
+
+## CLAUDE.md Guidelines
+
+<insert CLAUDE.md content from Step 5 here>
+
+Run a full code review of these wave changes. You are in swarm mode — do NOT ask the user about findings, return all results directly."
+
+Collect the skill output as the code review findings.
+{{/if}}
+{{/if}}
+
+### Step 7: Fix Critical Code Review Issues (if any)
+
+If the code review returned findings with confidence 95-100 (Critical):
+
+1. For each critical finding, invoke the fix agent:
+
+/iloom-swarm-issue-implementer "Your working directory is {{EPIC_WORKTREE_PATH}}. cd there before doing any work.
+
+Fix the following critical code review findings in the epic worktree:
+
+<list the specific critical findings with file, line, issue, recommendation>
+
+Fix ONLY these specific issues. Do not refactor or make additional changes beyond what is listed."
+
+2. After fixing, stage and commit from the epic worktree:
+   ```bash
+   cd "{{EPIC_WORKTREE_PATH}}"
+   git add -A
+   git commit -m "fix(review): address critical wave code review findings"
+   ```
+3. Record which issues were fixed
+
+If no critical findings, skip this step.
+
+### Step 8: Return Structured Report
 
 Return the verification report in this exact format:
 
@@ -219,6 +307,22 @@ Return the verification report in this exact format:
   - Fix result: Partial — file created but still failing
 
 *(If no fix skills were invoked: "None — all must-haves passed on initial verification.")*
+
+### Code Review
+
+{{#if HAS_REVIEW_GEMINI}}
+- **Findings**: X critical, Y warnings
+- **Auto-fixed**: N critical issues
+- **Remaining**: Z issues require manual attention
+{{else}}
+{{#if HAS_REVIEW_CODEX}}
+- **Findings**: X critical, Y warnings
+- **Auto-fixed**: N critical issues
+- **Remaining**: Z issues require manual attention
+{{else}}
+- **Status**: Skipped (no review providers configured)
+{{/if}}
+{{/if}}
 
 ### Overall Status: [ALL_PASSED | ALL_FIXED | PARTIALLY_FIXED | FAILURES_REMAIN]
 

--- a/templates/prompts/plan-prompt.txt
+++ b/templates/prompts/plan-prompt.txt
@@ -308,6 +308,8 @@ Each child issue should include ONLY these sections:
    - `substantive: <file-path> — <what it should contain or export>` — the file has expected content, exports, or structure
    - `wired: <file-path> — <how it should be integrated>` — the code is properly connected to the rest of the system (e.g., registered in a router, imported by a parent module, called from an entry point)
 
+   For replacement or migration work, the `substantive` check type means "equivalent to the original in observable terms" — not just "file has expected content or exports." Specify what observable behavior or output the file must reproduce from the original.
+
    Example:
    ```
    ## Must-Haves
@@ -316,6 +318,14 @@ Each child issue should include ONLY these sections:
    - wired: src/lib/WaveVerifier.ts — imported and invoked in src/commands/finish.ts
    ```
 {{/if}}
+
+**Acceptance Criteria Quality Rules:**
+
+- **Observable over structural**: Criteria must describe what a user or developer can observe by using the app or running a command — not what exists in code. "A user can log in and make an authenticated API call that returns data" not "Auth module is configured with Cognito credentials." If you can't verify the criterion without reading source code, rewrite it.
+- **Replacement work requires comparison criteria**: When an issue replaces or rewrites existing functionality, at least one acceptance criterion must define equivalence to the original in observable terms — visual appearance, feature set, and behavior. Specify which dimensions must match. "Has a login form" is not a replacement criterion; "Login page renders with the same layout, branding, interactive features, and error states as the existing page" is.
+- **Integration points need cross-boundary criteria**: When work involves two systems communicating (shared auth, data passing between frameworks, synchronized state), at least one criterion must verify behavior across the boundary — not just that each side is configured. Pattern: "Action in system A produces expected result in system B."
+- **Criteria must specify the verification context**: State the conditions under which the criterion is verified. If the work must function within a specific environment (inside an existing app's layout, behind a specific auth flow, on a single dev server), the criterion must say so. "Works" is ambiguous; "works when run via the project's standard dev command on a single port" is not.
+- **Include constraint criteria for shared systems**: When work modifies or integrates with a shared system, at least one criterion must verify that existing behavior is preserved. "All existing pages/features continue to function unchanged" catches regressions that purely additive criteria miss.
 
 Do NOT add "Implementation Details", "Technical Approach", or similar sections — these violate the rule above.
 
@@ -355,8 +365,9 @@ Before presenting the plan to the user, audit it against these questions:
 1. **For each blocking dependency:** "Can I replace this with a shared contract so both issues run in parallel?" If yes, rewrite the issues with an explicit contract and remove the dependency.
 2. **DAG shape check:** Is the graph wide and shallow, or narrow and linear? If your longest chain is more than 2 deep, re-examine whether intermediate dependencies are truly hard blockers.
 3. **Contract completeness:** Does every issue that produces or consumes a shared API specify the exact contract (function signatures, types, module exports) in its description?
+4. **Acceptance criteria observability:** For each acceptance criterion, ask: can this be verified by using the app or running a command, without reading source code? If not, rewrite it.
 {{#if WAVE_VERIFICATION}}
-4. **Wave verification tasks:** Does every wave boundary have a verification child issue? Count your waves — if you have N waves, you need N verification issues (one after each wave, including a final one). If any wave boundary is missing a verification issue, add one now. This is mandatory, not optional.
+5. **Wave verification tasks:** Does every wave boundary have a verification child issue? Count your waves — if you have N waves, you need N verification issues (one after each wave, including a final one). If any wave boundary is missing a verification issue, add one now. This is mandatory, not optional.
 {{/if}}
 
 {{#if WAVE_VERIFICATION}}


### PR DESCRIPTION
## Summary

- Add code review Steps 5-7 to wave verifier: gather wave diff, invoke code reviewer, auto-fix critical findings
- Add "Pre-provided Diff Check" to code reviewer agent so it skips diff gathering when invoked from the verifier with a pre-gathered diff
- Pass `buildReviewTemplateVariables` to wave verifier rendering in `SwarmSetupService` so review provider conditionals resolve correctly
- Enhance plan prompt with acceptance criteria quality rules (observable over structural, replacement comparison, cross-boundary, verification context, constraint criteria)

## Test plan

- [x] Existing tests pass (pre-commit hook ran lint, compile, tests, build)
- [x] New tests for `renderSwarmWaveVerifierAgent` with review template variables
- [ ] Manual: run a swarm with wave verification and Gemini/Codex review configured — verify code review runs after must-have checks