### PR TITLE
Support configuring dev server protocol (https) for displayed URLs

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -828,6 +828,7 @@ Set `capabilities.web.devServer` to `"docker"` in your `.iloom/settings.json`:
 {
   "capabilities": {
     "web": {
+      "protocol": "https",
       "devServer": "docker",
       "dockerFile": "./Dockerfile",
       "containerPort": 4200,
@@ -847,6 +848,7 @@ Set `capabilities.web.devServer` to `"docker"` in your `.iloom/settings.json`:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `protocol` | `"http"` \| `"https"` | `"http"` | Protocol for dev server URLs. Set to `"https"` if your app serves over HTTPS (e.g., Angular with `ssl: true`). Applies to all dev server modes (native process and Docker). |
 | `devServer` | `"process"` \| `"docker"` | `"process"` | Dev server execution mode. `"process"` runs natively, `"docker"` runs inside a Docker container with port mapping. |
 | `dockerFile` | `string` | `"./Dockerfile"` | Path to the Dockerfile relative to the worktree root. Only used when `devServer` is `"docker"`. |
 | `containerPort` | `number` | Auto-detected | Port the application listens on inside the Docker container. If not set, iloom attempts to detect it from `EXPOSE` directives in the built Docker image (via `docker image inspect`), falling back to Dockerfile parsing. |
@@ -862,7 +864,7 @@ Each loom workspace gets a unique port calculated as `basePort + issue/PR number
 2. The container runs with `-p <workspace-port>:<container-port>`
 3. Your app runs on `containerPort` inside the container (e.g., 4200 for Angular)
 4. Docker maps that to the workspace port on the host (e.g., 3025)
-5. You access the app at `http://localhost:3025` as usual
+5. You access the app at `http://localhost:3025` (or `https://` if `protocol` is set to `"https"`) as usual
 
 This means frameworks that hardcode their listen port work correctly -- Docker handles the port translation transparently.
 

--- a/src/commands/dev-server.test.ts
+++ b/src/commands/dev-server.test.ts
@@ -226,6 +226,26 @@ describe('DevServerCommand', () => {
 			)
 		})
 
+		it('should use https protocol when configured', async () => {
+			const mockCapabilities: ProjectCapabilities = {
+				capabilities: ['web'],
+				binEntries: {},
+			}
+			vi.mocked(mockCapabilityDetector.detectCapabilities).mockResolvedValue(mockCapabilities)
+			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValue({
+				capabilities: { web: { protocol: 'https' as const } },
+			})
+
+			vi.mocked(fs.pathExists).mockResolvedValue(true)
+			vi.mocked(fs.readFile).mockResolvedValue('PORT=3087\n')
+
+			const result = await command.execute({ identifier: '87' })
+
+			expect(result.status).toBe('started')
+			expect(result.url).toBe('https://localhost:3087')
+			expect(result.port).toBe(3087)
+		})
+
 		it('should return gracefully for non-web project with info message', async () => {
 			const mockCapabilities: ProjectCapabilities = {
 				capabilities: ['cli'],

--- a/src/commands/dev-server.ts
+++ b/src/commands/dev-server.ts
@@ -9,6 +9,7 @@ import { IdentifierParser } from '../utils/IdentifierParser.js'
 import { loadWorkspaceEnv, isNoEnvFilesFoundError } from '../utils/env.js'
 import { getWorkspacePort } from '../utils/port.js'
 import { extractIssueNumber } from '../utils/git.js'
+import { buildDevServerUrl } from '../utils/dev-server.js'
 import { logger } from '../utils/logger.js'
 import { extractSettingsOverrides } from '../utils/cli-overrides.js'
 import type { GitWorktree } from '../types/worktree.js'
@@ -139,7 +140,8 @@ export class DevServerCommand {
 			basePort: settingsForPort.capabilities?.web?.basePort,
 			checkEnvFile: true,
 		})
-		const url = `http://localhost:${port}`
+		const protocol = settingsForPort.capabilities?.web?.protocol ?? 'http'
+		const url = buildDevServerUrl(port, protocol)
 
 		// 6. Check if server already running
 		const isRunning = await this.devServerManager.isServerRunning(port, dockerConfig)

--- a/src/commands/open.test.ts
+++ b/src/commands/open.test.ts
@@ -18,12 +18,11 @@ vi.mock('../lib/DevServerManager.js')
 vi.mock('../utils/IdentifierParser.js')
 vi.mock('fs-extra')
 vi.mock('execa')
+const mockLoadSettings = vi.fn().mockResolvedValue({})
 vi.mock('../lib/SettingsManager.js', () => {
 	return {
 		SettingsManager: class MockSettingsManager {
-			async loadSettings() {
-				return {}
-			}
+			loadSettings = mockLoadSettings
 		},
 	}
 })
@@ -65,9 +64,6 @@ describe('OpenCommand', () => {
 		mockDevServerManager = new DevServerManager()
 		mockIdentifierParser = new IdentifierParser(mockGitWorktreeManager)
 
-		// Mock DevServerManager to always return true (server ready)
-		vi.mocked(mockDevServerManager.ensureServerRunning).mockResolvedValue(true)
-
 		command = new OpenCommand(
 			mockGitWorktreeManager,
 			mockCapabilityDetector,
@@ -75,8 +71,14 @@ describe('OpenCommand', () => {
 			mockDevServerManager
 		)
 
-		// Reset all mocks
+		// Reset all mocks then set defaults
 		vi.clearAllMocks()
+
+		// Mock DevServerManager to always return true (server ready)
+		vi.mocked(mockDevServerManager.ensureServerRunning).mockResolvedValue(true)
+
+		// Mock SettingsManager to return empty settings by default
+		mockLoadSettings.mockResolvedValue({})
 	})
 
 	describe('workspace detection', () => {
@@ -726,6 +728,19 @@ describe('OpenCommand', () => {
 
 			// Should not call ensureServerRunning for CLI-only projects
 			expect(mockDevServerManager.ensureServerRunning).not.toHaveBeenCalled()
+		})
+
+		it('should use https protocol when configured', async () => {
+			mockLoadSettings.mockResolvedValue({
+				capabilities: { web: { protocol: 'https' } },
+			})
+
+			vi.mocked(fs.pathExists).mockResolvedValue(true)
+			vi.mocked(fs.readFile).mockResolvedValue('PORT=3087\n')
+
+			await command.execute({ identifier: '87' })
+
+			expect(openBrowser).toHaveBeenCalledWith('https://localhost:3087')
 		})
 	})
 })

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -10,6 +10,7 @@ import { IdentifierParser } from '../utils/IdentifierParser.js'
 import { openBrowser } from '../utils/browser.js'
 import { getWorkspacePort } from '../utils/port.js'
 import { extractIssueNumber } from '../utils/git.js'
+import { buildDevServerUrl } from '../utils/dev-server.js'
 import { logger } from '../utils/logger.js'
 import { extractSettingsOverrides } from '../utils/cli-overrides.js'
 import type { GitWorktree } from '../types/worktree.js'
@@ -254,7 +255,8 @@ export class OpenCommand {
 		}
 
 		// Construct URL and open browser
-		const url = `http://localhost:${port}`
+		const protocol = settings.capabilities?.web?.protocol ?? 'http'
+		const url = buildDevServerUrl(port, protocol)
 		logger.info(`Opening browser: ${url}`)
 		await openBrowser(url)
 		logger.success('Browser opened')

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -18,12 +18,11 @@ vi.mock('../lib/DevServerManager.js')
 vi.mock('../utils/IdentifierParser.js')
 vi.mock('fs-extra')
 vi.mock('execa')
+const mockLoadSettings = vi.fn().mockResolvedValue({})
 vi.mock('../lib/SettingsManager.js', () => {
 	return {
 		SettingsManager: class MockSettingsManager {
-			async loadSettings() {
-				return {}
-			}
+			loadSettings = mockLoadSettings
 		},
 	}
 })
@@ -65,9 +64,6 @@ describe('RunCommand', () => {
 		mockDevServerManager = new DevServerManager()
 		mockIdentifierParser = new IdentifierParser(mockGitWorktreeManager)
 
-		// Mock DevServerManager to always return true (server ready)
-		vi.mocked(mockDevServerManager.ensureServerRunning).mockResolvedValue(true)
-
 		command = new RunCommand(
 			mockGitWorktreeManager,
 			mockCapabilityDetector,
@@ -75,8 +71,14 @@ describe('RunCommand', () => {
 			mockDevServerManager
 		)
 
-		// Reset all mocks
+		// Reset all mocks then set defaults
 		vi.clearAllMocks()
+
+		// Mock DevServerManager to always return true (server ready)
+		vi.mocked(mockDevServerManager.ensureServerRunning).mockResolvedValue(true)
+
+		// Mock SettingsManager to return empty settings by default
+		mockLoadSettings.mockResolvedValue({})
 	})
 
 	describe('workspace detection', () => {
@@ -623,6 +625,19 @@ describe('RunCommand', () => {
 
 			// Should not call ensureServerRunning for CLI-only projects
 			expect(mockDevServerManager.ensureServerRunning).not.toHaveBeenCalled()
+		})
+
+		it('should use https protocol when configured', async () => {
+			mockLoadSettings.mockResolvedValue({
+				capabilities: { web: { protocol: 'https' } },
+			})
+
+			vi.mocked(fs.pathExists).mockResolvedValue(true)
+			vi.mocked(fs.readFile).mockResolvedValue('PORT=3087\n')
+
+			await command.execute({ identifier: '87' })
+
+			expect(openBrowser).toHaveBeenCalledWith('https://localhost:3087')
 		})
 	})
 })

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,6 +10,7 @@ import { IdentifierParser } from '../utils/IdentifierParser.js'
 import { openBrowser } from '../utils/browser.js'
 import { getWorkspacePort } from '../utils/port.js'
 import { extractIssueNumber } from '../utils/git.js'
+import { buildDevServerUrl } from '../utils/dev-server.js'
 import { logger } from '../utils/logger.js'
 import { extractSettingsOverrides } from '../utils/cli-overrides.js'
 import type { GitWorktree } from '../types/worktree.js'
@@ -296,7 +297,8 @@ export class RunCommand {
 		}
 
 		// Construct URL and open browser
-		const url = `http://localhost:${port}`
+		const protocol = settings.capabilities?.web?.protocol ?? 'http'
+		const url = buildDevServerUrl(port, protocol)
 		logger.info(`Opening browser: ${url}`)
 		await openBrowser(url)
 		logger.success('Browser opened')

--- a/src/lib/DevServerManager.ts
+++ b/src/lib/DevServerManager.ts
@@ -64,6 +64,7 @@ function toStrategyConfig(config: DockerConfig): StrategyDockerConfig {
 		buildSecrets: config.dockerBuildSecrets,
 		runArgs: config.dockerRunArgs,
 		identifier: config.identifier,
+		protocol: config.protocol,
 	}
 }
 

--- a/src/lib/DockerDevServerStrategy.ts
+++ b/src/lib/DockerDevServerStrategy.ts
@@ -21,6 +21,8 @@ export interface DockerConfig {
 	runArgs?: string[] | undefined
 	/** Identifier for naming containers/images (issue number, branch name). Falls back to worktreePath if not set. */
 	identifier?: string | undefined
+	/** Protocol for displayed URLs (http or https, default http) */
+	protocol?: 'http' | 'https' | undefined
 }
 
 /**
@@ -236,7 +238,8 @@ export class DockerDevServerStrategy {
 
 		args.push(imageName)
 
-		logger.info(`Starting Docker container "${containerName}" in background (http://localhost:${hostPort} → container:${containerPort})...`)
+		const displayProtocol = config.protocol ?? 'http'
+		logger.info(`Starting Docker container "${containerName}" in background (${displayProtocol}://localhost:${hostPort} → container:${containerPort})...`)
 
 		try {
 			await execa('docker', args)
@@ -303,7 +306,8 @@ export class DockerDevServerStrategy {
 
 		args.push(imageName)
 
-		logger.info(`Running Docker container "${containerName}" in foreground (http://localhost:${hostPort} → container:${containerPort})...`)
+		const displayProtocol = config.protocol ?? 'http'
+		logger.info(`Running Docker container "${containerName}" in foreground (${displayProtocol}://localhost:${hostPort} → container:${containerPort})...`)
 
 		const stdio = redirectToStderr
 			? [process.stdin, process.stderr, process.stderr] as const

--- a/src/lib/DockerManager.ts
+++ b/src/lib/DockerManager.ts
@@ -31,6 +31,8 @@ export interface DockerConfig {
 	dockerRunArgs?: string[] | undefined
 	/** Identifier for container naming (issue number, branch name) */
 	identifier: string
+	/** Protocol for dev server URLs (http or https) */
+	protocol?: 'http' | 'https' | undefined
 }
 
 /**
@@ -45,6 +47,7 @@ interface WebSettings {
 	dockerBuildArgs?: Record<string, string> | undefined
 	dockerBuildSecrets?: Record<string, string> | undefined
 	dockerRunArgs?: string[] | undefined
+	protocol?: 'http' | 'https' | undefined
 }
 
 /**
@@ -428,6 +431,7 @@ export class DockerManager {
 			dockerBuildSecrets: webSettings.dockerBuildSecrets,
 			dockerRunArgs: webSettings.dockerRunArgs,
 			identifier,
+			protocol: webSettings.protocol,
 		}
 	}
 }

--- a/src/lib/SettingsManager.test.ts
+++ b/src/lib/SettingsManager.test.ts
@@ -1358,6 +1358,120 @@ describe('SettingsManager', () => {
 		})
 	})
 
+	describe('capabilities.web.protocol configuration', () => {
+		it('should accept "http" as protocol value', async () => {
+			const projectRoot = '/test/project'
+			const settings = {
+				capabilities: {
+					web: {
+						protocol: 'http',
+					},
+				},
+			}
+
+			const error: { code?: string; message: string } = {
+				code: 'ENOENT',
+				message: 'File not found',
+			}
+			vi.mocked(readFile)
+			.mockRejectedValueOnce(error) // global settings
+			.mockResolvedValueOnce(JSON.stringify(settings)) // settings.json
+			.mockRejectedValueOnce(error) // settings.local.json
+
+			const result = await settingsManager.loadSettings(projectRoot)
+			expect(result.capabilities?.web?.protocol).toBe('http')
+		})
+
+		it('should accept "https" as protocol value', async () => {
+			const projectRoot = '/test/project'
+			const settings = {
+				capabilities: {
+					web: {
+						protocol: 'https',
+					},
+				},
+			}
+
+			const error: { code?: string; message: string } = {
+				code: 'ENOENT',
+				message: 'File not found',
+			}
+			vi.mocked(readFile)
+			.mockRejectedValueOnce(error) // global settings
+			.mockResolvedValueOnce(JSON.stringify(settings)) // settings.json
+			.mockRejectedValueOnce(error) // settings.local.json
+
+			const result = await settingsManager.loadSettings(projectRoot)
+			expect(result.capabilities?.web?.protocol).toBe('https')
+		})
+
+		it('should reject invalid protocol value (e.g., "ftp")', async () => {
+			const projectRoot = '/test/project'
+			const settings = {
+				capabilities: {
+					web: {
+						protocol: 'ftp',
+					},
+				},
+			}
+
+			const error: { code?: string; message: string } = {
+				code: 'ENOENT',
+				message: 'File not found',
+			}
+			vi.mocked(readFile)
+			.mockRejectedValueOnce(error) // global settings
+			.mockResolvedValueOnce(JSON.stringify(settings)) // settings.json
+			.mockRejectedValueOnce(error) // settings.local.json
+
+			await expect(settingsManager.loadSettings(projectRoot)).rejects.toThrow(
+				/Settings validation failed[\s\S]*capabilities\.web\.protocol/,
+			)
+		})
+
+		it('should default to "http" when not specified', async () => {
+			const projectRoot = '/test/project'
+			const settings = {
+				capabilities: {
+					web: {
+						basePort: 3000,
+					},
+				},
+			}
+
+			const error: { code?: string; message: string } = {
+				code: 'ENOENT',
+				message: 'File not found',
+			}
+			vi.mocked(readFile)
+			.mockRejectedValueOnce(error) // global settings
+			.mockResolvedValueOnce(JSON.stringify(settings)) // settings.json
+			.mockRejectedValueOnce(error) // settings.local.json
+
+			const result = await settingsManager.loadSettings(projectRoot)
+			expect(result.capabilities?.web?.protocol).toBe('http')
+		})
+
+		it('should accept missing capabilities.web.protocol (uses default)', async () => {
+			const projectRoot = '/test/project'
+			const settings = {
+				mainBranch: 'main',
+			}
+
+			const error: { code?: string; message: string } = {
+				code: 'ENOENT',
+				message: 'File not found',
+			}
+			vi.mocked(readFile)
+			.mockRejectedValueOnce(error) // global settings
+			.mockResolvedValueOnce(JSON.stringify(settings)) // settings.json
+			.mockRejectedValueOnce(error) // settings.local.json
+
+			const result = await settingsManager.loadSettings(projectRoot)
+			expect(result.capabilities?.web?.protocol).toBeUndefined()
+		})
+	})
+
 	describe('WorkflowPermissionSchema - Component Launch Configuration', () => {
 		it('should validate workflow config with all component flags enabled', async () => {
 			const projectRoot = '/test/project'

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -212,6 +212,10 @@ export const CapabilitiesSettingsSchema = z
 					.max(65535, 'Base port must be <= 65535')
 					.optional()
 					.describe('Base port for web workspace port calculations (default: 3000)'),
+				protocol: z
+					.enum(['http', 'https'])
+					.default('http')
+					.describe('Protocol for dev server URLs (http or https)'),
 				devServer: z
 					.enum(['process', 'docker'])
 					.default('process')
@@ -268,6 +272,10 @@ export const CapabilitiesSettingsSchemaNoDefaults = z
 					.max(65535, 'Base port must be <= 65535')
 					.optional()
 					.describe('Base port for web workspace port calculations (default: 3000)'),
+				protocol: z
+					.enum(['http', 'https'])
+					.optional()
+					.describe('Protocol for dev server URLs (http or https)'),
 				devServer: z
 					.enum(['process', 'docker'])
 					.optional()

--- a/src/utils/dev-server.test.ts
+++ b/src/utils/dev-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildDevServerCommand, getDevServerLaunchCommand } from './dev-server.js'
+import { buildDevServerCommand, buildDevServerUrl, getDevServerLaunchCommand } from './dev-server.js'
 import * as packageManager from './package-manager.js'
 
 // Mock package-manager module
@@ -128,5 +128,19 @@ describe('getDevServerLaunchCommand', () => {
 		const parts = command.split(' && ')
 		expect(parts).toHaveLength(1)
 		expect(parts[0]).toBe('npm run dev')
+	})
+})
+
+describe('buildDevServerUrl', () => {
+	it('should return http URL by default', () => {
+		expect(buildDevServerUrl(3087)).toBe('http://localhost:3087')
+	})
+
+	it('should return http URL when protocol is http', () => {
+		expect(buildDevServerUrl(3087, 'http')).toBe('http://localhost:3087')
+	})
+
+	it('should return https URL when protocol is https', () => {
+		expect(buildDevServerUrl(3087, 'https')).toBe('https://localhost:3087')
 	})
 })

--- a/src/utils/dev-server.ts
+++ b/src/utils/dev-server.ts
@@ -3,6 +3,13 @@ import { logger } from './logger.js'
 import type { Capability } from '../types/loom.js'
 
 /**
+ * Build the dev server URL from port and protocol
+ */
+export function buildDevServerUrl(port: number, protocol: 'http' | 'https' = 'http'): string {
+	return `${protocol}://localhost:${port}`
+}
+
+/**
  * Build dev server command for workspace
  * Detects package manager and constructs appropriate command
  */


### PR DESCRIPTION
Fixes #920

## Support configuring dev server protocol (https) for displayed URLs

When using dev server mode (both Docker and process), iloom displays the dev server URL as `http://localhost:<port>`. However, if the app serves over HTTPS (e.g., Angular with `ssl: true` in serve options), the displayed URL is incorrect and won't work in the browser.

This affects all dev server modes, not just Docker.

**Suggested enhancement:** Add a `protocol` option to the web capabilities settings, e.g.:

```json
{
  "capabilities": {
    "web": {
      "protocol": "https"
    }
  }
}
```

This would change the displayed URL from `http://localhost:4232` to `https://localhost:4232`.

Default should remain `http` for backward compatibility.

---
*This PR was created automatically by iloom.*