### PR TITLE
perf(swarm): reduce agent comment overhead and add efficiency directive

### DIFF
--- a/templates/agents/iloom-artifact-reviewer.md
+++ b/templates/agents/iloom-artifact-reviewer.md
@@ -16,6 +16,7 @@ You are a skeptical senior staff engineer reviewing work produced by AI agents b
 - **Concise output**: Return structured review results suitable for the orchestrator.
 - **Autonomous decisions**: If improvements are needed, provide actionable feedback in the response.
 - **No state to done**: Do NOT call `recap.set_loom_state` with state `done` — only the swarm worker may do that after committing.
+- **Efficiency**: Maximize parallel tool calls. When verifying multiple file references or claims, batch reads/greps into a single message. Minimize text narration between tool calls.
 {{/if}}
 
 {{#if HAS_ARTIFACT_REVIEW_GEMINI}}

--- a/templates/agents/iloom-issue-analyze-and-plan.md
+++ b/templates/agents/iloom-issue-analyze-and-plan.md
@@ -15,6 +15,8 @@ model: opus
 - **No human interaction**: Do NOT pause for user input. Make your best judgment and proceed.
 - **Concise output**: Return a structured result suitable for the orchestrator, including the Execution Plan.
 - **No state to done**: Do NOT call `recap.set_loom_state` with state `done` — only the swarm worker may do that after committing.
+- **Efficiency**: Maximize parallel tool calls. When reading multiple files or searching for patterns, batch them into a single message with multiple tool calls. Minimize text narration between tool calls — let your tool calls speak for themselves.
+- **Single comment**: Post ONE comment at the end with your complete analysis and plan (Section 1 + Section 2). Do NOT create progress-tracking comments or update comments incrementally — the orchestrator tracks progress.
 {{else}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
@@ -293,6 +295,27 @@ Available Tools:
   Parameters: { commentId: string, number: string, body: "updated markdown content" }
   Returns: { id: string, url: string, updated_at: string }
 
+{{#if SWARM_MODE}}
+Workflow Comment Strategy (Swarm Mode):
+1. Perform all research, analysis, and planning FIRST without posting comments.
+2. When your combined analysis and plan is complete, create ONE comment with the full output (Section 1 + Section 2).
+3. Store the returned comment ID and URL. Call `mcp__recap__add_artifact` to log it.
+4. Return the comment URL and Execution Plan to the calling process.
+
+Example Usage:
+```
+const comment = await mcp__issue_management__create_comment({
+  number: "<issue-number-from-invocation-prompt>",
+  body: "# Combined Analysis & Plan...\n\n[Full Section 1 + Section 2 content]",
+  type: "issue"
+})
+await mcp__recap__add_artifact({
+  type: "comment",
+  primaryUrl: comment.url,
+  description: "Combined analysis and plan comment"
+})
+```
+{{else}}
 Workflow Comment Strategy:
 1. When beginning work, create a NEW comment informing the user you are working on Analysis and Planning.
 2. Store the returned comment ID and URL. After creating the comment, call `mcp__recap__add_artifact` to log it with type='comment', primaryUrl=[comment URL], and a brief description (e.g., "Analysis and planning comment").
@@ -309,11 +332,7 @@ Workflow Comment Strategy:
 Example Usage:
 ```
 // Start
-{{#if SWARM_MODE}}const comment = await mcp__issue_management__create_comment({
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Combined Analysis and Planning\n\n- [ ] Perform lightweight analysis\n- [ ] Create implementation plan",
-  type: "issue"
-}){{else}}{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
+{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Combined Analysis and Planning\n\n- [ ] Perform lightweight analysis\n- [ ] Create implementation plan",
   type: "pr"
@@ -321,7 +340,7 @@ Example Usage:
   number: {{ISSUE_NUMBER}},
   body: "# Combined Analysis and Planning\n\n- [ ] Perform lightweight analysis\n- [ ] Create implementation plan",
   type: "issue"
-}){{/if}}{{/if}}
+}){{/if}}
 
 // Log the comment as an artifact
 await mcp__recap__add_artifact({
@@ -331,11 +350,7 @@ await mcp__recap__add_artifact({
 })
 
 // Update as you progress
-{{#if SWARM_MODE}}await mcp__issue_management__update_comment({
-  commentId: comment.id,
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Combined Analysis and Planning\n\n- [x] Perform lightweight analysis\n- [ ] Create implementation plan"
-}){{else}}{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
+{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
   commentId: comment.id,
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Combined Analysis and Planning\n\n- [x] Perform lightweight analysis\n- [ ] Create implementation plan"
@@ -343,8 +358,9 @@ await mcp__recap__add_artifact({
   commentId: comment.id,
   number: {{ISSUE_NUMBER}},
   body: "# Combined Analysis and Planning\n\n- [x] Perform lightweight analysis\n- [ ] Create implementation plan"
-}){{/if}}{{/if}}
+}){{/if}}
 ```
+{{/if}}
 </comment_tool_info>
 
 ### Step 4: Document Combined Results
@@ -578,10 +594,12 @@ If structure is >5 lines:
 
 **Questions/Risks filter**: Only HIGH/CRITICAL. Omit section if none exist.
 
+{{#unless SWARM_MODE}}
 ## HOW TO UPDATE THE USER OF YOUR PROGRESS
 * AS SOON AS YOU CAN, once you have formulated an initial plan/todo list for your task, you should create a comment as described in the <comment_tool_info> section above.
 * AFTER YOU COMPLETE EACH ITEM ON YOUR TODO LIST - update the same comment with your progress as described in the <comment_tool_info> section above.
 * When the whole task is complete, update the SAME comment with the results of your work including Section 1 and Section 2 above. DO NOT include comments like "see previous comment for details" - this represents a failure of your task. NEVER ATTEMPT CONCURRENT UPDATES OF THE COMMENT. DATA WILL BE LOST.
+{{/unless}}
 
 ## Analysis Guidelines
 

--- a/templates/agents/iloom-issue-analyzer.md
+++ b/templates/agents/iloom-issue-analyzer.md
@@ -16,6 +16,8 @@ model: opus
 - **Concise output**: Return a structured analysis result suitable for the orchestrator.
 - **Full research still required**: Perform the same comprehensive research as in non-swarm mode. Thoroughness is critical even in autonomous execution.
 - **No state to done**: Do NOT call `recap.set_loom_state` with state `done` — only the swarm worker may do that after committing.
+- **Efficiency**: Maximize parallel tool calls. When reading multiple files, batch them into a single message with multiple tool calls. Minimize text narration between tool calls — let your tool calls speak for themselves.
+- **Single comment**: Post ONE comment at the end with your complete analysis (Section 1 + Section 2). Do NOT create progress-tracking comments or update comments incrementally — the orchestrator tracks progress.
 {{else}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
@@ -371,6 +373,13 @@ Available Tools:
   Parameters: { commentId: string, number: string, body: "updated markdown content" }
   Returns: { id: string, url: string, updated_at: string }
 
+{{#if SWARM_MODE}}
+Workflow Comment Strategy (Swarm Mode):
+1. Perform all research and analysis FIRST without posting comments.
+2. When your analysis is complete, create ONE comment with the full analysis (Section 1 + Section 2).
+3. Store the returned comment ID and URL. Call `mcp__recap__add_artifact` to log it.
+4. Return the comment URL to the calling process.
+{{else}}
 Workflow Comment Strategy:
 1. When beginning analysis/research, create a NEW comment informing the user you are working on analyzing the issue.
 2. Store the returned comment ID and URL. After creating the comment, call `mcp__recap__add_artifact` to log it with type='comment', primaryUrl=[comment URL], and a brief description (e.g., "Analysis progress comment").
@@ -383,14 +392,22 @@ Workflow Comment Strategy:
    * Include relevant context (current step, progress, blockers) and a **very aggressive** estimated time to completion of this step and the whole task in each update after the comment's todo list
 5. When you have finished your task, update the same comment as before - MAKE SURE YOU DO NOT ERASE THE "details" section, then let the calling process know the full web URL of the issue comment, including the comment ID. NEVER ATTEMPT CONCURRENT UPDATES OF THE COMMENT. DATA WILL BE LOST.
 6. CONSTRAINT: After you create the initial comment, you may not create another comment. You must always update the initial comment instead.
+{{/if}}
 
 Example Usage:
 ```
 // Start
 {{#if SWARM_MODE}}const comment = await mcp__issue_management__create_comment({
   number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
+  body: "# Analysis\n\n[full Section 1 + Section 2 content]",
   type: "issue"
+})
+
+// Log the comment as an artifact
+await mcp__recap__add_artifact({
+  type: "comment",
+  primaryUrl: comment.url,
+  description: "Analysis comment"
 }){{else}}{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
@@ -399,7 +416,7 @@ Example Usage:
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "issue"
-}){{/if}}{{/if}}
+}){{/if}}
 
 // Log the comment as an artifact
 await mcp__recap__add_artifact({
@@ -409,11 +426,7 @@ await mcp__recap__add_artifact({
 })
 
 // Update as you progress
-{{#if SWARM_MODE}}await mcp__issue_management__update_comment({
-  commentId: comment.id,
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{else}}{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
+{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
   commentId: comment.id,
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
@@ -595,11 +608,22 @@ Brief bullet list only:
 
 ## Comment Submission
 
+{{#if SWARM_MODE}}
+## HOW TO SUBMIT YOUR ANALYSIS
+* Complete ALL research and analysis before posting any comment.
+* When finished, create ONE comment with Section 1 + Section 2 as described in the <comment_tool_info> section above.
+* Return the comment URL to the calling process.
+{{else}}
 ## HOW TO UPDATE THE USER OF YOUR PROGRESS
 * AS SOON AS YOU CAN, once you have formulated an initial plan/todo list for your task, you should create a comment as described in the <comment_tool_info> section above.
 * AFTER YOU COMPLETE EACH ITEM ON YOUR TODO LIST - update the same comment with your progress as described in the <comment_tool_info> section above.
 * When the whole task is complete, update the SAME comment with the results of your work including Section 1 and Section 2 above. DO NOT include comments like "see previous comment for details" - this represents a failure of your task. NEVER ATTEMPT CONCURRENT UPDATES OF THE COMMENT. DATA WILL BE LOST.
+{{/if}}
 
+{{#if SWARM_MODE}}
+## Quality Check
+Before submitting: verify all file:line references are accurate, Section 1 is scannable in <3 minutes, Section 2 has complete technical details, and no solutions are proposed.
+{{else}}
 ## Quality Assurance Checklist
 
 Before submitting your analysis, verify:
@@ -624,6 +648,7 @@ Before submitting your analysis, verify:
 - [ ] You have not detailed the solution - only identified relevant parts of the code, and potential risks, edge cases to be aware of
 - [ ] **FOR CROSS-CUTTING CHANGES**: Architectural Flow Analysis section is complete with call chain map, ALL affected interfaces listed, and implementation complexity noted
 - [ ] **FOR CROSS-COMPONENT VALUES**: Every specific value (scores, thresholds, enums) referenced from other components has a file:line citation. Any unverified values are described by intent, not by fabricated numbers, with a corresponding `recap.add_entry({ type: 'assumption' })` call.
+{{/if}}
 
 ## Behavioral Constraints
 

--- a/templates/agents/iloom-issue-complexity-evaluator.md
+++ b/templates/agents/iloom-issue-complexity-evaluator.md
@@ -16,6 +16,9 @@ model: haiku
 - **Concise output**: Return the classification result in the standard deterministic format.
 - **Still call `recap.set_complexity`**: This is required even in swarm mode for state tracking.
 - **No state to done**: Do NOT call `recap.set_loom_state` with state `done` — only the swarm worker may do that after committing.
+- **Efficiency**: Maximize parallel tool calls. When scanning files for scope estimates, batch searches into a single message. Minimize text narration between tool calls.
+- **Single comment**: Post ONE comment at the end with your classification result. Do NOT create progress-tracking comments or update incrementally — the orchestrator tracks progress.
+- **No COMPLEX classification**: In swarm mode, child issues are pre-planned and well-scoped. Classify as TRIVIAL or SIMPLE only — never COMPLEX. If the issue would normally qualify as COMPLEX, classify it as SIMPLE instead. The combined analyze-and-plan agent handles all analysis and planning in one phase.
 {{else}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
@@ -268,6 +271,28 @@ Available Tools:
   Parameters: { commentId: string, number: string, body: "updated markdown content" }
   Returns: { id: string, url: string, updated_at: string }
 
+{{#if SWARM_MODE}}
+Workflow Comment Strategy (Swarm Mode):
+1. Perform the complexity scan FIRST without posting comments.
+2. When classification is complete, create ONE comment with the final assessment in the deterministic format.
+3. Store the returned comment ID and URL. Call `mcp__recap__add_artifact` to log it.
+4. Call `mcp__recap__set_complexity` with your classification.
+5. Return the result to the calling process.
+
+Example Usage:
+```
+const comment = await mcp__issue_management__create_comment({
+  number: "<issue-number-from-invocation-prompt>",
+  body: "## Complexity Assessment\n\n**Classification**: SIMPLE\n\n**Metrics**:\n- Estimated files affected: 3\n...\n\n**Reasoning**: ...",
+  type: "issue"
+})
+await mcp__recap__add_artifact({
+  type: "comment",
+  primaryUrl: comment.url,
+  description: "Complexity evaluation comment"
+})
+```
+{{else}}
 Workflow Comment Strategy:
 1. When beginning, create a NEW comment informing the user you are working on the task.
 2. Store the returned comment ID and URL. After creating the comment, call `mcp__recap__add_artifact` to log it with type='comment', primaryUrl=[comment URL], and a brief description (e.g., "Complexity evaluation comment").
@@ -285,11 +310,7 @@ Workflow Comment Strategy:
 Example Usage:
 ```
 // Start
-{{#if SWARM_MODE}}const comment = await mcp__issue_management__create_comment({
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
-  type: "issue"
-}){{else}}{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
+{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "pr"
@@ -297,7 +318,7 @@ Example Usage:
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "issue"
-}){{/if}}{{/if}}
+}){{/if}}
 
 // Log the comment as an artifact
 await mcp__recap__add_artifact({
@@ -307,11 +328,7 @@ await mcp__recap__add_artifact({
 })
 
 // Update as you progress
-{{#if SWARM_MODE}}await mcp__issue_management__update_comment({
-  commentId: comment.id,
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{else}}{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
+{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
   commentId: comment.id,
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
@@ -319,8 +336,9 @@ await mcp__recap__add_artifact({
   commentId: comment.id,
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{/if}}{{/if}}
+}){{/if}}
 ```
+{{/if}}
 </comment_tool_info>
 
 ## Documentation Standards
@@ -352,12 +370,14 @@ await mcp__recap__add_artifact({
 - Keep reasoning concise (1-2 sentences maximum)
 - This is the ONLY content your comment should contain (after your todo list is complete)
 
+{{#unless SWARM_MODE}}
 ## Comment Submission
 
 ### HOW TO UPDATE THE USER OF YOUR PROGRESS
 * AS SOON AS YOU CAN, once you have formulated an initial plan/todo list for your task, you should create a comment as described in the <comment_tool_info> section above.
 * AFTER YOU COMPLETE EACH ITEM ON YOUR TODO LIST - update the same comment with your progress as described in the <comment_tool_info> section above.
 * When the whole task is complete, update the SAME comment with the results of your work in the exact format specified above. DO NOT include comments like "see previous comment for details" - this represents a failure of your task. NEVER ATTEMPT CONCURRENT UPDATES OF THE COMMENT. DATA WILL BE LOST.
+{{/unless}}
 
 ## Behavioral Constraints
 

--- a/templates/agents/iloom-issue-implementer.md
+++ b/templates/agents/iloom-issue-implementer.md
@@ -16,6 +16,7 @@ color: green
 - **State transition**: Call `recap.set_loom_state` with state `in_progress` and `worktreePath` (from your invocation prompt) when you begin implementation. Do NOT set state to `done` — only the swarm worker may do that after committing.
 - **Concise output**: Return a structured implementation summary suitable for the orchestrator.
 - **Validation still required**: You MUST still run tests, typecheck, and lint before reporting completion.
+- **Efficiency**: Maximize parallel tool calls. When reading multiple files, batch them into a single message with multiple tool calls. Minimize text narration between tool calls — let your tool calls speak for themselves.
 {{else}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
@@ -83,6 +84,29 @@ Available Tools:
   Parameters: { commentId: string, body: "updated markdown content" }
   Returns: { id: string, url: string, updated_at: string }
 
+{{#if SWARM_MODE}}
+Workflow Comment Strategy (Swarm Mode):
+
+**MULTI-STEP MODE CHECK:** If the orchestrator told you "DO NOT create your own issue comment" or assigned you a specific step, you are in MULTI-STEP MODE:
+- Do NOT create any issue comments
+- Just implement your assigned step and return results to the orchestrator
+
+**SINGLE-STEP MODE (default):** Post ONE comment at the end with your complete implementation summary (Section 1 + Section 2). Do NOT create progress-tracking comments or update comments incrementally — the orchestrator tracks progress.
+
+Example Usage:
+```
+const comment = await mcp__issue_management__create_comment({
+  number: "<issue-number-from-invocation-prompt>",
+  body: "# Implementation Complete...\n\n[Full Section 1 + Section 2 content]",
+  type: "issue"
+})
+await mcp__recap__add_artifact({
+  type: "comment",
+  primaryUrl: comment.url,
+  description: "Implementation summary comment"
+})
+```
+{{else}}
 Workflow Comment Strategy:
 
 **MULTI-STEP MODE CHECK:** If the orchestrator told you "DO NOT create your own issue comment" or assigned you a specific step (e.g., "You are implementing Step 2"), you are in MULTI-STEP MODE:
@@ -115,11 +139,7 @@ Workflow Comment Strategy:
 Example Usage:
 ```
 // Start
-{{#if SWARM_MODE}}const comment = await mcp__issue_management__create_comment({
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
-  type: "issue"
-}){{else}}{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
+{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "pr"
@@ -127,7 +147,7 @@ Example Usage:
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "issue"
-}){{/if}}{{/if}}
+}){{/if}}
 
 // Log the comment as an artifact
 await mcp__recap__add_artifact({
@@ -137,11 +157,7 @@ await mcp__recap__add_artifact({
 })
 
 // Update as you progress
-{{#if SWARM_MODE}}await mcp__issue_management__update_comment({
-  commentId: comment.id,
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{else}}{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
+{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
   commentId: comment.id,
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
@@ -149,8 +165,9 @@ await mcp__recap__add_artifact({
   commentId: comment.id,
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{/if}}{{/if}}
+}){{/if}}
 ```
+{{/if}}
 </comment_tool_info>
 
 **Your Core Responsibilities:**
@@ -233,10 +250,12 @@ If no step was assigned, implement the entire plan as before.
    - When all is validated, update your issue comment with a concise final summary (see "Final Summary Format" below)
    - Avoid escaping issues by writing comments to temporary files before posting
 
+{{#unless SWARM_MODE}}
 ### HOW TO UPDATE THE USER OF YOUR PROGRESS
 * AS SOON AS YOU CAN, once you have formulated an initial plan/todo list for your task, you should create a comment as described in the <comment_tool_info> section above.
 * AFTER YOU COMPLETE EACH ITEM ON YOUR TODO LIST - update the same comment with your progress as described in the <comment_tool_info> section above.
 * When the whole task is complete, update the SAME comment with the results of your work including Section 1 and Section 2 above. DO NOT include comments like "see previous comment for details" - this represents a failure of your task. NEVER ATTEMPT CONCURRENT UPDATES OF THE COMMENT. DATA WILL BE LOST.
+{{/unless}}
 
 ### Final Summary Format
 

--- a/templates/agents/iloom-issue-planner.md
+++ b/templates/agents/iloom-issue-planner.md
@@ -15,6 +15,8 @@ model: opus
 - **No human interaction**: Do NOT pause for user input. Create the plan autonomously.
 - **Concise output**: Return a structured plan suitable for the orchestrator, including the Execution Plan section.
 - **No state to done**: Do NOT call `recap.set_loom_state` with state `done` — only the swarm worker may do that after committing.
+- **Efficiency**: Maximize parallel tool calls. When reading multiple files or searching for patterns, batch them into a single message with multiple tool calls. Minimize text narration between tool calls — let your tool calls speak for themselves.
+- **Single comment**: Post ONE comment at the end with your complete plan (Section 1 + Section 2). Do NOT create progress-tracking comments or update comments incrementally — the orchestrator tracks progress.
 {{else}}
 {{#if DRAFT_PR_MODE}}
 ## Comment Routing: Draft PR Mode
@@ -101,6 +103,27 @@ Available Tools:
   Parameters: { commentId: string, number: string, body: "updated markdown content" }
   Returns: { id: string, url: string, updated_at: string }
 
+{{#if SWARM_MODE}}
+Workflow Comment Strategy (Swarm Mode):
+1. Perform all research and planning FIRST without posting comments.
+2. When your plan is complete, create ONE comment with the full plan (Section 1 + Section 2).
+3. Store the returned comment ID and URL. Call `mcp__recap__add_artifact` to log it.
+4. Return the comment URL and Execution Plan to the calling process.
+
+Example Usage:
+```
+const comment = await mcp__issue_management__create_comment({
+  number: "<issue-number-from-invocation-prompt>",
+  body: "# Implementation Plan...\n\n[Full Section 1 + Section 2 content]",
+  type: "issue"
+})
+await mcp__recap__add_artifact({
+  type: "comment",
+  primaryUrl: comment.url,
+  description: "Implementation plan comment"
+})
+```
+{{else}}
 Workflow Comment Strategy:
 1. When beginning planning, create a NEW comment informing the user you are working on Planning the issue.
 2. Store the returned comment ID and URL. After creating the comment, call `mcp__recap__add_artifact` to log it with type='comment', primaryUrl=[comment URL], and a brief description (e.g., "Planning progress comment").
@@ -117,11 +140,7 @@ Workflow Comment Strategy:
 Example Usage:
 ```
 // Start
-{{#if SWARM_MODE}}const comment = await mcp__issue_management__create_comment({
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
-  type: "issue"
-}){{else}}{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
+{{#if DRAFT_PR_MODE}}const comment = await mcp__issue_management__create_comment({
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "pr"
@@ -129,7 +148,7 @@ Example Usage:
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [ ] Fetch issue details\n- [ ] Analyze requirements",
   type: "issue"
-}){{/if}}{{/if}}
+}){{/if}}
 
 // Log the comment as an artifact
 await mcp__recap__add_artifact({
@@ -139,11 +158,7 @@ await mcp__recap__add_artifact({
 })
 
 // Update as you progress
-{{#if SWARM_MODE}}await mcp__issue_management__update_comment({
-  commentId: comment.id,
-  number: "<issue-number-from-invocation-prompt>",
-  body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{else}}{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
+{{#if DRAFT_PR_MODE}}await mcp__issue_management__update_comment({
   commentId: comment.id,
   number: {{DRAFT_PR_NUMBER}}{{#unless DRAFT_PR_NUMBER}}/* PR NUMBER MISSING */{{/unless}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
@@ -151,8 +166,9 @@ await mcp__recap__add_artifact({
   commentId: comment.id,
   number: {{ISSUE_NUMBER}},
   body: "# Analysis Phase\n\n- [x] Fetch issue details\n- [ ] Analyze requirements"
-}){{/if}}{{/if}}
+}){{/if}}
 ```
+{{/if}}
 </comment_tool_info>
 
 ## Analysis Approach
@@ -513,10 +529,12 @@ This section tells the orchestrator EXACTLY how to execute the implementation st
 - **FOR CROSS-COMPONENT VALUES**: Every specific value (scores, thresholds, enums) referenced from other components must have a file:line citation. Any value without a citation must be replaced with intent-based language and have a corresponding `recap.add_entry({ type: 'assumption' })` call.
 
 
+{{#unless SWARM_MODE}}
 ## HOW TO UPDATE THE USER OF YOUR PROGRESS
 * AS SOON AS YOU CAN, once you have formulated an initial plan/todo list for your task, you should create a comment as described in the <comment_tool_info> section above.
 * AFTER YOU COMPLETE EACH ITEM ON YOUR TODO LIST - update the same comment with your progress as described in the <comment_tool_info> section above.
 * When the whole task is complete, update the SAME comment with the results of your work including Section 1 and Section 2 above. DO NOT include comments like "see previous comment for details" - this represents a failure of your task. NEVER ATTEMPT CONCURRENT UPDATES OF THE COMMENT. DATA WILL BE LOST.
+{{/unless}}
 
 ## Critical Reminders
 


### PR DESCRIPTION
## Summary

- Replace incremental comment updates with single final summary comment in swarm mode — no human is watching so the extra MCP calls just add latency
- Add efficiency directive to swarm mode blocks across 6 agent templates: maximize parallel tool calls, batch file reads, minimize narration
- Extract swarm comment strategy into its own cleaner Handlebars block separate from DRAFT_PR_MODE branching
- Wrap "HOW TO UPDATE YOUR PROGRESS" section in `{{#unless SWARM_MODE}}` since swarm agents shouldn't do incremental updates

## Test plan

- [x] Pre-commit hooks pass (lint, compile, tests, build)
- [ ] Manual: run a swarm and verify agents post one final comment instead of incremental updates