### PR TITLE
fix(plan): tell plan agent which issue tracker and VCS are configured

### DIFF
--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -214,6 +214,94 @@ describe('PlanCommand', () => {
 		})
 	})
 
+	describe('Issue tracker and VCS provider variables', () => {
+		it('should pass github tracker variables by default', async () => {
+			await command.execute()
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({
+					ISSUE_TRACKER: 'github',
+					IS_GITHUB_TRACKER: true,
+					VCS_PROVIDER: 'github',
+					IS_GITHUB_VCS: true,
+				})
+			)
+		})
+
+		it('should pass linear tracker with github VCS when configured', async () => {
+			const { SettingsManager } = await import('../lib/SettingsManager.js')
+			vi.mocked(SettingsManager).mockImplementation(() => ({
+				loadSettings: vi.fn().mockResolvedValue({ issueManagement: { provider: 'linear' } }),
+				getPlanModel: vi.fn().mockReturnValue('opus'),
+				getPlanPlanner: vi.fn().mockReturnValue('claude'),
+				getPlanReviewer: vi.fn().mockReturnValue('none'),
+				getPlanWaveVerification: vi.fn().mockReturnValue(true),
+			}) as unknown as InstanceType<typeof SettingsManager>)
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('linear')
+			command = new PlanCommand(mockTemplateManager, mockAgentManager as unknown as AgentManager)
+
+			await command.execute()
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({
+					ISSUE_TRACKER: 'linear',
+					IS_GITHUB_TRACKER: false,
+					VCS_PROVIDER: 'github',
+					IS_GITHUB_VCS: true,
+				})
+			)
+		})
+
+		it('should pass jira tracker when configured', async () => {
+			const { SettingsManager } = await import('../lib/SettingsManager.js')
+			vi.mocked(SettingsManager).mockImplementation(() => ({
+				loadSettings: vi.fn().mockResolvedValue({ issueManagement: { provider: 'jira' } }),
+				getPlanModel: vi.fn().mockReturnValue('opus'),
+				getPlanPlanner: vi.fn().mockReturnValue('claude'),
+				getPlanReviewer: vi.fn().mockReturnValue('none'),
+				getPlanWaveVerification: vi.fn().mockReturnValue(true),
+			}) as unknown as InstanceType<typeof SettingsManager>)
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('jira')
+			command = new PlanCommand(mockTemplateManager, mockAgentManager as unknown as AgentManager)
+
+			await command.execute()
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({
+					ISSUE_TRACKER: 'jira',
+					IS_GITHUB_TRACKER: false,
+				})
+			)
+		})
+
+		it('should pass bitbucket VCS when configured', async () => {
+			const { SettingsManager } = await import('../lib/SettingsManager.js')
+			vi.mocked(SettingsManager).mockImplementation(() => ({
+				loadSettings: vi.fn().mockResolvedValue({
+					versionControl: { provider: 'bitbucket' },
+				}),
+				getPlanModel: vi.fn().mockReturnValue('opus'),
+				getPlanPlanner: vi.fn().mockReturnValue('claude'),
+				getPlanReviewer: vi.fn().mockReturnValue('none'),
+				getPlanWaveVerification: vi.fn().mockReturnValue(true),
+			}) as unknown as InstanceType<typeof SettingsManager>)
+			command = new PlanCommand(mockTemplateManager, mockAgentManager as unknown as AgentManager)
+
+			await command.execute()
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({
+					VCS_PROVIDER: 'bitbucket',
+					IS_GITHUB_VCS: false,
+				})
+			)
+		})
+	})
+
 	describe('Claude CLI availability', () => {
 		it('should throw error when Claude CLI is not available', async () => {
 			vi.mocked(claudeUtils.detectClaudeCli).mockResolvedValue(false)

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -445,6 +445,10 @@ export class PlanCommand {
 		const templateVariables: TemplateVariables = {
 			IS_VSCODE_MODE: isVscodeMode,
 			WAVE_VERIFICATION: waveVerification,
+			ISSUE_TRACKER: provider,
+			IS_GITHUB_TRACKER: provider === 'github',
+			VCS_PROVIDER: settings?.versionControl?.provider ?? 'github',
+			IS_GITHUB_VCS: (settings?.versionControl?.provider ?? 'github') === 'github',
 			EXISTING_ISSUE_MODE: !!decompositionContext,
 			FRESH_PLANNING_MODE: !decompositionContext,
 			PARENT_ISSUE_NUMBER: decompositionContext?.identifier,

--- a/src/lib/PromptTemplateManager.ts
+++ b/src/lib/PromptTemplateManager.ts
@@ -118,6 +118,11 @@ export interface TemplateVariables {
 	POST_SWARM_REVIEW?: boolean  // True when post-swarm code review is enabled (defaults to true)
 	ISSUE_PREFIX?: string  // "#" for GitHub, "" for Linear/Jira — used in commit message templates
 	SWARM_TEAM_NAME?: string  // Unique team name for swarm orchestrator (project-epic-timestamp)
+	// Issue tracker and VCS provider context
+	ISSUE_TRACKER?: string  // Configured issue tracker: 'github', 'linear', 'jira'
+	IS_GITHUB_TRACKER?: boolean  // True when issue tracker is GitHub
+	VCS_PROVIDER?: string  // Configured VCS provider: 'github', 'bitbucket'
+	IS_GITHUB_VCS?: boolean  // True when VCS provider is GitHub
 }
 
 /**

--- a/templates/prompts/plan-prompt.txt
+++ b/templates/prompts/plan-prompt.txt
@@ -331,6 +331,21 @@ Do NOT add "Implementation Details", "Technical Approach", or similar sections â
 
 ---
 
+## Issue Tracker
+
+The configured issue tracker for this project is **{{ISSUE_TRACKER}}**.
+
+**All issue operations** (creating issues, fetching issue details, managing dependencies, posting comments) **MUST use the `mcp__issue_management__*` MCP tools** listed below. These tools abstract across tracker backends (GitHub, Linear, Jira) and handle authentication, format conversion, and API differences automatically.
+
+{{#unless IS_GITHUB_TRACKER}}
+**Do NOT use `gh` CLI for issue or project management** (e.g., `gh issue`, `gh search`, `gh project`, `gh api` for issues) â€” the configured tracker is {{ISSUE_TRACKER}}, not GitHub. The `gh` CLI only works with GitHub issues and will fail or return irrelevant results. Use the MCP tools above instead.
+{{#if IS_GITHUB_VCS}}
+`gh` is still available for GitHub VCS operations: `gh pr`, `gh repo`.
+{{/if}}
+{{/unless}}
+
+---
+
 ## Issue Creation
 
 At the end of the planning session, you have MCP tools to create issues:


### PR DESCRIPTION
## Summary

- Pass `ISSUE_TRACKER` and `VCS_PROVIDER` template variables to the plan prompt so the agent knows the configured backends
- Add `IS_GITHUB_TRACKER` and `IS_GITHUB_VCS` boolean flags for conditional template blocks
- Add "Issue Tracker" section to plan prompt that directs the agent to use `mcp__issue_management__*` tools exclusively for issue operations
- For non-GitHub trackers: prohibit `gh issue`/`gh search`/`gh project` commands, but allow `gh pr`/`gh repo` when VCS is GitHub
- Add `TemplateVariables` type definitions for the 4 new fields

## Test plan

- [x] Pre-commit hooks pass (lint, compile, tests, build)
- [x] 4 new tests covering: default GitHub, Linear+GitHub, Jira, Bitbucket VCS
- [ ] Manual: run `il plan` with Linear tracker configured — verify agent uses MCP tools instead of `gh`