### PR TITLE
Use --plugin-dir for swarm agents to avoid rulesync conflicts

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -610,15 +610,14 @@ When `il spin` detects an epic loom (created via `il start --epic` or by confirm
 
 1. **Fetches/refreshes child data** - Re-fetches child issue details and dependency map from the issue tracker
 2. **Creates child worktrees** - One worktree per child issue, branched off the epic branch, with dependencies installed
-3. **Renders swarm agents** - Writes swarm-mode agent templates to `.claude/agents/` in the epic worktree
-4. **Renders swarm worker agent** - Writes the iloom workflow as a custom agent type to `.claude/agents/iloom-swarm-worker.md`
-5. **Copies agents to child worktrees** - Copies `.claude/agents/` from the epic worktree to each child worktree so workers can resolve agent files locally
-6. **Launches orchestrator** - Starts Claude with agent teams enabled and `bypassPermissions` mode
+3. **Renders swarm agents** - Writes swarm-mode agent templates to a temporary plugin directory (`iloom-swarm` plugin)
+4. **Renders swarm worker agent** - Writes the iloom workflow as a custom agent type (`iloom-swarm:worker`) to the plugin directory
+5. **Launches orchestrator** - Starts Claude with agent teams enabled, `bypassPermissions` mode, and `--plugin-dir` pointing to the temporary plugin directory
 
 The orchestrator then:
 - Analyzes the dependency DAG to identify initially unblocked issues
 - Spawns parallel agents for all unblocked child issues simultaneously
-- Each agent uses the `iloom-swarm-worker` custom agent type, receiving the full iloom workflow as its system prompt
+- Each agent uses the `iloom-swarm:worker` custom agent type, receiving the full iloom workflow as its system prompt
 - Completed work is rebased and fast-forward merged into the epic branch for clean linear history
 - Newly unblocked issues are spawned as their dependencies complete
 - Failed children are isolated and do not block unrelated issues
@@ -1865,7 +1864,7 @@ Only sibling dependencies (between child issues of the same epic) are included. 
 
 Each child agent runs in complete isolation:
 
-1. The orchestrator spawns the agent with `subagent_type: "iloom-swarm-worker"`, passing the child's issue number, title, worktree path, and issue body in the Task prompt
+1. The orchestrator spawns the agent with `subagent_type: "iloom-swarm:worker"`, passing the child's issue number, title, worktree path, and issue body in the Task prompt
 2. The agent's system prompt contains the full iloom issue workflow adapted for swarm mode (high-authority instructions)
 3. The agent implements the issue autonomously in its own worktree (branched off the epic branch)
 4. On completion, the agent reports back to the orchestrator with status and summary
@@ -2061,29 +2060,33 @@ Swarm mode is designed to maximize throughput despite individual failures:
 
 ### File Structure
 
-During swarm mode, the following files are created:
+During swarm mode, swarm agents are rendered to a temporary plugin directory (outside the worktree) and loaded via `--plugin-dir`. This avoids conflicts with tools like [rulesync](https://github.com/dyoshikawa/rulesync) that manage the `.claude/` directory.
 
 ```
+$TMPDIR/iloom-swarm-plugin-<random>/   # Temporary plugin directory
+├── .claude-plugin/
+│   └── plugin.json                    # {"name": "iloom-swarm", "version": "<cli-version>"}
+├── agents/
+│   ├── worker.md                      # iloom-swarm:worker — full iloom workflow
+│   ├── issue-implementer.md           # iloom-swarm:issue-implementer
+│   ├── wave-verifier.md               # iloom-swarm:wave-verifier
+│   └── ...                            # Other phase agents
+└── skills/
+    ├── issue-analyzer/SKILL.md        # /iloom-swarm:issue-analyzer
+    ├── issue-planner/SKILL.md         # /iloom-swarm:issue-planner
+    └── ...                            # Other skill wrappers
+
 ~/project-looms/
 ├── epic-issue-100/                    # Epic worktree
-│   └── .claude/
-│       └── agents/
-│           ├── iloom-swarm-worker.md              # Worker agent with full iloom workflow
-│           ├── iloom-swarm-issue-implementer.md   # Swarm agent definitions
-│           └── ...
+│   └── iloom-metadata.json
 ├── issue-101/                         # Child worktree (branched off epic)
-│   ├── .claude/
-│   │   └── agents/                    # Copied from epic worktree during setup (not committed)
-│   │       ├── iloom-swarm-worker.md
-│   │       ├── iloom-swarm-issue-implementer.md
-│   │       └── ...
 │   └── iloom-metadata.json            # state: pending -> in_progress -> done
 ├── issue-102/                         # Another child worktree
 │   └── iloom-metadata.json
 └── ...
 ```
 
-Swarm agent files are not committed to the repository.
+Plugin agents are namespaced as `iloom-swarm:<agent-name>` (e.g., `iloom-swarm:worker`, `iloom-swarm:issue-implementer`). The temporary directory is cleaned up by the OS naturally since agents are loaded into memory at session start.
 
 ---
 

--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -71,6 +71,7 @@ vi.mock('../lib/SwarmSetupService.js', () => ({
 			renderedAgents: [],
 			workerAgentRendered: false,
 			verifierAgentRendered: false,
+			pluginDir: '/tmp/iloom-swarm-plugin-mock',
 		}),
 	})),
 }))
@@ -3335,6 +3336,7 @@ describe('IgniteCommand', () => {
 					renderedAgents: [],
 					workerAgentRendered: true,
 					verifierAgentRendered: false,
+					pluginDir: '/tmp/iloom-swarm-plugin-mock',
 				}),
 			}) as unknown as SwarmSetupService)
 
@@ -3436,6 +3438,7 @@ describe('IgniteCommand', () => {
 				renderedAgents: [],
 				workerAgentRendered: true,
 				verifierAgentRendered: false,
+				pluginDir: '/tmp/iloom-swarm-plugin-mock',
 			})
 
 			const { SwarmSetupService } = await import('../lib/SwarmSetupService.js')
@@ -3748,6 +3751,7 @@ describe('IgniteCommand', () => {
 					renderedAgents: [],
 					workerAgentRendered: true,
 					verifierAgentRendered: false,
+					pluginDir: '/tmp/iloom-swarm-plugin-mock',
 				}),
 			}) as unknown as SwarmSetupService)
 		})
@@ -4094,6 +4098,7 @@ describe('IgniteCommand', () => {
 					renderedAgents: [],
 					workerAgentRendered: true,
 					verifierAgentRendered: false,
+					pluginDir: '/tmp/iloom-swarm-plugin-mock',
 				}),
 			}) as unknown as SwarmSetupService)
 

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -993,8 +993,8 @@ export class IgniteCommand {
 			}
 		}
 
-		// Run swarm setup (renders agents, worker agent, and wave verifier to epic worktree)
-		await swarmSetup.setupSwarm(
+		// Run swarm setup (renders agents, worker agent, and wave verifier to plugin dir)
+		const swarmSetupResult = await swarmSetup.setupSwarm(
 			epicBranch,
 			epicWorktreePath,
 		)
@@ -1179,6 +1179,7 @@ export class IgniteCommand {
 			mcpConfig: mcpConfigs,
 			allowedTools,
 			...(agents && { agents }),
+			pluginDir: swarmSetupResult.pluginDir,
 		})
 
 		// Track swarm child completions and overall completion

--- a/src/lib/SwarmSetupService.test.ts
+++ b/src/lib/SwarmSetupService.test.ts
@@ -17,12 +17,20 @@ vi.mock('../utils/logger-context.js', () => ({
 
 vi.mock('fs-extra', () => ({
 	default: {
-		ensureDir: vi.fn().mockResolvedValue(undefined),
-		writeFile: vi.fn().mockResolvedValue(undefined),
-		pathExists: vi.fn().mockResolvedValue(true),
-		copy: vi.fn().mockResolvedValue(undefined),
+		ensureDir: vi.fn(),
+		writeFile: vi.fn(),
+		pathExists: vi.fn(),
+		copy: vi.fn(),
+		mkdtemp: vi.fn(),
 	},
 }))
+
+vi.mock('../utils/package-info.js', () => ({
+	getPackageInfo: () => ({ name: 'iloom', version: '1.2.3' }),
+}))
+
+const PLUGIN_DIR = '/tmp/iloom-swarm-plugin-test'
+const EPIC_WORKTREE_PATH = '/Users/dev/project-epic-610'
 
 describe('SwarmSetupService', () => {
 	let service: SwarmSetupService
@@ -31,6 +39,12 @@ describe('SwarmSetupService', () => {
 	let mockTemplateManager: PromptTemplateManager
 
 	beforeEach(() => {
+		vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+		vi.mocked(fs.pathExists).mockResolvedValue(true as never)
+		vi.mocked(fs.copy).mockResolvedValue(undefined)
+		vi.mocked(fs.mkdtemp).mockResolvedValue('/tmp/iloom-swarm-plugin-abc123')
+
 		mockAgentManager = {
 			loadAgents: vi.fn().mockResolvedValue({
 				'iloom-issue-implementer': {
@@ -59,57 +73,57 @@ describe('SwarmSetupService', () => {
 	})
 
 	describe('renderSwarmAgents', () => {
-		it('writes agent files to .claude/agents/ and skill wrappers to .claude/skills/', async () => {
-			const result = await service.renderSwarmAgents('/Users/dev/project-epic-610')
+		it('writes agent files to pluginDir/agents/ and skill wrappers to pluginDir/skills/', async () => {
+			const result = await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(result.renderedSkills).toHaveLength(1)
-			expect(result.renderedSkills[0]).toBe('iloom-swarm-issue-implementer')
+			expect(result.renderedSkills[0]).toBe('issue-implementer')
 			expect(result.renderedAgents).toHaveLength(1)
-			expect(result.renderedAgents[0]).toBe('iloom-swarm-issue-implementer')
+			expect(result.renderedAgents[0]).toBe('issue-implementer')
 
-			// Verify agents directory was created
+			// Verify agents directory was created in plugin dir
 			expect(fs.ensureDir).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/agents',
+				`${PLUGIN_DIR}/agents`,
 			)
 
-			// Verify agent file was written
+			// Verify agent file was written to plugin dir
 			expect(fs.writeFile).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/agents/iloom-swarm-issue-implementer.md',
+				`${PLUGIN_DIR}/agents/issue-implementer.md`,
 				expect.any(String),
 				'utf-8',
 			)
 
-			// Verify skill directory was created
+			// Verify skill directory was created in plugin dir
 			expect(fs.ensureDir).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/skills/iloom-swarm-issue-implementer',
+				`${PLUGIN_DIR}/skills/issue-implementer`,
 			)
 
-			// Verify thin SKILL.md was written to the skill directory
+			// Verify thin SKILL.md was written to the plugin skill directory
 			expect(fs.writeFile).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/skills/iloom-swarm-issue-implementer/SKILL.md',
+				`${PLUGIN_DIR}/skills/issue-implementer/SKILL.md`,
 				expect.any(String),
 				'utf-8',
 			)
 		})
 
 		it('loads agents with SWARM_MODE and EPIC_WORKTREE_PATH', async () => {
-			await service.renderSwarmAgents('/Users/dev/project-epic-610')
+			await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({
 					SWARM_MODE: true,
-					EPIC_WORKTREE_PATH: '/Users/dev/project-epic-610',
+					EPIC_WORKTREE_PATH,
 				}),
 			)
 		})
 
 		it('writes agent file with full prompt and skill wrapper with delegation body', async () => {
-			await service.renderSwarmAgents('/Users/dev/project-epic-610')
+			await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writeFileCalls = vi.mocked(fs.writeFile).mock.calls
 			const agentFileCall = writeFileCalls.find(
-				(call) => (call[0] as string).endsWith('iloom-swarm-issue-implementer.md'),
+				(call) => (call[0] as string).endsWith('issue-implementer.md'),
 			)
 			const skillFileCall = writeFileCalls.find(
 				(call) => (call[0] as string).endsWith('SKILL.md'),
@@ -118,7 +132,7 @@ describe('SwarmSetupService', () => {
 			// Agent file should contain full prompt
 			const agentContent = agentFileCall![1] as string
 			expect(agentContent).toMatch(/^---/)
-			expect(agentContent).toContain('name: iloom-swarm-issue-implementer')
+			expect(agentContent).toContain('name: issue-implementer')
 			expect(agentContent).toContain('description: Implementer agent')
 			expect(agentContent).toContain('model: ')
 			expect(agentContent).not.toContain('context: fork')
@@ -128,11 +142,11 @@ describe('SwarmSetupService', () => {
 			// Skill wrapper should be thin with agent reference
 			const skillContent = skillFileCall![1] as string
 			expect(skillContent).toMatch(/^---/)
-			expect(skillContent).toContain('name: iloom-swarm-issue-implementer')
+			expect(skillContent).toContain('name: issue-implementer')
 			expect(skillContent).toContain('description: Implementer agent')
 			expect(skillContent).toContain('model: ')
 			expect(skillContent).toContain('context: fork')
-			expect(skillContent).toContain('agent: iloom-swarm-issue-implementer')
+			expect(skillContent).toContain('agent: issue-implementer')
 			expect(skillContent).not.toContain('agent: general-purpose')
 			expect(skillContent).toContain('Proceed via your system prompt.')
 			expect(skillContent).not.toContain('Implement things')
@@ -163,9 +177,9 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
-				expect(getAgentContent('iloom-swarm-issue-implementer')).toContain('model: haiku')
+				expect(getAgentContent('issue-implementer')).toContain('model: haiku')
 			})
 
 			it('applies default swarmModel (sonnet) for agents in default map when no swarmModel configured', async () => {
@@ -184,10 +198,10 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 				// iloom-issue-implementer is in the default swarmModel map, so it should be sonnet
-				expect(getAgentContent('iloom-swarm-issue-implementer')).toContain('model: sonnet')
+				expect(getAgentContent('issue-implementer')).toContain('model: sonnet')
 			})
 
 			it('applies default swarmModel (opus) for analyzer agent', async () => {
@@ -201,10 +215,10 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 				// iloom-issue-analyzer is in the default swarmModel map as opus
-				expect(getAgentContent('iloom-swarm-issue-analyzer')).toContain('model: opus')
+				expect(getAgentContent('issue-analyzer')).toContain('model: opus')
 			})
 
 			it('non-swarm model override does not affect swarm mode when default map covers the agent', async () => {
@@ -234,13 +248,13 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 				// Even though non-swarm model is set to haiku, swarm defaults override
 				// Check agent files (which carry the full prompt and model)
-				expect(getAgentContent('iloom-swarm-issue-implementer')).toContain('model: sonnet')
-				expect(getAgentContent('iloom-swarm-issue-analyzer')).toContain('model: opus')
-				expect(getAgentContent('iloom-swarm-issue-planner')).toContain('model: sonnet')
+				expect(getAgentContent('issue-implementer')).toContain('model: sonnet')
+				expect(getAgentContent('issue-analyzer')).toContain('model: opus')
+				expect(getAgentContent('issue-planner')).toContain('model: sonnet')
 			})
 
 			it('explicit swarmModel overrides both non-swarm model and default map', async () => {
@@ -264,11 +278,11 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 				// Explicit swarmModel always wins over both non-swarm model and default map
-				expect(getAgentContent('iloom-swarm-issue-implementer')).toContain('model: opus')
-				expect(getAgentContent('iloom-swarm-issue-analyzer')).toContain('model: haiku')
+				expect(getAgentContent('issue-implementer')).toContain('model: opus')
+				expect(getAgentContent('issue-analyzer')).toContain('model: haiku')
 			})
 
 			it('different agents can have different swarmModels', async () => {
@@ -293,10 +307,10 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
-				expect(getAgentContent('iloom-swarm-issue-implementer')).toContain('model: sonnet')
-				expect(getAgentContent('iloom-swarm-issue-planner')).toContain('model: haiku')
+				expect(getAgentContent('issue-implementer')).toContain('model: sonnet')
+				expect(getAgentContent('issue-planner')).toContain('model: haiku')
 			})
 
 			it('swarmModel override does not emit allowed-tools even when agent has tools', async () => {
@@ -315,9 +329,9 @@ describe('SwarmSetupService', () => {
 					},
 				})
 
-				await service.renderSwarmAgents('/Users/dev/project-epic-610')
+				await service.renderSwarmAgents(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
-				const agentContent = getAgentContent('iloom-swarm-issue-implementer')
+				const agentContent = getAgentContent('issue-implementer')
 				expect(agentContent).toContain('model: haiku')
 				expect(agentContent).not.toContain('allowed-tools')
 			})
@@ -326,7 +340,7 @@ describe('SwarmSetupService', () => {
 
 	describe('renderSwarmWorkerAgent', () => {
 		it('calls PromptTemplateManager.getPrompt with SWARM_MODE=true and ONE_SHOT_MODE=true', async () => {
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
 				'issue',
@@ -338,18 +352,18 @@ describe('SwarmSetupService', () => {
 		})
 
 		it('passes EPIC_WORKTREE_PATH as template variable', async () => {
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
 				'issue',
 				expect.objectContaining({
-					EPIC_WORKTREE_PATH: '/Users/dev/project-epic-610',
+					EPIC_WORKTREE_PATH,
 				}),
 			)
 		})
 
 		it('does not pass MCP_CONFIG_JSON or SWARM_AGENT_METADATA as template variables', async () => {
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const calledVariables = vi.mocked(mockTemplateManager.getPrompt).mock.calls[0]![1]
 			expect(calledVariables).not.toHaveProperty('MCP_CONFIG_JSON')
@@ -357,21 +371,21 @@ describe('SwarmSetupService', () => {
 			expect(calledVariables).not.toHaveProperty('SWARM_SUB_AGENT_TIMEOUT_MS')
 		})
 
-		it('writes agent file with frontmatter to .claude/agents/iloom-swarm-worker.md', async () => {
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+		it('writes agent file with frontmatter to pluginDir/agents/worker.md', async () => {
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(fs.writeFile).toHaveBeenCalledWith(
-				'/Users/dev/project-epic-610/.claude/agents/iloom-swarm-worker.md',
-				expect.stringContaining('---\nname: iloom-swarm-worker\n'),
+				`${PLUGIN_DIR}/agents/worker.md`,
+				expect.stringContaining('---\nname: worker\n'),
 				'utf-8',
 			)
 		})
 
 		it('includes frontmatter with correct fields and defaults model to sonnet', async () => {
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string
-			expect(writtenContent).toContain('name: iloom-swarm-worker')
+			expect(writtenContent).toContain('name: worker')
 			expect(writtenContent).toContain('description: Swarm worker agent that implements a child issue following the full iloom workflow.')
 			expect(writtenContent).toContain('model: sonnet')
 		})
@@ -385,7 +399,7 @@ describe('SwarmSetupService', () => {
 				},
 			} as unknown as IloomSettings)
 
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string
 			expect(writtenContent).toContain('model: haiku')
@@ -393,7 +407,7 @@ describe('SwarmSetupService', () => {
 		})
 
 		it('includes rendered template content in the body', async () => {
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string
 			expect(writtenContent).toContain('# Rendered swarm skill content')
@@ -409,7 +423,7 @@ describe('SwarmSetupService', () => {
 				},
 		} as unknown as IloomSettings)
 
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
 				'issue',
@@ -423,7 +437,7 @@ describe('SwarmSetupService', () => {
 		})
 
 		it('returns true on success', async () => {
-			const result = await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			const result = await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(result).toBe(true)
 		})
@@ -433,7 +447,7 @@ describe('SwarmSetupService', () => {
 				new Error('Template not found'),
 			)
 
-			const result = await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			const result = await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(result).toBe(false)
 		})
@@ -446,7 +460,7 @@ describe('SwarmSetupService', () => {
 				},
 			} as unknown as IloomSettings)
 
-			await service.renderSwarmWorkerAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWorkerAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			// swarmReview: false should override review: true for planner in swarm mode
 			// analyzer has no swarmReview, so it defaults to false in swarm mode
@@ -480,13 +494,13 @@ describe('SwarmSetupService', () => {
 				},
 			})
 
-			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({
 					SWARM_MODE: true,
-					EPIC_WORKTREE_PATH: '/Users/dev/project-epic-610',
+					EPIC_WORKTREE_PATH,
 					REVIEW_ENABLED: true,
 					REVIEW_CLAUDE_MODEL: 'opus',
 					HAS_REVIEW_CLAUDE: true,
@@ -508,13 +522,13 @@ describe('SwarmSetupService', () => {
 				},
 			})
 
-			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
-				(call) => (call[0] as string).endsWith('iloom-swarm-wave-verifier.md'),
+				(call) => (call[0] as string).endsWith('wave-verifier.md'),
 			)?.[1] as string
 
-			expect(writtenContent).toContain('name: iloom-swarm-wave-verifier')
+			expect(writtenContent).toContain('name: wave-verifier')
 			expect(writtenContent).toContain('description: Wave verification agent')
 			expect(writtenContent).toContain('model: sonnet')
 			expect(writtenContent).toContain('Verify the wave integration')
@@ -535,10 +549,10 @@ describe('SwarmSetupService', () => {
 				},
 			})
 
-			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
-				(call) => (call[0] as string).endsWith('iloom-swarm-wave-verifier.md'),
+				(call) => (call[0] as string).endsWith('wave-verifier.md'),
 			)?.[1] as string
 
 			expect(writtenContent).toContain('model: opus')
@@ -554,10 +568,10 @@ describe('SwarmSetupService', () => {
 				},
 			})
 
-			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
-				(call) => (call[0] as string).endsWith('iloom-swarm-wave-verifier.md'),
+				(call) => (call[0] as string).endsWith('wave-verifier.md'),
 			)?.[1] as string
 
 			expect(writtenContent).toContain('tools: Bash, Read, Grep')
@@ -566,7 +580,7 @@ describe('SwarmSetupService', () => {
 		it('returns false when wave verifier template is not found', async () => {
 			vi.mocked(mockAgentManager.loadAgents).mockResolvedValueOnce({})
 
-			const result = await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			const result = await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(result).toBe(false)
 		})
@@ -576,7 +590,7 @@ describe('SwarmSetupService', () => {
 				new Error('Failed to load agents'),
 			)
 
-			const result = await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			const result = await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(result).toBe(false)
 		})
@@ -592,7 +606,7 @@ describe('SwarmSetupService', () => {
 				},
 			})
 
-			await service.renderSwarmWaveVerifierAgent('/Users/dev/project-epic-610')
+			await service.renderSwarmWaveVerifierAgent(PLUGIN_DIR, EPIC_WORKTREE_PATH)
 
 			expect(mockAgentManager.loadAgents).toHaveBeenCalledWith(
 				null,
@@ -608,14 +622,39 @@ describe('SwarmSetupService', () => {
 		})
 	})
 
+	describe('createPluginManifest', () => {
+		it('writes plugin.json to pluginDir/.claude-plugin/', async () => {
+			await service.createPluginManifest(PLUGIN_DIR)
+
+			expect(fs.ensureDir).toHaveBeenCalledWith(`${PLUGIN_DIR}/.claude-plugin`)
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				`${PLUGIN_DIR}/.claude-plugin/plugin.json`,
+				expect.stringContaining('"name": "iloom-swarm"'),
+				'utf-8',
+			)
+		})
+
+		it('includes version from package info', async () => {
+			await service.createPluginManifest(PLUGIN_DIR)
+
+			const writtenContent = vi.mocked(fs.writeFile).mock.calls.find(
+				(call) => (call[0] as string).endsWith('plugin.json'),
+			)?.[1] as string
+
+			const parsed = JSON.parse(writtenContent)
+			expect(parsed.name).toBe('iloom-swarm')
+			expect(parsed.version).toBe('1.2.3')
+		})
+	})
+
 	describe('setupSwarm', () => {
 		it('runs full setup: renders agents, worker agent, and verifier agent', async () => {
 			const result = await service.setupSwarm(
 				'epic/610',
-				'/Users/dev/project-epic-610',
+				EPIC_WORKTREE_PATH,
 			)
 
-			expect(result.epicWorktreePath).toBe('/Users/dev/project-epic-610')
+			expect(result.epicWorktreePath).toBe(EPIC_WORKTREE_PATH)
 			expect(result.epicBranch).toBe('epic/610')
 			expect(result.skillsRendered.length).toBeGreaterThan(0)
 			expect(result.renderedAgents.length).toBeGreaterThan(0)
@@ -623,17 +662,45 @@ describe('SwarmSetupService', () => {
 			expect(result.verifierAgentRendered).toBeDefined()
 		})
 
+		it('returns pluginDir in result', async () => {
+			const result = await service.setupSwarm(
+				'epic/610',
+				EPIC_WORKTREE_PATH,
+			)
+
+			expect(result.pluginDir).toBe('/tmp/iloom-swarm-plugin-abc123')
+		})
+
+		it('creates plugin manifest before rendering agents', async () => {
+			await service.setupSwarm(
+				'epic/610',
+				EPIC_WORKTREE_PATH,
+			)
+
+			// Verify mkdtemp was called to create temp dir
+			expect(fs.mkdtemp).toHaveBeenCalledWith(
+				expect.stringContaining('iloom-swarm-plugin-'),
+			)
+
+			// Verify plugin manifest was created
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining('.claude-plugin/plugin.json'),
+				expect.stringContaining('"name": "iloom-swarm"'),
+				'utf-8',
+			)
+		})
+
 		it('does not pass SWARM_AGENT_METADATA or MCP_CONFIG_JSON to worker agent', async () => {
 			await service.setupSwarm(
 				'epic/610',
-				'/Users/dev/project-epic-610',
+				EPIC_WORKTREE_PATH,
 			)
 
 			// Verify getPrompt was called for the worker agent
 			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
 				'issue',
 				expect.objectContaining({
-					EPIC_WORKTREE_PATH: '/Users/dev/project-epic-610',
+					EPIC_WORKTREE_PATH,
 				}),
 			)
 			const calledVariables = vi.mocked(mockTemplateManager.getPrompt).mock.calls[0]![1]

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -1,10 +1,12 @@
 import path from 'path'
+import os from 'os'
 import fs from 'fs-extra'
 import { AgentManager } from './AgentManager.js'
 import { SettingsManager, type ClaudeModel } from './SettingsManager.js'
 import { PromptTemplateManager, buildReviewTemplateVariables, type TemplateVariables } from './PromptTemplateManager.js'
 import { IssueManagementProviderFactory } from '../mcp/IssueManagementProviderFactory.js'
 import { getLogger } from '../utils/logger-context.js'
+import { getPackageInfo } from '../utils/package-info.js'
 
 /**
  * Result of the swarm setup process
@@ -16,6 +18,7 @@ export interface SwarmSetupResult {
 	renderedAgents: string[]
 	workerAgentRendered: boolean
 	verifierAgentRendered: boolean
+	pluginDir: string
 }
 
 /**
@@ -35,20 +38,22 @@ export class SwarmSetupService {
 	 * Render swarm-mode agent templates as custom agent files AND thin skill wrappers.
 	 *
 	 * For each phase agent, two files are written:
-	 * 1. Agent file at `.claude/agents/iloom-swarm-<phase>.md` - contains frontmatter
+	 * 1. Agent file at `<pluginDir>/agents/<phase>.md` - contains frontmatter
 	 *    (name, description, model) and the full agent prompt as body.
-	 * 2. Thin skill wrapper at `.claude/skills/iloom-swarm-<phase>/SKILL.md` - contains
-	 *    frontmatter with `agent: iloom-swarm-<phase>` and a minimal body.
+	 * 2. Thin skill wrapper at `<pluginDir>/skills/<phase>/SKILL.md` - contains
+	 *    frontmatter with `agent: <phase>` and a minimal body.
 	 *
 	 * Skills are auto-discovered by Claude Code and invoked via /skill-name syntax.
 	 * The agent file carries the real prompt; the skill just delegates to it.
+	 * Agent names use short form (e.g., `issue-implementer`) since the plugin
+	 * namespace (`iloom-swarm:`) provides the prefix.
 	 */
-	async renderSwarmAgents(epicWorktreePath: string): Promise<{
+	async renderSwarmAgents(pluginDir: string, epicWorktreePath: string): Promise<{
 		renderedSkills: string[]
 		renderedAgents: string[]
 	}> {
-		const claudeSkillsDir = path.join(epicWorktreePath, '.claude', 'skills')
-		const claudeAgentsDir = path.join(epicWorktreePath, '.claude', 'agents')
+		const claudeSkillsDir = path.join(pluginDir, 'skills')
+		const claudeAgentsDir = path.join(pluginDir, 'agents')
 		await fs.ensureDir(claudeSkillsDir)
 		await fs.ensureDir(claudeAgentsDir)
 
@@ -89,7 +94,7 @@ export class SwarmSetupService {
 		const renderedAgents: string[] = []
 
 		// Agents that are rendered as standalone custom agent types (with frontmatter
-		// in .claude/agents/) rather than as skills. These are skipped here
+		// in <pluginDir>/agents/) rather than as skills. These are skipped here
 		// and rendered separately with their own dedicated methods.
 		const standaloneAgents = new Set(['iloom-wave-verifier'])
 
@@ -98,12 +103,13 @@ export class SwarmSetupService {
 				continue
 			}
 
-			// Compute agent/skill name: iloom-swarm-<phase>
+			// Compute agent/skill name: <phase> (e.g., issue-implementer)
+			// The plugin namespace (iloom-swarm:) provides the full qualified name.
 			const swarmName = agentName.startsWith('iloom-')
-				? `iloom-swarm-${agentName.slice('iloom-'.length)}`
-				: `iloom-swarm-${agentName}`
+				? agentName.slice('iloom-'.length)
+				: agentName
 
-			// 1. Write agent file to .claude/agents/<swarmName>.md
+			// 1. Write agent file to <pluginDir>/agents/<swarmName>.md
 			const agentFrontmatter = [
 				'---',
 				`name: ${swarmName}`,
@@ -117,7 +123,7 @@ export class SwarmSetupService {
 			renderedAgents.push(swarmName)
 			getLogger().debug(`Rendered swarm agent: ${swarmName}`)
 
-			// 2. Write thin skill wrapper to .claude/skills/<swarmName>/SKILL.md
+			// 2. Write thin skill wrapper to <pluginDir>/skills/<swarmName>/SKILL.md
 			const skillDir = path.join(claudeSkillsDir, swarmName)
 			await fs.ensureDir(skillDir)
 
@@ -142,11 +148,11 @@ export class SwarmSetupService {
 	}
 
 	/**
-	 * Render the swarm worker agent file to the epic worktree's .claude/agents/ directory.
+	 * Render the swarm worker agent file to the plugin directory.
 	 *
-	 * This creates an agent file at `.claude/agents/iloom-swarm-worker.md` containing
+	 * This creates an agent file at `<pluginDir>/agents/worker.md` containing
 	 * the full iloom workflow instructions (rendered from issue-prompt.txt with SWARM_MODE=true).
-	 * The orchestrator spawns children with `subagent_type: "iloom-swarm-worker"` so these
+	 * The orchestrator spawns children with `subagent_type: "iloom-swarm:worker"` so these
 	 * instructions become the agent's system prompt (high authority), rather than arriving
 	 * as a skill invocation (low authority user message).
 	 *
@@ -154,10 +160,11 @@ export class SwarmSetupService {
 	 * worktree path, body) is provided per-child via the Task prompt from the orchestrator.
 	 */
 	async renderSwarmWorkerAgent(
+		pluginDir: string,
 		epicWorktreePath: string,
 	): Promise<boolean> {
-		const agentsDir = path.join(epicWorktreePath, '.claude', 'agents')
-		const agentOutputPath = path.join(agentsDir, 'iloom-swarm-worker.md')
+		const agentsDir = path.join(pluginDir, 'agents')
+		const agentOutputPath = path.join(agentsDir, 'worker.md')
 
 		await fs.ensureDir(agentsDir)
 
@@ -180,12 +187,13 @@ export class SwarmSetupService {
 			// Render issue prompt template with swarm variables
 			const agentBody = await this.templateManager.getPrompt('issue', variables)
 
-			// Build the agent file with frontmatter
+			// Settings key stays as 'iloom-swarm-worker' for backward compatibility,
+			// even though the plugin agent name is now just 'worker' (namespaced as iloom-swarm:worker).
 			const workerModel = settings?.agents?.['iloom-swarm-worker']?.model ?? 'sonnet'
 
 			const frontmatter = [
 				'---',
-				'name: iloom-swarm-worker',
+				'name: worker',
 				'description: Swarm worker agent that implements a child issue following the full iloom workflow.',
 				`model: ${workerModel}`,
 				'---',
@@ -207,16 +215,16 @@ export class SwarmSetupService {
 	}
 
 	/**
-	 * Render the wave verifier agent file to the epic worktree's .claude/agents/ directory.
+	 * Render the wave verifier agent file to the plugin directory.
 	 *
-	 * This creates an agent file at `.claude/agents/iloom-swarm-wave-verifier.md` WITH frontmatter,
-	 * making it available as a custom agent type via `subagent_type: "iloom-swarm-wave-verifier"`.
+	 * This creates an agent file at `<pluginDir>/agents/wave-verifier.md` WITH frontmatter,
+	 * making it available as a custom agent type via `subagent_type: "iloom-swarm:wave-verifier"`.
 	 * Unlike phase agents (which are appended as system prompts), the wave verifier is a standalone
 	 * agent that the orchestrator spawns directly for verification child issues.
 	 */
-	async renderSwarmWaveVerifierAgent(epicWorktreePath: string): Promise<boolean> {
-		const agentsDir = path.join(epicWorktreePath, '.claude', 'agents')
-		const agentOutputPath = path.join(agentsDir, 'iloom-swarm-wave-verifier.md')
+	async renderSwarmWaveVerifierAgent(pluginDir: string, epicWorktreePath: string): Promise<boolean> {
+		const agentsDir = path.join(pluginDir, 'agents')
+		const agentOutputPath = path.join(agentsDir, 'wave-verifier.md')
 
 		await fs.ensureDir(agentsDir)
 
@@ -244,7 +252,7 @@ export class SwarmSetupService {
 			// Build the agent file WITH frontmatter (standalone custom agent type)
 			const frontmatter = [
 				'---',
-				'name: iloom-swarm-wave-verifier',
+				'name: wave-verifier',
 				`description: ${verifierConfig.description ?? 'Wave verification agent that checks must-have criteria after each swarm wave.'}`,
 				`model: ${verifierModel}`,
 				...(verifierConfig.tools ? [`tools: ${verifierConfig.tools.join(', ')}`] : []),
@@ -265,8 +273,33 @@ export class SwarmSetupService {
 	}
 
 	/**
+	 * Create the plugin manifest file at `<pluginDir>/.claude-plugin/plugin.json`.
+	 *
+	 * The manifest declares the plugin name (`iloom-swarm`) and version, enabling
+	 * Claude Code to namespace all agents/skills under `iloom-swarm:`.
+	 */
+	async createPluginManifest(pluginDir: string): Promise<void> {
+		const manifestDir = path.join(pluginDir, '.claude-plugin')
+		await fs.ensureDir(manifestDir)
+
+		const manifest = {
+			name: 'iloom-swarm',
+			version: getPackageInfo().version,
+		}
+
+		await fs.writeFile(
+			path.join(manifestDir, 'plugin.json'),
+			JSON.stringify(manifest, null, 2),
+			'utf-8',
+		)
+		getLogger().debug(`Created plugin manifest at ${manifestDir}/plugin.json`)
+	}
+
+	/**
 	 * Run the full swarm setup: render agents, worker agent, and wave verifier.
 	 *
+	 * Creates a temporary plugin directory for all swarm agent/skill files,
+	 * keeping them isolated from the worktree's `.claude/` directory.
 	 * The epic worktree already exists (created by `il start`).
 	 * Child worktrees are created on-the-fly by the orchestrator as issues become unblocked.
 	 */
@@ -274,15 +307,19 @@ export class SwarmSetupService {
 		epicBranch: string,
 		epicWorktreePath: string,
 	): Promise<SwarmSetupResult> {
-		// 1. Render swarm agents and skill wrappers to epic worktree
+		// 0. Create temp plugin directory for swarm agents/skills
+		const pluginDir = await fs.mkdtemp(path.join(os.tmpdir(), 'iloom-swarm-plugin-'))
+		await this.createPluginManifest(pluginDir)
+
+		// 1. Render swarm agents and skill wrappers to plugin dir
 		const { renderedSkills: skillsRendered, renderedAgents } =
-			await this.renderSwarmAgents(epicWorktreePath)
+			await this.renderSwarmAgents(pluginDir, epicWorktreePath)
 
 		// 2. Render the swarm worker agent file
-		const workerAgentRendered = await this.renderSwarmWorkerAgent(epicWorktreePath)
+		const workerAgentRendered = await this.renderSwarmWorkerAgent(pluginDir, epicWorktreePath)
 
 		// 3. Render the wave verifier agent file (standalone custom agent type with frontmatter)
-		const verifierAgentRendered = await this.renderSwarmWaveVerifierAgent(epicWorktreePath)
+		const verifierAgentRendered = await this.renderSwarmWaveVerifierAgent(pluginDir, epicWorktreePath)
 
 		getLogger().success('Swarm setup complete: agents and skills rendered')
 
@@ -293,6 +330,7 @@ export class SwarmSetupService {
 			renderedAgents,
 			workerAgentRendered,
 			verifierAgentRendered,
+			pluginDir,
 		}
 	}
 }

--- a/templates/agents/iloom-wave-verifier.md
+++ b/templates/agents/iloom-wave-verifier.md
@@ -142,7 +142,7 @@ If any must-haves FAILED, invoke the fix skill to address them:
 CRITICAL: Skills run with `context: fork` and start at the project root. You MUST include the child worktree path so the forked agent works in the correct location.
 
 ```
-/iloom-swarm-issue-implementer "Your working directory is /path/to/child/worktree. cd there before doing any work. Implement the following missing must-haves for issue #NNN '[issue title]'. DO NOT create your own issue comment.
+/iloom-swarm:issue-implementer "Your working directory is /path/to/child/worktree. cd there before doing any work. Implement the following missing must-haves for issue #NNN '[issue title]'. DO NOT create your own issue comment.
 
 The following must-have criteria FAILED verification:
 1. [exists] src/components/Foo.tsx — File does not exist
@@ -204,7 +204,7 @@ After ALL fix skill invocations have completed:
 {{#if HAS_REVIEW_GEMINI}}
 Invoke the code reviewer skill with the pre-gathered diff:
 
-/iloom-swarm-code-reviewer "
+/iloom-swarm:code-reviewer "
 ## Pre-gathered Diff
 
 The following diff contains all changes made in this wave (from pre-wave commit to current epic branch HEAD). Use this diff directly — do NOT run git commands to gather your own diff.
@@ -224,7 +224,7 @@ Collect the skill output as the code review findings.
 {{#if HAS_REVIEW_CODEX}}
 Invoke the code reviewer skill with the pre-gathered diff:
 
-/iloom-swarm-code-reviewer "
+/iloom-swarm:code-reviewer "
 ## Pre-gathered Diff
 
 The following diff contains all changes made in this wave (from pre-wave commit to current epic branch HEAD). Use this diff directly — do NOT run git commands to gather your own diff.
@@ -260,7 +260,7 @@ CRITICAL: Skills run with `context: fork` and start at the project root. You MUS
 For each file that has critical findings, invoke:
 
 ```
-/iloom-swarm-issue-implementer "Your working directory is {{EPIC_WORKTREE_PATH}}. cd there before doing any work.
+/iloom-swarm:issue-implementer "Your working directory is {{EPIC_WORKTREE_PATH}}. cd there before doing any work.
 
 Fix the following critical code review findings in FILE_PATH. DO NOT create your own issue comment. Do NOT commit changes — just make the edits.
 
@@ -270,7 +270,7 @@ Fix the following critical code review findings in FILE_PATH. DO NOT create your
 Fix ONLY these specific issues. Do not refactor or make additional changes beyond what is listed."
 ```
 
-**Parallel invocation:** If critical findings span 3 files, you invoke 3 separate `/iloom-swarm-issue-implementer` skills in a single response message. This runs them concurrently. Each invocation handles findings for ONE file only, preventing edit conflicts.
+**Parallel invocation:** If critical findings span 3 files, you invoke 3 separate `/iloom-swarm:issue-implementer` skills in a single response message. This runs them concurrently. Each invocation handles findings for ONE file only, preventing edit conflicts.
 
 **Fix prompt construction:** Copy each critical finding EXACTLY from the code reviewer's output (file path, line number, score, issue description, and recommendation). Do NOT paraphrase or summarize — the fix agent needs the precise details to locate and fix each issue.
 

--- a/templates/hooks/iloom-hook.js
+++ b/templates/hooks/iloom-hook.js
@@ -330,12 +330,12 @@ async function main() {
 | Request Type | Action |
 |--------------|--------|
 | Trivial (quick answer, single-line fix) | Handle directly |
-| Bug investigation / analysis - ESPECIALLY INVOLVING 3rd PARTY APIs/LIBRARIES | \`@agent-iloom-swarm-issue-analyzer\` → present findings → offer to fix |
-| Code changes | \`@agent-iloom-swarm-issue-implementer\` - TELL THE AGENT NOT TO MAKE/UPDATE ISSUE COMMENTS TO AVOID POLLUTION |
-| On 3rd repeated attempt at fixing the same problem | \`@agent-iloom-swarm-issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm-issue-implementer\` - DO NOT PROVIDE ADDITIONAL GUIDANCE ABOUT ISSUE COMMENTS |
-| New features / complex changes | \`@agent-iloom-swarm-issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm-issue-implementer\` - IN THIS CASE IT'S OK TO CREATE/UPDATE ISSUE COMMENTS |
-| Deep questions (how/why something works) | \`@agent-iloom-swarm-issue-analyzer\` |
-| Code review request | \`@agent-iloom-swarm-code-reviewer\` |`;
+| Bug investigation / analysis - ESPECIALLY INVOLVING 3rd PARTY APIs/LIBRARIES | \`@agent-iloom-swarm:issue-analyzer\` → present findings → offer to fix |
+| Code changes | \`@agent-iloom-swarm:issue-implementer\` - TELL THE AGENT NOT TO MAKE/UPDATE ISSUE COMMENTS TO AVOID POLLUTION |
+| On 3rd repeated attempt at fixing the same problem | \`@agent-iloom-swarm:issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm:issue-implementer\` - DO NOT PROVIDE ADDITIONAL GUIDANCE ABOUT ISSUE COMMENTS |
+| New features / complex changes | \`@agent-iloom-swarm:issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm:issue-implementer\` - IN THIS CASE IT'S OK TO CREATE/UPDATE ISSUE COMMENTS |
+| Deep questions (how/why something works) | \`@agent-iloom-swarm:issue-analyzer\` |
+| Code review request | \`@agent-iloom-swarm:code-reviewer\` |`;
           const output = {
             hookSpecificOutput: {
               hookEventName: 'UserPromptSubmit',
@@ -348,7 +348,7 @@ async function main() {
         }
 
         // Swarm still in progress — agents handle their own workflow, only remind about code reviewer
-        const swarmReminder = `**REMINDER**: When the user requests a code review, use \`@agent-iloom-code-reviewer\`.`;
+        const swarmReminder = `**REMINDER**: When the user requests a code review, use \`@agent-iloom-swarm:code-reviewer\`.`;
         const output = {
           hookSpecificOutput: {
             hookEventName: 'UserPromptSubmit',

--- a/templates/prompts/CLAUDE.md
+++ b/templates/prompts/CLAUDE.md
@@ -16,7 +16,7 @@ il finish <epic>   Merge epic branch back to main
 
 **Orchestrator** (`swarm-orchestrator-prompt.txt`) — runs in the epic worktree, fully autonomous (`bypassPermissions`). Stays lean as a pure coordinator: manages a DAG-based dependency scheduler, spawns child agents in parallel for unblocked issues, monitors completions, delegates all heavy git operations (rebasing, merging, pushing, conflict resolution) to subagents, spawns newly unblocked children, handles failures.
 
-**Child agents** (`iloom-swarm-worker` custom agent type) — each implements one child issue in its own worktree. Strict isolation: only works in its assigned worktree, never merges branches or closes issues (orchestrator handles that). Reports success/failure back to orchestrator then stops.
+**Child agents** (`iloom-swarm:worker` custom agent type) — each implements one child issue in its own worktree. Strict isolation: only works in its assigned worktree, never merges branches or closes issues (orchestrator handles that). Reports success/failure back to orchestrator then stops.
 
 ## Key Files
 

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -7,14 +7,14 @@ Each phase agent is available as a skill in your .claude/skills/ directory.
 **Your MANDATORY FIRST ACTION** is reading the issue details via MCP tools.
 
 **Skill invocation pattern:**
-- Enhancement: /iloom-swarm-issue-enhancer "Enhance issue #ISSUE_NUMBER..."
-- Complexity: /iloom-swarm-issue-complexity-evaluator "Evaluate complexity..."
-- Analysis: /iloom-swarm-issue-analyzer "Analyze issue #ISSUE_NUMBER..."
-- Planning: /iloom-swarm-issue-planner "Create implementation plan..."
-- Analyze+Plan: /iloom-swarm-issue-analyze-and-plan "Analyze and plan..."
-- Implementation: /iloom-swarm-issue-implementer "Implement the plan..."
-- Code Review: /iloom-swarm-code-reviewer "Run code review."
-- Artifact Review: /iloom-swarm-artifact-reviewer "Review this artifact..."
+- Enhancement: /iloom-swarm:issue-enhancer "Enhance issue #ISSUE_NUMBER..."
+- Complexity: /iloom-swarm:issue-complexity-evaluator "Evaluate complexity..."
+- Analysis: /iloom-swarm:issue-analyzer "Analyze issue #ISSUE_NUMBER..."
+- Planning: /iloom-swarm:issue-planner "Create implementation plan..."
+- Analyze+Plan: /iloom-swarm:issue-analyze-and-plan "Analyze and plan..."
+- Implementation: /iloom-swarm:issue-implementer "Implement the plan..."
+- Code Review: /iloom-swarm:code-reviewer "Run code review."
+- Artifact Review: /iloom-swarm:artifact-reviewer "Review this artifact..."
 
 Skills run inline in your context. Their output is directly available to you.
 
@@ -344,19 +344,19 @@ without temp files or output parsing.
 
 **Skill invocation:**
 ```
-/iloom-swarm-<phase> "<prompt for the phase>"
+/iloom-swarm:<phase> "<prompt for the phase>"
 ```
 
 **Available skills:**
-The following skills are pre-rendered in your .claude/skills/ directory:
-- /iloom-swarm-issue-enhancer
-- /iloom-swarm-issue-complexity-evaluator
-- /iloom-swarm-issue-analyzer
-- /iloom-swarm-issue-analyze-and-plan
-- /iloom-swarm-issue-planner
-- /iloom-swarm-issue-implementer
-- /iloom-swarm-code-reviewer
-- /iloom-swarm-artifact-reviewer
+The following skills are available via the iloom-swarm plugin:
+- /iloom-swarm:issue-enhancer
+- /iloom-swarm:issue-complexity-evaluator
+- /iloom-swarm:issue-analyzer
+- /iloom-swarm:issue-analyze-and-plan
+- /iloom-swarm:issue-planner
+- /iloom-swarm:issue-implementer
+- /iloom-swarm:code-reviewer
+- /iloom-swarm:artifact-reviewer
 
 **Output handling:**
 Skill output is returned directly in your conversation. Extract the relevant
@@ -369,42 +369,42 @@ project root, NOT your current working directory. You MUST include the worktree
 path in every skill invocation prompt so the forked agent works in the correct
 location. Example:
 ```
-/iloom-swarm-issue-implementer "Your working directory is /path/to/child/worktree. cd there before doing any work. Implement the plan..."
+/iloom-swarm:issue-implementer "Your working directory is /path/to/child/worktree. cd there before doing any work. Implement the plan..."
 ```
 Always prepend: `"Your working directory is <worktree-path>. cd there before doing any work."`
 
 **Todo List:**
 1. Initialize: cd to worktree, set state to `in_progress` (pass `worktreePath: "<your-worktree-path>"` to target your own metadata, not the epic's), read issue
 2. Run upfront scan to determine workflow plan (enhancement, complexity eval, analysis, planning, implementation decisions)
-3. Run issue enhancement (if needed) via /iloom-swarm-issue-enhancer skill. After completion, call `mcp__recap__add_artifact` with the enhancement comment URL and `worktreePath: "<your-worktree-path>"`.
+3. Run issue enhancement (if needed) via /iloom-swarm:issue-enhancer skill. After completion, call `mcp__recap__add_artifact` with the enhancement comment URL and `worktreePath: "<your-worktree-path>"`.
 {{#if ARTIFACT_REVIEW_ENABLED}}{{#if ENHANCER_REVIEW_ENABLED}}
-3a. Run artifact review on enhancement output via /iloom-swarm-artifact-reviewer skill
+3a. Run artifact review on enhancement output via /iloom-swarm:artifact-reviewer skill
 {{/if}}{{/if}}
 {{#if COMPLEXITY_OVERRIDE}}
 4. Complexity has been overridden to {{COMPLEXITY_OVERRIDE}}. Skip complexity evaluation and proceed directly to routing.
 5. Route to appropriate workflow based on overridden complexity: {{COMPLEXITY_OVERRIDE}}
 {{else}}
-4. Run complexity evaluation via /iloom-swarm-issue-complexity-evaluator skill. After completion, call `mcp__recap__add_artifact` with the complexity evaluation comment URL and `worktreePath: "<your-worktree-path>"`.
+4. Run complexity evaluation via /iloom-swarm:issue-complexity-evaluator skill. After completion, call `mcp__recap__add_artifact` with the complexity evaluation comment URL and `worktreePath: "<your-worktree-path>"`.
 {{#if ARTIFACT_REVIEW_ENABLED}}{{#if COMPLEXITY_REVIEW_ENABLED}}
-4a. Run artifact review on complexity evaluation output via /iloom-swarm-artifact-reviewer skill
+4a. Run artifact review on complexity evaluation output via /iloom-swarm:artifact-reviewer skill
 {{/if}}{{/if}}
 5. Route based on complexity (TRIVIAL skips to implementation, SIMPLE uses combined analyze-and-plan, COMPLEX uses separate analysis then planning)
 {{/if}}
-6. Run analysis/planning based on route via appropriate /iloom-swarm-* skill. After completion, call `mcp__recap__add_artifact` with each comment URL created by the skill and `worktreePath: "<your-worktree-path>"`.
+6. Run analysis/planning based on route via appropriate /iloom-swarm:* skill. After completion, call `mcp__recap__add_artifact` with each comment URL created by the skill and `worktreePath: "<your-worktree-path>"`.
 {{#if ARTIFACT_REVIEW_ENABLED}}{{#if ANALYZER_REVIEW_ENABLED}}
-6a. If COMPLEX: Run artifact review on analysis output via /iloom-swarm-artifact-reviewer skill
+6a. If COMPLEX: Run artifact review on analysis output via /iloom-swarm:artifact-reviewer skill
 {{/if}}{{/if}}
 {{#if ARTIFACT_REVIEW_ENABLED}}{{#if PLANNER_REVIEW_ENABLED}}
-6b. If COMPLEX: Run artifact review on plan output via /iloom-swarm-artifact-reviewer skill
+6b. If COMPLEX: Run artifact review on plan output via /iloom-swarm:artifact-reviewer skill
 {{/if}}{{/if}}
 {{#if ARTIFACT_REVIEW_ENABLED}}{{#if ANALYZE_AND_PLAN_REVIEW_ENABLED}}
-6c. If SIMPLE: Run artifact review on combined analysis and plan output via /iloom-swarm-artifact-reviewer skill
+6c. If SIMPLE: Run artifact review on combined analysis and plan output via /iloom-swarm:artifact-reviewer skill
 {{/if}}{{/if}}
-7. Run implementation via /iloom-swarm-issue-implementer skill. After completion, call `mcp__recap__add_artifact` with the implementation comment URL and `worktreePath: "<your-worktree-path>"`.
+7. Run implementation via /iloom-swarm:issue-implementer skill. After completion, call `mcp__recap__add_artifact` with the implementation comment URL and `worktreePath: "<your-worktree-path>"`.
 {{#if ARTIFACT_REVIEW_ENABLED}}{{#if IMPLEMENTER_REVIEW_ENABLED}}
-7a. Run artifact review on implementation output via /iloom-swarm-artifact-reviewer skill
+7a. Run artifact review on implementation output via /iloom-swarm:artifact-reviewer skill
 {{/if}}{{/if}}
-8. Set state to `code_review` (pass `worktreePath: "<your-worktree-path>"`), run code review via /iloom-swarm-code-reviewer skill
+8. Set state to `code_review` (pass `worktreePath: "<your-worktree-path>"`), run code review via /iloom-swarm:code-reviewer skill
 9. If critical/high issues found, auto-fix and optionally re-review
 10. Stage and commit all changes: `git add -A && git commit -m "feat(issue-<issue-number>): [descriptive summary of changes]"` — the commit message must summarize what was implemented (not just "fixes #NNN")
 11. Set state to `done` (pass `worktreePath: "<your-worktree-path>"`), report structured result to orchestrator
@@ -558,7 +558,7 @@ For the Enhancement Decision specifically: you check whether an existing comment
 
 Only execute if workflow plan determined NEEDS_ENHANCEMENT:
 {{#if SWARM_MODE}}
-1. Execute enhancement phase via /iloom-swarm-issue-enhancer skill with prompt: "Enhance issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
+1. Execute enhancement phase via /iloom-swarm:issue-enhancer skill with prompt: "Enhance issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
 {{else}}
 1. Execute: @agent-iloom-issue-enhancer {{ISSUE_NUMBER}} {{#if ONE_SHOT_MODE}}with the following instructions about assumptions:
    - Before making assumptions, scan ALL issue comments for previously asked questions and their answers.
@@ -587,7 +587,7 @@ Only execute if workflow plan determined NEEDS_ENHANCEMENT:
 2.6. Artifact Review (Enhancement):
    - The enhancer output should be reviewed before posting
 {{#if SWARM_MODE}}
-   - Execute artifact review via /iloom-swarm-artifact-reviewer skill with prompt: "Review this ENHANCEMENT artifact for issue #{{ISSUE_NUMBER}}: [ENHANCER_OUTPUT]"
+   - Execute artifact review via /iloom-swarm:artifact-reviewer skill with prompt: "Review this ENHANCEMENT artifact for issue #{{ISSUE_NUMBER}}: [ENHANCER_OUTPUT]"
 {{else}}
    - Invoke: @agent-iloom-artifact-reviewer with context: "Review this ENHANCEMENT artifact for issue #{{ISSUE_NUMBER}}: [ENHANCER_OUTPUT]"
 {{/if}}
@@ -597,7 +597,7 @@ Only execute if workflow plan determined NEEDS_ENHANCEMENT:
      a. If verdict is SUGGEST_IMPROVEMENTS:
         - Log: "Artifact review suggests improvements: [summary]"
 {{#if SWARM_MODE}}
-        - Re-invoke enhancer via /iloom-swarm-issue-enhancer skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
+        - Re-invoke enhancer via /iloom-swarm:issue-enhancer skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{else}}
         - Re-invoke @agent-iloom-issue-enhancer with: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{/if}}
@@ -605,7 +605,7 @@ Only execute if workflow plan determined NEEDS_ENHANCEMENT:
      b. If verdict is RECOMMEND_REGENERATION:
         - Log: "Artifact review recommends regeneration: [summary]"
 {{#if SWARM_MODE}}
-        - Re-run enhancer via /iloom-swarm-issue-enhancer skill from scratch with the reviewer's feedback, return to step 2
+        - Re-run enhancer via /iloom-swarm:issue-enhancer skill from scratch with the reviewer's feedback, return to step 2
 {{else}}
         - Re-run @agent-iloom-issue-enhancer from scratch with the reviewer's feedback, return to step 2
 {{/if}}
@@ -662,7 +662,7 @@ The complexity has been overridden to **{{COMPLEXITY_OVERRIDE}}** via CLI flag. 
 {{else}}
 Only execute if workflow plan determined NEEDS_COMPLEXITY_EVAL:
 {{#if SWARM_MODE}}
-1. Execute complexity evaluation via /iloom-swarm-issue-complexity-evaluator skill with prompt: "Evaluate complexity for issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
+1. Execute complexity evaluation via /iloom-swarm:issue-complexity-evaluator skill with prompt: "Evaluate complexity for issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
 {{else}}
 1. Execute: @agent-iloom-issue-complexity-evaluator {{ISSUE_NUMBER}} {{#if ONE_SHOT_MODE}}with the following instructions about assumptions:
    - Before making assumptions, scan ALL issue comments for previously asked questions and their answers.
@@ -691,7 +691,7 @@ Only execute if workflow plan determined NEEDS_COMPLEXITY_EVAL:
 2.6. Artifact Review (Complexity Evaluation):
    - The complexity evaluator output should be reviewed before posting
 {{#if SWARM_MODE}}
-   - Execute artifact review via /iloom-swarm-artifact-reviewer skill with prompt: "Review this COMPLEXITY EVALUATION artifact for issue #{{ISSUE_NUMBER}}: [COMPLEXITY_EVALUATOR_OUTPUT]"
+   - Execute artifact review via /iloom-swarm:artifact-reviewer skill with prompt: "Review this COMPLEXITY EVALUATION artifact for issue #{{ISSUE_NUMBER}}: [COMPLEXITY_EVALUATOR_OUTPUT]"
 {{else}}
    - Invoke: @agent-iloom-artifact-reviewer with context: "Review this COMPLEXITY EVALUATION artifact for issue #{{ISSUE_NUMBER}}: [COMPLEXITY_EVALUATOR_OUTPUT]"
 {{/if}}
@@ -701,7 +701,7 @@ Only execute if workflow plan determined NEEDS_COMPLEXITY_EVAL:
      a. If verdict is SUGGEST_IMPROVEMENTS:
         - Log: "Artifact review suggests improvements: [summary]"
 {{#if SWARM_MODE}}
-        - Re-invoke complexity evaluator via /iloom-swarm-issue-complexity-evaluator skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
+        - Re-invoke complexity evaluator via /iloom-swarm:issue-complexity-evaluator skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{else}}
         - Re-invoke @agent-iloom-issue-complexity-evaluator with: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{/if}}
@@ -709,7 +709,7 @@ Only execute if workflow plan determined NEEDS_COMPLEXITY_EVAL:
      b. If verdict is RECOMMEND_REGENERATION:
         - Log: "Artifact review recommends regeneration: [summary]"
 {{#if SWARM_MODE}}
-        - Re-run complexity evaluator via /iloom-swarm-issue-complexity-evaluator skill from scratch with the reviewer's feedback, return to step 2
+        - Re-run complexity evaluator via /iloom-swarm:issue-complexity-evaluator skill from scratch with the reviewer's feedback, return to step 2
 {{else}}
         - Re-run @agent-iloom-issue-complexity-evaluator from scratch with the reviewer's feedback, return to step 2
 {{/if}}
@@ -775,7 +775,7 @@ If workflow plan determined SKIP_COMPLEXITY_EVAL:
 
 Only execute if workflow plan determined NEEDS_ANALYSIS AND complexity is COMPLEX:
 {{#if SWARM_MODE}}
-1. Execute analysis phase via /iloom-swarm-issue-analyzer skill with prompt: "Analyze issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
+1. Execute analysis phase via /iloom-swarm:issue-analyzer skill with prompt: "Analyze issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
 {{else}}
 1. Execute: @agent-iloom-issue-analyzer {{ISSUE_NUMBER}} {{#if ONE_SHOT_MODE}}with the following instructions about assumptions:
    - Before making assumptions, scan ALL issue comments for previously asked questions and their answers.
@@ -804,7 +804,7 @@ Only execute if workflow plan determined NEEDS_ANALYSIS AND complexity is COMPLE
 2.6. Artifact Review (Analysis):
    - The analyzer output should be reviewed before posting
 {{#if SWARM_MODE}}
-   - Execute artifact review via /iloom-swarm-artifact-reviewer skill with prompt: "Review this ANALYSIS artifact for issue #{{ISSUE_NUMBER}}: [ANALYZER_OUTPUT]"
+   - Execute artifact review via /iloom-swarm:artifact-reviewer skill with prompt: "Review this ANALYSIS artifact for issue #{{ISSUE_NUMBER}}: [ANALYZER_OUTPUT]"
 {{else}}
    - Invoke: @agent-iloom-artifact-reviewer with context: "Review this ANALYSIS artifact for issue #{{ISSUE_NUMBER}}: [ANALYZER_OUTPUT]"
 {{/if}}
@@ -814,7 +814,7 @@ Only execute if workflow plan determined NEEDS_ANALYSIS AND complexity is COMPLE
      a. If verdict is SUGGEST_IMPROVEMENTS:
         - Log: "Artifact review suggests improvements: [summary]"
 {{#if SWARM_MODE}}
-        - Re-invoke analyzer via /iloom-swarm-issue-analyzer skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
+        - Re-invoke analyzer via /iloom-swarm:issue-analyzer skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{else}}
         - Re-invoke @agent-iloom-issue-analyzer with: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{/if}}
@@ -822,7 +822,7 @@ Only execute if workflow plan determined NEEDS_ANALYSIS AND complexity is COMPLE
      b. If verdict is RECOMMEND_REGENERATION:
         - Log: "Artifact review recommends regeneration: [summary]"
 {{#if SWARM_MODE}}
-        - Re-run analyzer via /iloom-swarm-issue-analyzer skill from scratch with the reviewer's feedback, return to step 2
+        - Re-run analyzer via /iloom-swarm:issue-analyzer skill from scratch with the reviewer's feedback, return to step 2
 {{else}}
         - Re-run @agent-iloom-issue-analyzer from scratch with the reviewer's feedback, return to step 2
 {{/if}}
@@ -880,7 +880,7 @@ After STEP 1.5 completes and complexity is confirmed, determine which workflow p
 1. Call `recap.set_complexity({ complexity: 'simple', reason: '[brief reason from evaluator]' })`
 {{/if}}
 {{#if SWARM_MODE}}
-2. Log: "Using SIMPLE workflow: Combined analysis and planning via /iloom-swarm-issue-analyze-and-plan skill, then implementation"
+2. Log: "Using SIMPLE workflow: Combined analysis and planning via /iloom-swarm:issue-analyze-and-plan skill, then implementation"
 {{else}}
 2. Display to user: "Using SIMPLE workflow: Combined analysis and planning via @agent-iloom-issue-analyze-and-plan, then implementation"
 {{/if}}
@@ -912,7 +912,7 @@ After STEP 1.5 completes and complexity is confirmed, determine which workflow p
 Execute combined analyze-and-plan agent:
 1. Display: "Executing combined analyze-and-plan agent for SIMPLE task..."
 {{#if SWARM_MODE}}
-2. Execute combined analyze-and-plan phase via /iloom-swarm-issue-analyze-and-plan skill with prompt: "Analyze and plan issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
+2. Execute combined analyze-and-plan phase via /iloom-swarm:issue-analyze-and-plan skill with prompt: "Analyze and plan issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
 {{else}}
 2. Execute: @agent-iloom-issue-analyze-and-plan {{ISSUE_NUMBER}} {{#if ONE_SHOT_MODE}}with the following instructions about assumptions:
    - Before making assumptions, scan ALL issue comments for previously asked questions and their answers.
@@ -943,7 +943,7 @@ Execute combined analyze-and-plan agent:
 3.6. Artifact Review (Analysis and Plan):
    - The analyze-and-plan output should be reviewed before posting
 {{#if SWARM_MODE}}
-   - Execute artifact review via /iloom-swarm-artifact-reviewer skill with prompt: "Review this ANALYSIS AND PLAN artifact for issue #{{ISSUE_NUMBER}}: [ANALYZE_AND_PLAN_OUTPUT]"
+   - Execute artifact review via /iloom-swarm:artifact-reviewer skill with prompt: "Review this ANALYSIS AND PLAN artifact for issue #{{ISSUE_NUMBER}}: [ANALYZE_AND_PLAN_OUTPUT]"
 {{else}}
    - Invoke: @agent-iloom-artifact-reviewer with context: "Review this ANALYSIS AND PLAN artifact for issue #{{ISSUE_NUMBER}}: [ANALYZE_AND_PLAN_OUTPUT]"
 {{/if}}
@@ -953,7 +953,7 @@ Execute combined analyze-and-plan agent:
      a. If verdict is SUGGEST_IMPROVEMENTS:
         - Log: "Artifact review suggests improvements: [summary]"
 {{#if SWARM_MODE}}
-        - Re-invoke analyze-and-plan via /iloom-swarm-issue-analyze-and-plan skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
+        - Re-invoke analyze-and-plan via /iloom-swarm:issue-analyze-and-plan skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{else}}
         - Re-invoke @agent-iloom-issue-analyze-and-plan with: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{/if}}
@@ -961,7 +961,7 @@ Execute combined analyze-and-plan agent:
      b. If verdict is RECOMMEND_REGENERATION:
         - Log: "Artifact review recommends regeneration: [summary]"
 {{#if SWARM_MODE}}
-        - Re-run analyze-and-plan via /iloom-swarm-issue-analyze-and-plan skill from scratch with the reviewer's feedback, return to step 2
+        - Re-run analyze-and-plan via /iloom-swarm:issue-analyze-and-plan skill from scratch with the reviewer's feedback, return to step 2
 {{else}}
         - Re-run @agent-iloom-issue-analyze-and-plan from scratch with the reviewer's feedback, return to step 2
 {{/if}}
@@ -997,7 +997,7 @@ Execute combined analyze-and-plan agent:
 
 Only execute if workflow plan determined NEEDS_PLANNING AND complexity is COMPLEX:
 {{#if SWARM_MODE}}
-1. Execute planning phase via /iloom-swarm-issue-planner skill with prompt: "Create implementation plan for issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
+1. Execute planning phase via /iloom-swarm:issue-planner skill with prompt: "Create implementation plan for issue #ISSUE_NUMBER. Before making assumptions, scan ALL issue comments for previously asked questions and their answers. When creating question tables, fill in your own assumed answers."
 {{else}}
 1. Execute: @agent-iloom-issue-planner {{ISSUE_NUMBER}} {{#if ONE_SHOT_MODE}}with the following instructions about assumptions:
    - Before making assumptions, scan ALL issue comments for previously asked questions and their answers.
@@ -1028,7 +1028,7 @@ Only execute if workflow plan determined NEEDS_PLANNING AND complexity is COMPLE
 2.6. Artifact Review (Plan):
    - The planner output should be reviewed before posting
 {{#if SWARM_MODE}}
-   - Execute artifact review via /iloom-swarm-artifact-reviewer skill with prompt: "Review this PLAN artifact for issue #{{ISSUE_NUMBER}}: [PLANNER_OUTPUT]"
+   - Execute artifact review via /iloom-swarm:artifact-reviewer skill with prompt: "Review this PLAN artifact for issue #{{ISSUE_NUMBER}}: [PLANNER_OUTPUT]"
 {{else}}
    - Invoke: @agent-iloom-artifact-reviewer with context: "Review this PLAN artifact for issue #{{ISSUE_NUMBER}}: [PLANNER_OUTPUT]"
 {{/if}}
@@ -1038,7 +1038,7 @@ Only execute if workflow plan determined NEEDS_PLANNING AND complexity is COMPLE
      a. If verdict is SUGGEST_IMPROVEMENTS:
         - Log: "Artifact review suggests improvements: [summary]"
 {{#if SWARM_MODE}}
-        - Re-invoke planner via /iloom-swarm-issue-planner skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
+        - Re-invoke planner via /iloom-swarm:issue-planner skill with prompt: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{else}}
         - Re-invoke @agent-iloom-issue-planner with: "Apply these specific improvements to your existing comment (comment ID: [COMMENT_ID]): [REVIEWER_FEEDBACK]"
 {{/if}}
@@ -1046,7 +1046,7 @@ Only execute if workflow plan determined NEEDS_PLANNING AND complexity is COMPLE
      b. If verdict is RECOMMEND_REGENERATION:
         - Log: "Artifact review recommends regeneration: [summary]"
 {{#if SWARM_MODE}}
-        - Re-run planner via /iloom-swarm-issue-planner skill from scratch with the reviewer's feedback, return to step 2
+        - Re-run planner via /iloom-swarm:issue-planner skill from scratch with the reviewer's feedback, return to step 2
 {{else}}
         - Re-run @agent-iloom-issue-planner from scratch with the reviewer's feedback, return to step 2
 {{/if}}
@@ -1118,12 +1118,12 @@ Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
 
 {{#if SWARM_MODE}}
       **If line says "Run Step N" (sequential):**
-      - Execute implementer via /iloom-swarm-issue-implementer skill with prompt: "You are implementing Step N of the plan in comment [COMMENT_ID] on issue #ISSUE_NUMBER. DO NOT create your own issue comment."
+      - Execute implementer via /iloom-swarm:issue-implementer skill with prompt: "You are implementing Step N of the plan in comment [COMMENT_ID] on issue #ISSUE_NUMBER. DO NOT create your own issue comment."
       - Wait for completion
       - Update progress comment: `- [x] Step N: [name] - [brief result]`
 
       **If line says "Run Steps X, Y, Z in parallel":**
-      - Execute each step sequentially via /iloom-swarm-issue-implementer skill (skills run inline, so execute one at a time)
+      - Execute each step sequentially via /iloom-swarm:issue-implementer skill (skills run inline, so execute one at a time)
       - Each with prompt: "You are implementing Step N of the plan in comment [COMMENT_ID] on issue #ISSUE_NUMBER. DO NOT create your own issue comment."
       - Update progress comment for all completed steps
 {{else}}
@@ -1142,7 +1142,7 @@ Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
    **FOR SIMPLE/TRIVIAL workflows (single implementation run):**
 
 {{#if SWARM_MODE}}
-   - Execute implementer via /iloom-swarm-issue-implementer skill with prompt: "Implement the plan in comment [COMMENT_ID] for issue #ISSUE_NUMBER. DO NOT create your own issue comment."
+   - Execute implementer via /iloom-swarm:issue-implementer skill with prompt: "Implement the plan in comment [COMMENT_ID] for issue #ISSUE_NUMBER. DO NOT create your own issue comment."
    - Wait for completion
 {{else}}
    - Launch ONE @agent-iloom-issue-implementer with: "The plan is in comment [COMMENT_ID]. DO NOT create your own issue comment."
@@ -1195,7 +1195,7 @@ Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
 5.5. Artifact Review (Implementation):
    - The implementer output should be reviewed for plan alignment before code review
 {{#if SWARM_MODE}}
-   - Execute artifact review via /iloom-swarm-artifact-reviewer skill with prompt: "Review this IMPLEMENTATION artifact for issue #{{ISSUE_NUMBER}}: [IMPLEMENTER_OUTPUT]. The plan it was executing: [PLAN_CONTENT]"
+   - Execute artifact review via /iloom-swarm:artifact-reviewer skill with prompt: "Review this IMPLEMENTATION artifact for issue #{{ISSUE_NUMBER}}: [IMPLEMENTER_OUTPUT]. The plan it was executing: [PLAN_CONTENT]"
 {{else}}
    - Invoke: @agent-iloom-artifact-reviewer with context: "Review this IMPLEMENTATION artifact for issue #{{ISSUE_NUMBER}}: [IMPLEMENTER_OUTPUT]. The plan it was executing: [PLAN_CONTENT]"
 {{/if}}
@@ -1205,7 +1205,7 @@ Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
      a. If verdict is SUGGEST_IMPROVEMENTS:
         - Log: "Artifact review suggests improvements: [summary]"
 {{#if SWARM_MODE}}
-        - Re-invoke implementer via /iloom-swarm-issue-implementer skill with prompt: "Apply these specific improvements to address plan gaps: [REVIEWER_FEEDBACK]"
+        - Re-invoke implementer via /iloom-swarm:issue-implementer skill with prompt: "Apply these specific improvements to address plan gaps: [REVIEWER_FEEDBACK]"
 {{else}}
         - Re-invoke @agent-iloom-issue-implementer with: "Apply these specific improvements to address plan gaps: [REVIEWER_FEEDBACK]"
 {{/if}}
@@ -1213,7 +1213,7 @@ Only execute if workflow plan determined NEEDS_IMPLEMENTATION:
      b. If verdict is RECOMMEND_REGENERATION:
         - Log: "Artifact review recommends regeneration: [summary]"
 {{#if SWARM_MODE}}
-        - Re-run implementer via /iloom-swarm-issue-implementer skill from scratch with the reviewer's feedback
+        - Re-run implementer via /iloom-swarm:issue-implementer skill from scratch with the reviewer's feedback
 {{else}}
         - Re-run @agent-iloom-issue-implementer from scratch with the reviewer's feedback
 {{/if}}
@@ -1247,7 +1247,7 @@ This section is about reviewing code changes for quality, security, and complian
 **Auto-Run Mode**: Review automatically executes after implementation completes. No manual trigger needed.
 
 {{#if SWARM_MODE}}
-1. Execute code review via /iloom-swarm-code-reviewer skill with prompt: "Run code review."
+1. Execute code review via /iloom-swarm:code-reviewer skill with prompt: "Run code review."
 {{else}}
 1. Execute: @agent-iloom-code-reviewer with prompt "Run code review." (foreground, no extra context)
 {{/if}}

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -219,7 +219,7 @@ Before spawning, check if a child issue is a **verification task** by examining 
 #### Spawning Regular (Implementation) Issues
 
 For regular child issues (non-verification), use these parameters:
-- `subagent_type`: `"iloom-swarm-worker"`
+- `subagent_type`: `"iloom-swarm:worker"`
 - `mode`: `"delegate"`
 - `team_name`: `"{{SWARM_TEAM_NAME}}"`
 - `name`: `"issue-<child-number>"`
@@ -241,7 +241,7 @@ Nothing else. No title. No body. No instructions. No context. The child's system
 
 For verification child issues (title starts with "Verify"), use the wave verifier agent instead of the regular swarm worker:
 
-- `subagent_type`: `"iloom-swarm-wave-verifier"`
+- `subagent_type`: `"iloom-swarm:wave-verifier"`
 - `mode`: `"delegate"`
 - `team_name`: `"{{SWARM_TEAM_NAME}}"`
 - `name`: `"verifier-<child-number>"`
@@ -483,7 +483,7 @@ git log --oneline -5
 
 **Delegate this to a subagent.** Spawn a Task subagent using the code reviewer agent directly:
 
-- `subagent_type`: `"iloom-swarm-code-reviewer"`
+- `subagent_type`: `"iloom-swarm:code-reviewer"`
 - Prompt:
 
 ```


### PR DESCRIPTION
Fixes #916

## Use --plugin-dir for swarm agents to avoid rulesync conflicts

## Problem

When a project uses [rulesync](https://github.com/dyoshikawa/rulesync) to manage its `.claude/` directory, the `rulesync generate` command overwrites `.claude/agents/` and `.claude/skills/` from `.rulesync/subagents/` and `.rulesync/skills/` sources. This clobbers the `iloom-swarm-*` agent and skill files that `SwarmSetupService.setupSwarm()` renders during `il spin`.

**Reproduction:**
1. Project has rulesync configured with a `postinstall` hook (`"postinstall": "rulesync generate"`) and/or a Claude Code `SessionStart` hook that runs `pnpm install`
2. `il spin` detects an epic and calls `setupSwarm()` → writes `iloom-swarm-*.md` agents and `iloom-swarm-*/SKILL.md` skills to `.claude/`
3. `rulesync generate` runs (via hook or install) → regenerates `.claude/agents/`, `.claude/skills/`, `.claude/commands/` from `.rulesync/` sources
4. All `iloom-swarm-*` files are gone — orchestrator can't spawn workers or verifiers

## Proposed Solution

Use Claude Code's `--plugin-dir` flag to load swarm agents from a standalone plugin directory in a temp directory, where rulesync can't touch them. Agents are loaded into memory at session start, so the directory doesn't need to persist.

**Plugin directory structure:**
```
$TMPDIR/iloom-swarm-plugin-<random>/
├── .claude-plugin/
│   └── plugin.json          # {"name": "iloom-swarm", "version": "<cli-version>"}
├── agents/
│   ├── issue-analyzer.md
│   ├── issue-planner.md
│   ├── issue-implementer.md
│   ├── issue-enhancer.md
│   ├── code-reviewer.md
│   ├── artifact-reviewer.md
│   ├── issue-analyze-and-plan.md
│   ├── issue-complexity-evaluator.md
│   ├── worker.md
│   └── wave-verifier.md
└── skills/
    ├── issue-analyzer/SKILL.md
    ├── issue-planner/SKILL.md
    └── ... (all swarm skill wrappers)
```

Plugin agents are namespaced as `plugin-name:agent-name`, so with plugin name `iloom-swarm`:
- `agents/worker.md` → `iloom-swarm:worker`
- `agents/wave-verifier.md` → `iloom-swarm:wave-verifier`
- `skills/issue-analyzer/SKILL.md` → `/iloom-swarm:issue-analyzer`

**Changes needed:**

1. **`SwarmSetupService`** — Redirect `renderSwarmAgents()`, `renderSwarmWorkerAgent()`, and `renderSwarmWaveVerifierAgent()` to write to a temp plugin directory instead of `.claude/agents/` and `.claude/skills/`. Add `createPluginManifest()`. Return the plugin dir path from `setupSwarm()`. Drop the `iloom-swarm-` prefix from agent filenames/names since the plugin namespace provides it.

2. **`ignite.ts` (executeSwarmMode)** — Pass `pluginDir` to `launchClaude()`. Infrastructure already exists (`ClaudeCliOptions.pluginDir` is wired up but unused).

3. **Orchestrator prompt** (`swarm-orchestrator-prompt.txt`) — Update `subagent_type` references:
   - `"iloom-swarm-worker"` → `"iloom-swarm:worker"`
   - `"iloom-swarm-wave-verifier"` → `"iloom-swarm:wave-verifier"`

4. **Stop writing swarm agents to `.claude/`** — Remove the current disk rendering to the worktree's `.claude/agents/` and `.claude/skills/` directories.

**Benefits:**
- Plugin agents merge with `.claude/agents/` — no conflict with rulesync or any other `.claude/` management tool
- Temp dir is outside the worktree — immune to git operations and file sync tools
- Agents loaded into memory at session start — temp dir can be cleaned up by OS naturally
- `launchClaude` already accepts `pluginDir` — minimal wiring needed
- Platform-agnostic (works on macOS, Linux, Windows)
- Clean namespacing (`iloom-swarm:worker` instead of `iloom-swarm-worker`)

## Additional Context

- `launchClaude` already supports `pluginDir` option (src/utils/claude.ts) with tests — just needs to be used
- This also benefits the regular (non-swarm) spin path if projects manage `.claude/agents/` externally
- Consider whether the non-swarm agent loading (`loadAndPrepare` in regular spin) should also use plugin-dir for consistency

---
*This PR was created automatically by iloom.*