### PR TITLE
fix(swarm): add plan prerequisite gate and remove dead code

### DIFF
--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -896,8 +896,6 @@ export class IgniteCommand {
 
 		// Create SwarmSetupService
 		const swarmSetup = new SwarmSetupService(
-			this.gitWorktreeManager,
-			metadataManager,
 			this.agentManager,
 			this.settingsManager,
 			this.templateManager,

--- a/src/lib/SwarmSetupService.test.ts
+++ b/src/lib/SwarmSetupService.test.ts
@@ -1,19 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import fs from 'fs-extra'
-import { SwarmSetupService, type SwarmChildIssue } from './SwarmSetupService.js'
-import type { GitWorktreeManager } from './GitWorktreeManager.js'
-import type { MetadataManager, LoomMetadata } from './MetadataManager.js'
+import { SwarmSetupService } from './SwarmSetupService.js'
 import type { AgentManager } from './AgentManager.js'
 import type { SettingsManager, IloomSettings } from './SettingsManager.js'
 import type { PromptTemplateManager } from './PromptTemplateManager.js'
-
-// Mock dependencies
-vi.mock('../utils/claude-trust.js', () => ({
-	preAcceptClaudeTrust: vi.fn().mockResolvedValue(undefined),
-}))
-vi.mock('../utils/package-manager.js', () => ({
-	installDependencies: vi.fn().mockResolvedValue(undefined),
-}))
 
 vi.mock('../utils/logger-context.js', () => ({
 	getLogger: () => ({
@@ -34,76 +24,13 @@ vi.mock('fs-extra', () => ({
 	},
 }))
 
-const { mockGenerateAndWriteMcpConfigFile } = vi.hoisted(() => ({
-	mockGenerateAndWriteMcpConfigFile: vi.fn().mockResolvedValue('/Users/test/.config/iloom-ai/mcp-configs/test.json'),
-}))
-
-vi.mock('../utils/mcp.js', () => ({
-	generateAndWriteMcpConfigFile: mockGenerateAndWriteMcpConfigFile,
-}))
-
-vi.mock('./IssueTrackerFactory.js', () => ({
-	IssueTrackerFactory: {
-		getProviderName: vi.fn().mockReturnValue('github'),
-	},
-}))
-
 describe('SwarmSetupService', () => {
 	let service: SwarmSetupService
-	let mockGitWorktree: GitWorktreeManager
-	let mockMetadataManager: MetadataManager
 	let mockAgentManager: AgentManager
 	let mockSettingsManager: SettingsManager
 	let mockTemplateManager: PromptTemplateManager
 
-	const childIssues: SwarmChildIssue[] = [
-		{ number: '#101', title: 'Child issue 1', body: 'Body 1', url: 'https://github.com/org/repo/issues/101' },
-		{ number: '#102', title: 'Child issue 2', body: 'Body 2', url: 'https://github.com/org/repo/issues/102' },
-	]
-
-	const mockLoomMetadata: LoomMetadata = {
-		description: 'Child issue 1',
-		created_at: '2024-01-01T00:00:00Z',
-		branchName: 'issue/101',
-		worktreePath: '/Users/dev/project__issue-101',
-		issueType: 'issue',
-		issueKey: null,
-		issue_numbers: ['101'],
-		pr_numbers: [],
-		issueTracker: 'github',
-		colorHex: '#808080',
-		sessionId: '',
-		projectPath: '/Users/dev/project',
-		issueUrls: { '101': 'https://github.com/org/repo/issues/101' },
-		prUrls: {},
-		draftPrNumber: null,
-		oneShot: null,
-		capabilities: [],
-		state: 'pending',
-		childIssueNumbers: [],
-		parentLoom: {
-			type: 'epic',
-			identifier: '610',
-			branchName: 'epic/610',
-			worktreePath: '/Users/dev/project-epic-610',
-		},
-		childIssues: [],
-		dependencyMap: {},
-		mcpConfigPath: null,
-	}
-
 	beforeEach(() => {
-		mockGitWorktree = {
-			createWorktree: vi.fn().mockResolvedValue(undefined),
-			removeWorktree: vi.fn().mockResolvedValue(undefined),
-		} as unknown as GitWorktreeManager
-
-		mockMetadataManager = {
-			writeMetadata: vi.fn().mockResolvedValue(undefined),
-			readMetadata: vi.fn().mockResolvedValue(mockLoomMetadata),
-			updateMetadata: vi.fn().mockResolvedValue(undefined),
-		} as unknown as MetadataManager
-
 		mockAgentManager = {
 			loadAgents: vi.fn().mockResolvedValue({
 				'iloom-issue-implementer': {
@@ -124,178 +51,11 @@ describe('SwarmSetupService', () => {
 			getPrompt: vi.fn().mockResolvedValue('# Rendered swarm skill content'),
 		} as unknown as PromptTemplateManager
 
-		// Re-configure mocks after vitest's automatic mockReset
-		mockGenerateAndWriteMcpConfigFile.mockResolvedValue('/Users/test/.config/iloom-ai/mcp-configs/test.json')
-		vi.mocked(fs.pathExists).mockResolvedValue(true as never)
-		vi.mocked(fs.copy).mockResolvedValue(undefined)
-
 		service = new SwarmSetupService(
-			mockGitWorktree,
-			mockMetadataManager,
 			mockAgentManager,
 			mockSettingsManager,
 			mockTemplateManager,
 		)
-	})
-
-	describe('createChildWorktrees', () => {
-		it('creates worktrees for each child issue with standard naming', async () => {
-			const results = await service.createChildWorktrees(
-				childIssues,
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			expect(results).toHaveLength(2)
-			expect(results[0]!.success).toBe(true)
-			expect(results[0]!.issueId).toBe('101')
-			expect(results[0]!.branch).toBe('issue/101')
-			expect(results[1]!.success).toBe(true)
-			expect(results[1]!.issueId).toBe('102')
-			expect(results[1]!.branch).toBe('issue/102')
-		})
-
-		it('creates worktrees branched from the epic branch', async () => {
-			await service.createChildWorktrees(
-				childIssues,
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			expect(mockGitWorktree.createWorktree).toHaveBeenCalledWith(
-				expect.objectContaining({
-					branch: 'issue/101',
-					createBranch: true,
-					baseBranch: 'epic/610',
-				}),
-			)
-		})
-
-		it('writes metadata with state pending and parentLoom reference', async () => {
-			await service.createChildWorktrees(
-				childIssues,
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			expect(mockMetadataManager.writeMetadata).toHaveBeenCalledTimes(2)
-			const firstCall = vi.mocked(mockMetadataManager.writeMetadata).mock.calls[0]
-			const metadataInput = firstCall![1]
-
-			expect(metadataInput.state).toBe('pending')
-			expect(metadataInput.issueType).toBe('issue')
-			expect(metadataInput.issue_numbers).toEqual(['101'])
-			expect(metadataInput.parentLoom).toEqual({
-				type: 'epic',
-				identifier: '610',
-				branchName: 'epic/610',
-				worktreePath: '/Users/dev/project-epic-610',
-			})
-		})
-
-		it('generates MCP config file for each child worktree', async () => {
-			await service.createChildWorktrees(
-				childIssues,
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			// Should be called once per child
-			expect(mockGenerateAndWriteMcpConfigFile).toHaveBeenCalledTimes(2)
-			// Should update metadata with mcpConfigPath
-			expect(mockMetadataManager.updateMetadata).toHaveBeenCalledTimes(2)
-			expect(mockMetadataManager.updateMetadata).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.objectContaining({
-					mcpConfigPath: '/Users/test/.config/iloom-ai/mcp-configs/test.json',
-				}),
-			)
-		})
-
-		it('writes iloom-swarm-mcp-config-path file to .claude/ in each child worktree', async () => {
-			await service.createChildWorktrees(
-				childIssues,
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			// Should write iloom-swarm-mcp-config-path for each child
-			const writeFileCalls = vi.mocked(fs.writeFile).mock.calls
-			const configPathWrites = writeFileCalls.filter(
-				(call) => typeof call[0] === 'string' && (call[0] as string).endsWith('iloom-swarm-mcp-config-path'),
-			)
-			expect(configPathWrites).toHaveLength(2)
-			// Each file should contain just the MCP config path string
-			expect(configPathWrites[0]![1]).toBe('/Users/test/.config/iloom-ai/mcp-configs/test.json')
-			expect(configPathWrites[1]![1]).toBe('/Users/test/.config/iloom-ai/mcp-configs/test.json')
-		})
-
-		it('handles individual worktree creation failures gracefully', async () => {
-			vi.mocked(mockGitWorktree.createWorktree)
-				.mockResolvedValueOnce(undefined)
-				.mockRejectedValueOnce(new Error('Branch already exists'))
-
-			const results = await service.createChildWorktrees(
-				childIssues,
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			expect(results).toHaveLength(2)
-			expect(results[0]!.success).toBe(true)
-			expect(results[1]!.success).toBe(false)
-			expect(results[1]!.error).toBe('Branch already exists')
-		})
-
-		it('cleans up worktree if metadata write fails', async () => {
-			vi.mocked(mockMetadataManager.writeMetadata).mockRejectedValueOnce(new Error('Write failed'))
-
-			const results = await service.createChildWorktrees(
-				[childIssues[0]!],
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			expect(results[0]!.success).toBe(false)
-			expect(mockGitWorktree.removeWorktree).toHaveBeenCalled()
-		})
-
-		it('continues if MCP config generation fails', async () => {
-			mockGenerateAndWriteMcpConfigFile.mockRejectedValueOnce(new Error('MCP config failed'))
-
-			const results = await service.createChildWorktrees(
-				[childIssues[0]!],
-				'epic/610',
-				'/Users/dev/project-epic-610',
-				'/Users/dev/project',
-				'610',
-				'github',
-			)
-
-			// Should still succeed despite MCP config failure
-			expect(results[0]!.success).toBe(true)
-		})
 	})
 
 	describe('renderSwarmAgents', () => {
@@ -848,120 +608,8 @@ describe('SwarmSetupService', () => {
 		})
 	})
 
-	describe('copyAgentsAndSkillsToChildWorktrees', () => {
-		it('copies both .claude/agents/ and .claude/skills/ from epic to each successful child worktree', async () => {
-			const childWorktrees = [
-				{ issueId: '101', worktreePath: '/Users/dev/project__issue-101', branch: 'issue/101', success: true },
-				{ issueId: '102', worktreePath: '/Users/dev/project__issue-102', branch: 'issue/102', success: true },
-			]
-
-			await service.copyAgentsAndSkillsToChildWorktrees('/Users/dev/project-epic-610', childWorktrees)
-
-			// 2 children x 2 directories (agents + skills) = 4 copy calls
-			expect(fs.copy).toHaveBeenCalledTimes(4)
-			expect(fs.copy).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/agents',
-				'/Users/dev/project__issue-101/.claude/agents',
-				{ overwrite: true },
-			)
-			expect(fs.copy).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/skills',
-				'/Users/dev/project__issue-101/.claude/skills',
-				{ overwrite: true },
-			)
-			expect(fs.copy).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/agents',
-				'/Users/dev/project__issue-102/.claude/agents',
-				{ overwrite: true },
-			)
-			expect(fs.copy).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/skills',
-				'/Users/dev/project__issue-102/.claude/skills',
-				{ overwrite: true },
-			)
-		})
-
-		it('skips failed child worktrees', async () => {
-			const childWorktrees = [
-				{ issueId: '101', worktreePath: '/Users/dev/project__issue-101', branch: 'issue/101', success: true },
-				{ issueId: '102', worktreePath: '', branch: '', success: false, error: 'Branch already exists' },
-			]
-
-			await service.copyAgentsAndSkillsToChildWorktrees('/Users/dev/project-epic-610', childWorktrees)
-
-			// 1 child x 2 directories = 2 copy calls
-			expect(fs.copy).toHaveBeenCalledTimes(2)
-		})
-
-		it('skips copy when neither agents nor skills directories exist', async () => {
-			vi.mocked(fs.pathExists).mockResolvedValue(false as never)
-
-			const childWorktrees = [
-				{ issueId: '101', worktreePath: '/Users/dev/project__issue-101', branch: 'issue/101', success: true },
-			]
-
-			await service.copyAgentsAndSkillsToChildWorktrees('/Users/dev/project-epic-610', childWorktrees)
-
-			expect(fs.copy).not.toHaveBeenCalled()
-		})
-
-		it('copies only agents when skills directory does not exist', async () => {
-			vi.mocked(fs.pathExists)
-				.mockResolvedValueOnce(true as never)  // agents exists
-				.mockResolvedValueOnce(false as never)  // skills does not exist
-
-			const childWorktrees = [
-				{ issueId: '101', worktreePath: '/Users/dev/project__issue-101', branch: 'issue/101', success: true },
-			]
-
-			await service.copyAgentsAndSkillsToChildWorktrees('/Users/dev/project-epic-610', childWorktrees)
-
-			expect(fs.copy).toHaveBeenCalledTimes(1)
-			expect(fs.copy).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/agents',
-				'/Users/dev/project__issue-101/.claude/agents',
-				{ overwrite: true },
-			)
-		})
-
-		it('copies only skills when agents directory does not exist', async () => {
-			vi.mocked(fs.pathExists)
-				.mockResolvedValueOnce(false as never)  // agents does not exist
-				.mockResolvedValueOnce(true as never)   // skills exists
-
-			const childWorktrees = [
-				{ issueId: '101', worktreePath: '/Users/dev/project__issue-101', branch: 'issue/101', success: true },
-			]
-
-			await service.copyAgentsAndSkillsToChildWorktrees('/Users/dev/project-epic-610', childWorktrees)
-
-			expect(fs.copy).toHaveBeenCalledTimes(1)
-			expect(fs.copy).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/skills',
-				'/Users/dev/project__issue-101/.claude/skills',
-				{ overwrite: true },
-			)
-		})
-
-		it('continues if copy fails for one child', async () => {
-			vi.mocked(fs.copy)
-				.mockRejectedValueOnce(new Error('Permission denied'))
-				.mockResolvedValue(undefined)
-
-			const childWorktrees = [
-				{ issueId: '101', worktreePath: '/Users/dev/project__issue-101', branch: 'issue/101', success: true },
-				{ issueId: '102', worktreePath: '/Users/dev/project__issue-102', branch: 'issue/102', success: true },
-			]
-
-			await service.copyAgentsAndSkillsToChildWorktrees('/Users/dev/project-epic-610', childWorktrees)
-
-			// Should attempt all copies despite first failure
-			expect(fs.copy).toHaveBeenCalled()
-		})
-	})
-
 	describe('setupSwarm', () => {
-		it('runs full setup: renders agents, worker agent, and verifier agent (no child worktrees)', async () => {
+		it('runs full setup: renders agents, worker agent, and verifier agent', async () => {
 			const result = await service.setupSwarm(
 				'epic/610',
 				'/Users/dev/project-epic-610',
@@ -973,18 +621,6 @@ describe('SwarmSetupService', () => {
 			expect(result.renderedAgents.length).toBeGreaterThan(0)
 			expect(result.workerAgentRendered).toBe(true)
 			expect(result.verifierAgentRendered).toBeDefined()
-		})
-
-		it('does not create child worktrees or copy agents/skills to children', async () => {
-			await service.setupSwarm(
-				'epic/610',
-				'/Users/dev/project-epic-610',
-			)
-
-			// Should NOT have called createWorktree (child worktrees are created on-the-fly by orchestrator)
-			expect(mockGitWorktree.createWorktree).not.toHaveBeenCalled()
-			// Should NOT have checked for agents/skills dirs to copy (no child worktrees to copy to)
-			expect(fs.copy).not.toHaveBeenCalled()
 		})
 
 		it('does not pass SWARM_AGENT_METADATA or MCP_CONFIG_JSON to worker agent', async () => {

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -1,17 +1,10 @@
 import path from 'path'
 import fs from 'fs-extra'
-import { GitWorktreeManager } from './GitWorktreeManager.js'
-import { MetadataManager, type WriteMetadataInput, type SwarmState } from './MetadataManager.js'
 import { AgentManager } from './AgentManager.js'
-import { SettingsManager, type IloomSettings } from './SettingsManager.js'
+import { SettingsManager } from './SettingsManager.js'
 import { PromptTemplateManager, buildReviewTemplateVariables, type TemplateVariables } from './PromptTemplateManager.js'
-import { IssueTrackerFactory } from './IssueTrackerFactory.js'
 import { IssueManagementProviderFactory } from '../mcp/IssueManagementProviderFactory.js'
 import { getLogger } from '../utils/logger-context.js'
-import { preAcceptClaudeTrust } from '../utils/claude-trust.js'
-import { installDependencies } from '../utils/package-manager.js'
-import { generateWorktreePath } from '../utils/git.js'
-import { generateAndWriteMcpConfigFile } from '../utils/mcp.js'
 
 /**
  * Result of the swarm setup process
@@ -26,195 +19,17 @@ export interface SwarmSetupResult {
 }
 
 /**
- * Child issue data as stored in epic metadata
- */
-export interface SwarmChildIssue {
-	number: string   // Prefixed: "#123" for GitHub, "ENG-123" for Linear
-	title: string
-	body: string
-	url: string
-}
-
-/**
- * SwarmSetupService handles the creation of child worktrees
- * for swarm mode, plus rendering swarm-mode agents and skill files.
+ * SwarmSetupService handles rendering swarm-mode agents and skill files.
  *
  * Called from the spin command (ignite.ts) when an epic loom is detected.
  * The epic worktree already exists (created by `il start`).
  */
 export class SwarmSetupService {
 	constructor(
-		private gitWorktree: GitWorktreeManager,
-		private metadataManager: MetadataManager,
 		private agentManager: AgentManager,
 		private settingsManager: SettingsManager,
 		private templateManager: PromptTemplateManager,
 	) {}
-
-	/**
-	 * Create child worktrees for each child issue, branched off the epic branch.
-	 * Writes iloom-metadata.json for each child with state: 'pending' and parentLoom.
-	 * Generates and writes per-loom MCP config file for each child.
-	 *
-	 * Uses standard iloom naming conventions via generateWorktreePath().
-	 *
-	 * @param childIssues - Array of child issues from epic metadata
-	 * @param epicBranch - The epic branch name (base branch for children)
-	 * @param epicWorktreePath - Path to the epic worktree
-	 * @param mainWorktreePath - Path to the main worktree (project root)
-	 * @param epicIssueNumber - The parent epic issue number
-	 * @param issueTrackerName - The issue tracker provider name (e.g., 'github')
-	 * @param settings - Optional settings for MCP config generation
-	 * @returns Array of results for each child worktree creation
-	 */
-	async createChildWorktrees(
-		childIssues: SwarmChildIssue[],
-		epicBranch: string,
-		epicWorktreePath: string,
-		mainWorktreePath: string,
-		epicIssueNumber: string | number,
-		issueTrackerName: string,
-		settings?: IloomSettings,
-	): Promise<Array<{
-		issueId: string
-		worktreePath: string
-		branch: string
-		success: boolean
-		error?: string
-	}>> {
-		return Promise.all(childIssues.map(async (child) => {
-			try {
-				// Strip prefix from child number (e.g., "#123" -> "123", "ENG-123" stays as-is for branch naming)
-				const rawId = child.number.replace(/^#/, '')
-
-				// Sanitize ID for safe git branch naming (replace non-alphanumeric except - and _ with -)
-				const safeId = rawId.replace(/[^a-zA-Z0-9-_]/g, '-')
-
-				// Use standard iloom branch naming: issue/<id> pattern
-				const childBranch = `issue/${safeId}`
-
-				// Use standard iloom worktree path generation
-				const childWorktreePath = generateWorktreePath(
-					childBranch,
-					mainWorktreePath,
-				)
-
-				getLogger().info(`Creating child worktree for ${child.number}: ${childWorktreePath}...`)
-
-				await this.gitWorktree.createWorktree({
-					path: childWorktreePath,
-					branch: childBranch,
-					createBranch: true,
-					baseBranch: epicBranch,
-				})
-
-				// Pre-accept Claude Code trust for child worktree
-				try {
-					await preAcceptClaudeTrust(childWorktreePath)
-				} catch (error) {
-					getLogger().warn(`Failed to pre-accept Claude trust for child worktree: ${error instanceof Error ? error.message : String(error)}`)
-				}
-
-				// Write metadata with state: 'pending' and parentLoom
-				const metadataInput: WriteMetadataInput = {
-					description: child.title,
-					branchName: childBranch,
-					worktreePath: childWorktreePath,
-					issueType: 'issue',
-					issue_numbers: [rawId],
-					pr_numbers: [],
-					issueTracker: issueTrackerName,
-					colorHex: '#808080',
-					sessionId: '', // No session - not launching Claude directly
-					projectPath: mainWorktreePath,
-					issueUrls: { [rawId]: child.url },
-					prUrls: {},
-					capabilities: [],
-					state: 'pending' as SwarmState,
-					parentLoom: {
-						type: 'epic',
-						identifier: epicIssueNumber,
-						branchName: epicBranch,
-						worktreePath: epicWorktreePath,
-					},
-				}
-
-				try {
-					await this.metadataManager.writeMetadata(childWorktreePath, metadataInput)
-				} catch (metaError) {
-					// Clean up the worktree to avoid zombie worktrees without metadata
-					getLogger().warn(`Metadata write failed for ${child.number}, cleaning up worktree...`)
-					try {
-						await this.gitWorktree.removeWorktree(childWorktreePath, { force: true })
-					} catch {
-						getLogger().debug(`Could not clean up worktree at ${childWorktreePath}`)
-					}
-					throw metaError
-				}
-
-				// Generate and write per-loom MCP config file
-				try {
-					const childMetadata = await this.metadataManager.readMetadata(childWorktreePath)
-					if (childMetadata) {
-						const providerName = IssueTrackerFactory.getProviderName(
-							settings ?? await this.settingsManager.loadSettings(),
-						) as 'github' | 'linear' | 'jira'
-						const mcpConfigPath = await generateAndWriteMcpConfigFile(
-							childWorktreePath,
-							childMetadata,
-							providerName,
-							settings,
-						)
-						await this.metadataManager.updateMetadata(childWorktreePath, { mcpConfigPath })
-
-						// Write MCP config path to .claude/iloom-swarm-mcp-config-path for worker discovery
-						const claudeDir = path.join(childWorktreePath, '.claude')
-						await fs.ensureDir(claudeDir)
-						await fs.writeFile(
-							path.join(claudeDir, 'iloom-swarm-mcp-config-path'),
-							mcpConfigPath,
-							'utf-8',
-						)
-
-						getLogger().debug(`Wrote MCP config for ${child.number}: ${mcpConfigPath}`)
-					}
-				} catch (error) {
-					// Non-fatal: child can still work without MCP config
-					getLogger().warn(
-						`Failed to write MCP config for child ${child.number}: ${error instanceof Error ? error.message : 'Unknown error'}`,
-					)
-				}
-
-				// Install dependencies in the child worktree
-				try {
-					await installDependencies(childWorktreePath, true, true)
-				} catch (error) {
-					getLogger().warn(
-						`Failed to install dependencies in child worktree ${child.number}: ${error instanceof Error ? error.message : 'Unknown error'}`,
-					)
-				}
-
-				getLogger().success(`Created child worktree for ${child.number}`)
-				return {
-					issueId: rawId,
-					worktreePath: childWorktreePath,
-					branch: childBranch,
-					success: true,
-				}
-			} catch (error) {
-				const rawId = child.number.replace(/^#/, '')
-				const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-				getLogger().warn(`Failed to create child worktree for ${child.number}: ${errorMessage}`)
-				return {
-					issueId: rawId,
-					worktreePath: '',
-					branch: '',
-					success: false,
-					error: errorMessage,
-				}
-			}
-		}))
-	}
 
 	/**
 	 * Render swarm-mode agent templates as custom agent files AND thin skill wrappers.
@@ -447,59 +262,6 @@ export class SwarmSetupService {
 			)
 			return false
 		}
-	}
-
-	/**
-	 * Copy .claude/agents/ and .claude/skills/ from the epic worktree to each child worktree.
-	 *
-	 * Child workers need local access to agent files (used as custom agent types) and
-	 * skill files (invoked via /skill-name). Without this copy, child worktrees lack
-	 * the rendered files since they only exist in the epic worktree after rendering.
-	 */
-	async copyAgentsAndSkillsToChildWorktrees(
-		epicWorktreePath: string,
-		childWorktrees: Array<{
-			issueId: string
-			worktreePath: string
-			branch: string
-			success: boolean
-			error?: string
-		}>,
-	): Promise<void> {
-		const agentsSourceDir = path.join(epicWorktreePath, '.claude', 'agents')
-		const skillsSourceDir = path.join(epicWorktreePath, '.claude', 'skills')
-
-		const agentsExist = await fs.pathExists(agentsSourceDir)
-		const skillsExist = await fs.pathExists(skillsSourceDir)
-
-		if (!agentsExist && !skillsExist) {
-			getLogger().warn('No .claude/agents/ or .claude/skills/ directory in epic worktree to copy')
-			return
-		}
-
-		const successfulChildren = childWorktrees.filter((c) => c.success)
-
-		await Promise.all(successfulChildren.map(async (child) => {
-			try {
-				if (agentsExist) {
-					const targetAgentsDir = path.join(child.worktreePath, '.claude', 'agents')
-					await fs.copy(agentsSourceDir, targetAgentsDir, { overwrite: true })
-					getLogger().debug(`Copied .claude/agents/ to ${child.worktreePath}`)
-				}
-				if (skillsExist) {
-					const targetSkillsDir = path.join(child.worktreePath, '.claude', 'skills')
-					await fs.copy(skillsSourceDir, targetSkillsDir, { overwrite: true })
-					getLogger().debug(`Copied .claude/skills/ to ${child.worktreePath}`)
-				}
-			} catch (error) {
-				// Non-fatal: worker can fall back to epic worktree path
-				getLogger().warn(
-					`Failed to copy agents/skills to child worktree ${child.issueId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
-				)
-			}
-		}))
-
-		getLogger().success(`Copied agents and skills to ${successfulChildren.length} child worktrees`)
 	}
 
 	/**

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -1082,6 +1082,9 @@ If workflow plan determined SKIP_PLANNING AND complexity is COMPLEX:
 
 **Execute for both SIMPLE and COMPLEX workflows**
 
+**PREREQUISITE CHECK — Do not skip this:**
+Before executing implementation, verify that a plan comment exists on the issue (either from STEP 2-SIMPLE or STEP 3). If no plan comment exists and the workflow scan determined NEEDS_PLANNING, you MUST stop and run the appropriate analyze-and-plan or planning skill before proceeding. Do not implement without a documented plan.
+
 Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
 
 1. **Extract plan location from previous agent:**


### PR DESCRIPTION
## Summary

- Add explicit prerequisite check at top of STEP 4 (Implementation Phase) in `issue-prompt.txt` — swarm workers must verify a plan comment exists before proceeding when `NEEDS_PLANNING` was flagged
- Remove dead `createChildWorktrees` and `copyAgentsAndSkillsToChildWorktrees` methods from `SwarmSetupService` (only called in tests, orchestrator handles worktree creation at runtime)
- Remove `metadataManager` constructor param and `SwarmChildIssue` interface (only used by removed methods)

## Test plan

- [x] All 4868 tests pass
- [x] Build succeeds
- [x] Pre-commit hooks (lint, compile, tests, build) pass