### PR TITLE
fix(start): allow branch mode to reuse existing local branches

### DIFF
--- a/src/lib/LoomManager.test.ts
+++ b/src/lib/LoomManager.test.ts
@@ -1472,7 +1472,7 @@ describe('LoomManager', testOptions, () => {
       )
     })
 
-    it('should check branch existence before creating worktree for branches', async () => {
+    it('should reuse existing branch for branch type', async () => {
       vi.mocked(branchExists).mockResolvedValue(true)
 
       const input: CreateLoomInput = {
@@ -1482,10 +1482,18 @@ describe('LoomManager', testOptions, () => {
       }
 
       vi.mocked(mockGitWorktree.generateWorktreePath).mockReturnValue('/test/path')
+      vi.mocked(mockGitWorktree.createWorktree).mockResolvedValue('/test/path')
+      vi.mocked(mockEnvironment.calculatePort).mockReturnValue(3000)
+      vi.mocked(mockClaude.prepareContext).mockResolvedValue()
 
-      await expect(manager.createIloom(input)).rejects.toThrow(
-        /branch .* already exists/
-      )
+      const result = await manager.createIloom(input)
+
+      expect(result.branch).toBe('existing-branch')
+      expect(mockGitWorktree.createWorktree).toHaveBeenCalledWith({
+        path: '/test/path',
+        branch: 'existing-branch',
+        createBranch: false,
+      })
     })
 
     it('should not check branch existence for PRs', async () => {

--- a/src/lib/LoomManager.ts
+++ b/src/lib/LoomManager.ts
@@ -750,9 +750,10 @@ export class LoomManager {
     // is handled separately in draft-pr mode
     const branchExistedLocally = await branchExists(branchName, process.cwd(), false)
 
-    // For non-PRs, throw error if branch exists
+    // For issues, throw error if branch exists (generated branch name collision means stale branch)
+    // For branches, allow reuse — the user explicitly named this branch
     // For PRs, we'll use this to determine if we need to reset later
-    if (input.type !== 'pr' && branchExistedLocally) {
+    if (input.type === 'issue' && branchExistedLocally) {
       throw new Error(
         `Cannot create worktree: branch '${branchName}' already exists. ` +
         `Use 'git branch -D ${branchName}' to delete it first if needed.`
@@ -803,7 +804,7 @@ export class LoomManager {
       await this.gitWorktree.createWorktree({
         path: worktreePath,
         branch: branchName,
-        createBranch: input.type !== 'pr', // PRs use existing branches
+        createBranch: input.type !== 'pr' && !branchExistedLocally, // PRs and existing branches use existing branches
         ...(baseBranch && { baseBranch }),
       })
 


### PR DESCRIPTION
## Summary
- `il start <branch-name>` now reuses an existing local branch instead of throwing an error
- Issue mode still throws on existing branches (auto-generated name collision = stale branch)
- Sets `createBranch: false` when the branch already exists, matching PR behavior

## Test plan
- [x] Updated test: branch mode with existing branch succeeds with `createBranch: false`
- [x] Existing test: issue mode with existing branch still throws
- [x] All 110 LoomManager tests pass
- [x] Pre-commit hooks pass (lint, compile, tests, build)