### PR TITLE
fix(list): load settings from primary worktree, not cwd

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1107,7 +1107,12 @@ program
       let currentProjectPath: string | null = null
       if (!options.global) {
         try {
-          currentProjectPath = await findMainWorktreePathWithSettings()
+          // Load settings from the primary git worktree (first in porcelain output),
+          // not cwd, so that settings.local.json overrides in child worktrees
+          // don't affect project path resolution
+          const primaryWorktrees = await manager.listWorktrees({ porcelain: true })
+          const primaryPath = primaryWorktrees[0]?.path
+          currentProjectPath = await findMainWorktreePathWithSettings(primaryPath)
         } catch (error) {
           // Only catch expected errors (not in a git repo or settings validation failed)
           // For these cases, we show all looms since we can't determine the current project


### PR DESCRIPTION
## Summary
- **Bug**: `il list` from a child worktree with `settings.local.json` overriding `mainBranch` showed only worktrees without metadata (e.g., `develop` and `develop-react`), filtering out all registered looms
- **Root cause**: `findMainWorktreePathWithSettings()` loaded settings from `process.cwd()`, picking up the child worktree's local override, resolving `currentProjectPath` to the wrong worktree
- **Fix**: Load settings from the primary git worktree (first in porcelain output) so project path resolution is consistent regardless of which worktree you're in

## Test plan
- [x] `il list` from a child worktree with `mainBranch` override in `settings.local.json` now shows all looms
- [x] `il list` from the main worktree still works correctly