### PR TITLE
Lightweight TUI for `il dev-server` with sticky URL status bar

### DIFF
--- a/src/commands/dev-server.test.ts
+++ b/src/commands/dev-server.test.ts
@@ -222,6 +222,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.any(Object),
+				undefined,
 				undefined
 			)
 		})
@@ -327,6 +328,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.any(Object),
+				undefined,
 				undefined
 			)
 		})
@@ -350,6 +352,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.any(Object),
+				undefined,
 				undefined
 			)
 		})
@@ -438,6 +441,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.any(Object),
+				undefined,
 				undefined
 			)
 		})
@@ -454,6 +458,7 @@ describe('DevServerCommand', () => {
 				true,
 				expect.any(Function),
 				expect.any(Object),
+				undefined,
 				undefined
 			)
 		})
@@ -496,6 +501,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.objectContaining({ DATABASE_URL: 'postgres://test', API_KEY: 'secret', ILOOM_LOOM: '87' }),
+				undefined,
 				undefined
 			)
 		})
@@ -514,6 +520,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.objectContaining({ ILOOM_LOOM: '87' }),
+				undefined,
 				undefined
 			)
 		})
@@ -530,6 +537,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.objectContaining({ ILOOM_LOOM: '87' }),
+				undefined,
 				undefined
 			)
 		})
@@ -554,6 +562,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.objectContaining({ ILOOM_LOOM: '87' }),
+				undefined,
 				undefined
 			)
 		})
@@ -707,7 +716,8 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.objectContaining({ ILOOM_LOOM: '87' }),
-				expectedDockerConfig
+				expectedDockerConfig,
+				undefined
 			)
 		})
 
@@ -741,7 +751,8 @@ describe('DevServerCommand', () => {
 				expect.objectContaining({
 					dockerFile: './Dockerfile',
 					identifier: '87',
-				})
+				}),
+				undefined
 			)
 		})
 
@@ -780,7 +791,8 @@ describe('DevServerCommand', () => {
 				expect.objectContaining({ ILOOM_LOOM: 'feat/docker-support' }),
 				expect.objectContaining({
 					identifier: 'feat/docker-support',
-				})
+				}),
+				undefined
 			)
 		})
 
@@ -838,6 +850,7 @@ describe('DevServerCommand', () => {
 				false,
 				expect.any(Function),
 				expect.objectContaining({ ILOOM_LOOM: '87' }),
+				undefined,
 				undefined
 			)
 		})

--- a/src/commands/dev-server.ts
+++ b/src/commands/dev-server.ts
@@ -3,6 +3,7 @@ import { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
 import { MetadataManager } from '../lib/MetadataManager.js'
 import { ProjectCapabilityDetector } from '../lib/ProjectCapabilityDetector.js'
 import { DevServerManager } from '../lib/DevServerManager.js'
+import { DevServerTUI } from '../lib/DevServerTUI.js'
 import { DockerManager } from '../lib/DockerManager.js'
 import { SettingsManager } from '../lib/SettingsManager.js'
 import { IdentifierParser } from '../utils/IdentifierParser.js'
@@ -181,25 +182,56 @@ export class DevServerCommand {
 			message,
 		}
 
-		// This will block until user stops the server (Ctrl+C)
-		// In JSON mode, redirect npm output to stderr so JSON can go to stdout
-		const processInfo = await this.devServerManager.runServerForeground(
-			worktree.path,
-			port,
-			!!input.json,
-			// Callback called immediately when process starts (for JSON output)
-			(pid) => {
-				if (input.json && pid) {
-					finalResult.pid = pid
-					this.outputJson(finalResult)
-				}
-			},
-			envOverrides,
-			dockerConfig
-		)
+		// Determine if TUI should be used:
+		// - Only when TTY is detected on both stdout and stdin
+		// - Disabled in JSON mode (JSON output goes to stdout)
+		const useTui = !input.json && process.stdout.isTTY === true && process.stdin.isTTY === true
 
-		if (processInfo.pid) {
-			finalResult.pid = processInfo.pid
+		let tui: DevServerTUI | undefined
+
+		if (useTui) {
+			tui = new DevServerTUI({
+				url,
+				port,
+				containerPort: dockerConfig?.containerPort,
+				onQuit: (): void => {
+					// Send SIGINT to self to trigger normal cleanup flow
+					process.kill(process.pid, 'SIGINT')
+				},
+			})
+			tui.start()
+		}
+
+		const onOutput = tui
+			? (data: Buffer): void => { tui?.handleOutput(data) }
+			: undefined
+
+		try {
+			// This will block until user stops the server (Ctrl+C)
+			// In JSON mode, redirect npm output to stderr so JSON can go to stdout
+			const processInfo = await this.devServerManager.runServerForeground(
+				worktree.path,
+				port,
+				!!input.json,
+				// Callback called immediately when process starts (for JSON output)
+				(pid) => {
+					if (input.json && pid) {
+						finalResult.pid = pid
+						this.outputJson(finalResult)
+					}
+				},
+				envOverrides,
+				dockerConfig,
+				onOutput
+			)
+
+			if (processInfo.pid) {
+				finalResult.pid = processInfo.pid
+			}
+		} finally {
+			if (tui) {
+				tui.cleanup()
+			}
 		}
 
 		return finalResult

--- a/src/lib/DevServerManager.ts
+++ b/src/lib/DevServerManager.ts
@@ -254,7 +254,8 @@ export class DevServerManager {
 		redirectToStderr = false,
 		onProcessStarted?: (pid?: number) => void,
 		envOverrides?: Record<string, string>,
-		dockerConfig?: DockerConfig
+		dockerConfig?: DockerConfig,
+		onOutput?: (data: Buffer) => void
 	): Promise<{ pid?: number }> {
 		// Docker mode: build image and run container in foreground
 		if (dockerConfig) {
@@ -290,7 +291,7 @@ export class DevServerManager {
 					port,
 					containerPort,
 					strategyConfig,
-					{ redirectToStderr, envOverrides }
+					{ redirectToStderr, envOverrides, onOutput }
 				)
 			} finally {
 				this.runningDockerContainers.delete(port)
@@ -304,6 +305,7 @@ export class DevServerManager {
 			redirectToStderr,
 			...(onProcessStarted !== undefined && { onProcessStarted }),
 			...(envOverrides !== undefined && { envOverrides }),
+			...(onOutput !== undefined && { onOutput }),
 		})
 	}
 

--- a/src/lib/DevServerStrategy.ts
+++ b/src/lib/DevServerStrategy.ts
@@ -8,6 +8,8 @@ export interface ForegroundOpts {
 	onProcessStarted?: (pid?: number) => void
 	/** Additional environment variables to pass to the server process/container */
 	envOverrides?: Record<string, string>
+	/** Callback for server output when using pipe mode (for TUI). When provided, stdio is piped instead of inherited. */
+	onOutput?: (data: Buffer) => void
 }
 
 /**

--- a/src/lib/DevServerTUI.test.ts
+++ b/src/lib/DevServerTUI.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DevServerTUI, type DevServerTUIOptions, type DevServerStatus } from './DevServerTUI.js'
+import { openBrowser } from '../utils/browser.js'
+import { execa } from 'execa'
+import { restoreTerminalState } from '../utils/terminal.js'
+
+// Mock dependencies
+vi.mock('execa')
+vi.mock('../utils/browser.js')
+vi.mock('../utils/terminal.js')
+
+vi.mock('../utils/logger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+		success: vi.fn(),
+	},
+}))
+
+/**
+ * Create a mock WriteStream for stdout with essential properties.
+ */
+function createMockStdout() {
+	const written: string[] = []
+	const stream = {
+		rows: 24,
+		columns: 80,
+		isTTY: true,
+		write: vi.fn((data: string) => {
+			written.push(data)
+			return true
+		}),
+		on: vi.fn(),
+		removeListener: vi.fn(),
+	} as unknown as NodeJS.WriteStream
+	return { stream, written }
+}
+
+/**
+ * Create a mock ReadStream for stdin with essential properties.
+ */
+function createMockStdin() {
+	const stream = {
+		isTTY: true,
+		setRawMode: vi.fn().mockReturnThis(),
+		resume: vi.fn(),
+		pause: vi.fn(),
+		on: vi.fn(),
+		once: vi.fn(),
+		removeListener: vi.fn(),
+	} as unknown as NodeJS.ReadStream
+	return stream
+}
+
+function createTUI(overrides: Partial<DevServerTUIOptions> = {}) {
+	const { stream: stdout, written } = createMockStdout()
+	const stdin = createMockStdin()
+
+	const options: DevServerTUIOptions = {
+		url: 'http://localhost:3920',
+		port: 3920,
+		stdout,
+		stdin,
+		...overrides,
+	}
+
+	const tui = new DevServerTUI(options)
+	return { tui, stdout, stdin, written }
+}
+
+describe('DevServerTUI', () => {
+	describe('constructor', () => {
+		it('should create instance with required options', () => {
+			const { tui } = createTUI()
+			expect(tui).toBeDefined()
+		})
+
+		it('should accept optional containerPort', () => {
+			const { tui } = createTUI({ containerPort: 4200 })
+			expect(tui).toBeDefined()
+		})
+	})
+
+	describe('start', () => {
+		it('should set up scroll region and render status bar', () => {
+			const { tui, stdout, written } = createTUI()
+			tui.start()
+
+			// Should write ANSI sequences: hide cursor, set scroll region, move cursor, render status bar
+			expect(stdout.write).toHaveBeenCalled()
+
+			// Check that scroll region was set (rows 1 to rows - 4 = 20)
+			const allOutput = written.join('')
+			// Scroll region: ESC[1;20r
+			expect(allOutput).toContain('\x1b[1;20r')
+			// Hide cursor
+			expect(allOutput).toContain('\x1b[?25l')
+			// Status bar should contain the URL
+			expect(allOutput).toContain('http://localhost:3920')
+
+			tui.cleanup()
+		})
+
+		it('should enable raw mode on stdin for keyboard input', () => {
+			const { tui, stdin } = createTUI()
+			tui.start()
+
+			expect(stdin.setRawMode).toHaveBeenCalledWith(true)
+			expect(stdin.resume).toHaveBeenCalled()
+			expect(stdin.on).toHaveBeenCalledWith('data', expect.any(Function))
+
+			tui.cleanup()
+		})
+
+		it('should listen for terminal resize events', () => {
+			const { tui, stdout } = createTUI()
+			tui.start()
+
+			expect(stdout.on).toHaveBeenCalledWith('resize', expect.any(Function))
+
+			tui.cleanup()
+		})
+
+		it('should be idempotent - calling start twice does not double-init', () => {
+			const { tui, stdin } = createTUI()
+			tui.start()
+			tui.start() // second call should be a no-op
+
+			// setRawMode should only be called once (from start), not twice
+			expect(stdin.setRawMode).toHaveBeenCalledTimes(1)
+
+			tui.cleanup()
+		})
+	})
+
+	describe('handleOutput', () => {
+		it('should write data to stdout', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			// Clear recorded writes from start()
+			const preStartWrites = written.length
+
+			tui.handleOutput(Buffer.from('Hello world\n'))
+
+			// Should have additional writes after start
+			expect(written.length).toBeGreaterThan(preStartWrites)
+
+			// Output should contain the data we sent
+			const postStartOutput = written.slice(preStartWrites).join('')
+			expect(postStartOutput).toContain('Hello world\n')
+
+			tui.cleanup()
+		})
+
+		it('should handle string data', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const preStartWrites = written.length
+
+			tui.handleOutput('String output\n')
+
+			const postStartOutput = written.slice(preStartWrites).join('')
+			expect(postStartOutput).toContain('String output\n')
+
+			tui.cleanup()
+		})
+
+		it('should not write if not started', () => {
+			const { tui, stdout } = createTUI()
+
+			// handleOutput before start should be a no-op
+			tui.handleOutput(Buffer.from('test'))
+
+			expect(stdout.write).not.toHaveBeenCalled()
+		})
+
+		it('should not write if cleaned up', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+			tui.cleanup()
+
+			const postCleanupWrites = written.length
+			tui.handleOutput(Buffer.from('test'))
+
+			// No additional writes after cleanup
+			expect(written.length).toBe(postCleanupWrites)
+		})
+	})
+
+	describe('updateStatus', () => {
+		it('should re-render status bar with new status', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const preUpdateWrites = written.length
+
+			tui.updateStatus('Stopped')
+
+			// Status bar should be re-rendered
+			const postUpdateOutput = written.slice(preUpdateWrites).join('')
+			expect(postUpdateOutput).toContain('Stopped')
+		})
+
+		it('should show correct icon for each status', () => {
+			const statuses: Array<{ status: DevServerStatus; icon: string }> = [
+				{ status: 'Running', icon: '\u25A0' },   // filled square
+				{ status: 'Stopped', icon: '\u25A1' },   // empty square
+				{ status: 'Restarting', icon: '\u25C6' }, // diamond
+			]
+
+			for (const { status, icon } of statuses) {
+				const { tui, written } = createTUI()
+				tui.start()
+
+				const preUpdateWrites = written.length
+				tui.updateStatus(status)
+
+				const postUpdateOutput = written.slice(preUpdateWrites).join('')
+				expect(postUpdateOutput).toContain(icon)
+				expect(postUpdateOutput).toContain(status)
+
+				tui.cleanup()
+			}
+		})
+	})
+
+	describe('renderStatusBar', () => {
+		it('should display URL in status bar', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const allOutput = written.join('')
+			expect(allOutput).toContain('http://localhost:3920')
+		})
+
+		it('should display port mapping when containerPort is set', () => {
+			const { tui, written } = createTUI({ containerPort: 4200 })
+			tui.start()
+
+			const allOutput = written.join('')
+			// Should contain port mapping: 4200 -> 3920
+			expect(allOutput).toContain('4200')
+			expect(allOutput).toContain('3920')
+
+			tui.cleanup()
+		})
+
+		it('should display single port when no containerPort', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const allOutput = written.join('')
+			expect(allOutput).toContain('Port 3920')
+
+			tui.cleanup()
+		})
+
+		it('should display box-drawing characters', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const allOutput = written.join('')
+			// Box-drawing characters
+			expect(allOutput).toContain('\u250C') // top-left corner
+			expect(allOutput).toContain('\u2510') // top-right corner
+			expect(allOutput).toContain('\u2514') // bottom-left corner
+			expect(allOutput).toContain('\u2518') // bottom-right corner
+			expect(allOutput).toContain('\u2500') // horizontal line
+
+			tui.cleanup()
+		})
+
+		it('should display keyboard shortcut hints', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const allOutput = written.join('')
+			expect(allOutput).toContain('[o] Open')
+			expect(allOutput).toContain('[c] Copy URL')
+			expect(allOutput).toContain('[q] Quit')
+			expect(allOutput).toContain('[r] Restart')
+
+			tui.cleanup()
+		})
+	})
+
+	describe('handleKeypress', () => {
+		/**
+		 * Simulate a keypress by finding the data handler registered on stdin
+		 * and calling it with the given key.
+		 */
+		function pressKey(stdin: NodeJS.ReadStream, key: string) {
+			const onCall = vi.mocked(stdin.on).mock.calls.find(
+				([event]) => event === 'data'
+			)
+			if (onCall) {
+				const handler = onCall[1] as (data: Buffer) => void
+				handler(Buffer.from(key))
+			}
+		}
+
+		it('should call openBrowser when "o" is pressed', () => {
+			vi.mocked(openBrowser).mockResolvedValue(undefined)
+
+			const { tui, stdin } = createTUI()
+			tui.start()
+
+			pressKey(stdin, 'o')
+
+			expect(openBrowser).toHaveBeenCalledWith('http://localhost:3920')
+
+			tui.cleanup()
+		})
+
+		it('should call onQuit when "q" is pressed', () => {
+			const onQuit = vi.fn()
+			const { tui, stdin } = createTUI({ onQuit })
+			tui.start()
+
+			pressKey(stdin, 'q')
+
+			expect(onQuit).toHaveBeenCalled()
+
+			tui.cleanup()
+		})
+
+		it('should call onQuit when Ctrl+C is pressed', () => {
+			const onQuit = vi.fn()
+			const { tui, stdin } = createTUI({ onQuit })
+			tui.start()
+
+			pressKey(stdin, '\x03')
+
+			expect(onQuit).toHaveBeenCalled()
+
+			tui.cleanup()
+		})
+
+		it('should call onRestart when "r" is pressed', () => {
+			const onRestart = vi.fn()
+			const { tui, stdin } = createTUI({ onRestart })
+			tui.start()
+
+			pressKey(stdin, 'r')
+
+			expect(onRestart).toHaveBeenCalled()
+
+			tui.cleanup()
+		})
+
+		it('should copy URL to clipboard when "c" is pressed', () => {
+			vi.mocked(execa).mockResolvedValue({} as never)
+
+			const originalPlatform = process.platform
+			Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+
+			try {
+				const { tui, stdin } = createTUI()
+				tui.start()
+
+				pressKey(stdin, 'c')
+
+				// Should call pbcopy on darwin
+				expect(execa).toHaveBeenCalledWith('pbcopy', [], { input: 'http://localhost:3920' })
+
+				tui.cleanup()
+			} finally {
+				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+			}
+		})
+
+		it('should ignore unknown keys', () => {
+			const onQuit = vi.fn()
+			const onRestart = vi.fn()
+			const { tui, stdin } = createTUI({ onQuit, onRestart })
+			tui.start()
+
+			pressKey(stdin, 'x')
+
+			expect(onQuit).not.toHaveBeenCalled()
+			expect(onRestart).not.toHaveBeenCalled()
+
+			tui.cleanup()
+		})
+	})
+
+	describe('cleanup', () => {
+		it('should restore scroll region to full terminal', () => {
+			const { tui, written } = createTUI()
+			tui.start()
+
+			const preCleanupWrites = written.length
+
+			tui.cleanup()
+
+			const cleanupOutput = written.slice(preCleanupWrites).join('')
+			// Reset scroll region: ESC[r
+			expect(cleanupOutput).toContain('\x1b[r')
+			// Show cursor
+			expect(cleanupOutput).toContain('\x1b[?25h')
+		})
+
+		it('should disable raw mode', () => {
+			const { tui, stdin } = createTUI()
+			tui.start()
+
+			tui.cleanup()
+
+			expect(stdin.setRawMode).toHaveBeenCalledWith(false)
+			expect(stdin.pause).toHaveBeenCalled()
+		})
+
+		it('should call restoreTerminalState', () => {
+			const { tui } = createTUI()
+			tui.start()
+			tui.cleanup()
+
+			expect(restoreTerminalState).toHaveBeenCalled()
+		})
+
+		it('should remove event listeners', () => {
+			const { tui, stdin, stdout } = createTUI()
+			tui.start()
+			tui.cleanup()
+
+			expect(stdin.removeListener).toHaveBeenCalledWith('data', expect.any(Function))
+			expect(stdout.removeListener).toHaveBeenCalledWith('resize', expect.any(Function))
+		})
+
+		it('should be idempotent - calling cleanup twice does not error', () => {
+			const { tui } = createTUI()
+			tui.start()
+			tui.cleanup()
+			tui.cleanup() // second call should be safe
+		})
+	})
+
+	describe('non-TTY behavior', () => {
+		it('should not set raw mode when stdin is not a TTY', () => {
+			const stdin = createMockStdin()
+			Object.defineProperty(stdin, 'isTTY', { value: false, configurable: true })
+
+			const { tui } = createTUI({ stdin })
+			tui.start()
+
+			expect(stdin.setRawMode).not.toHaveBeenCalled()
+
+			tui.cleanup()
+		})
+	})
+})

--- a/src/lib/DevServerTUI.ts
+++ b/src/lib/DevServerTUI.ts
@@ -1,0 +1,322 @@
+import { execa } from 'execa'
+import { openBrowser } from '../utils/browser.js'
+import { restoreTerminalState } from '../utils/terminal.js'
+import { logger } from '../utils/logger.js'
+
+/**
+ * ANSI escape sequences used for TUI rendering.
+ */
+const ESC = '\x1b'
+const CSI = `${ESC}[`
+
+/** Save cursor position */
+const CURSOR_SAVE = `${ESC}7`
+/** Restore cursor position */
+const CURSOR_RESTORE = `${ESC}8`
+/** Hide cursor */
+const CURSOR_HIDE = `${CSI}?25l`
+/** Show cursor */
+const CURSOR_SHOW = `${CSI}?25h`
+/** Clear from cursor to end of line */
+const CLEAR_LINE = `${CSI}K`
+/** Reset scroll region to full terminal */
+const SCROLL_REGION_RESET = `${CSI}r`
+
+/** Move cursor to row,col (1-based) */
+function moveTo(row: number, col: number): string {
+	return `${CSI}${row};${col}H`
+}
+
+/** Set scroll region to rows top..bottom (1-based, inclusive) */
+function setScrollRegion(top: number, bottom: number): string {
+	return `${CSI}${top};${bottom}r`
+}
+
+export type DevServerStatus = 'Running' | 'Stopped' | 'Restarting'
+
+export interface DevServerTUIOptions {
+	url: string
+	port: number
+	containerPort?: number | undefined
+	stdout?: NodeJS.WriteStream | undefined
+	stdin?: NodeJS.ReadStream | undefined
+	onQuit?: (() => void) | undefined
+	onRestart?: (() => void) | undefined
+}
+
+/**
+ * Height of the status bar area (top border + content + bottom border + hint line).
+ */
+const STATUS_BAR_HEIGHT = 4
+
+/**
+ * DevServerTUI - Lightweight terminal UI for dev server.
+ *
+ * Uses ANSI escape sequences to set a scroll region that restricts output
+ * to the upper portion of the terminal, keeping a fixed status bar at the
+ * bottom showing the external URL, server status, and port mapping.
+ *
+ * Keyboard shortcuts:
+ *   o - open URL in browser
+ *   c - copy URL to clipboard
+ *   q - quit (stop container and exit)
+ *   r - restart (if callback provided)
+ */
+export class DevServerTUI {
+	private readonly url: string
+	private readonly port: number
+	private readonly containerPort: number | undefined
+	private readonly stdout: NodeJS.WriteStream
+	private readonly stdin: NodeJS.ReadStream
+	private readonly onQuit: (() => void) | undefined
+	private readonly onRestart: (() => void) | undefined
+	private status: DevServerStatus = 'Running'
+	private started = false
+	private cleanedUp = false
+	private readonly onData: (data: Buffer) => void
+	private readonly onResize: () => void
+	private readonly onProcessExit: () => void
+
+	constructor(options: DevServerTUIOptions) {
+		this.url = options.url
+		this.port = options.port
+		this.containerPort = options.containerPort
+		this.stdout = options.stdout ?? process.stdout
+		this.stdin = options.stdin ?? process.stdin
+		this.onQuit = options.onQuit
+		this.onRestart = options.onRestart
+
+		// Bind handlers so they can be removed later
+		this.onData = (data: Buffer): void => this.handleKeypress(data)
+		this.onResize = (): void => this.handleResize()
+		this.onProcessExit = (): void => this.cleanup()
+	}
+
+	/**
+	 * Start the TUI - sets up scroll region, renders status bar, starts keyboard listener.
+	 */
+	start(): void {
+		if (this.started) return
+		this.started = true
+
+		const rows = this.stdout.rows ?? 24
+
+		// Hide cursor during TUI operation
+		this.stdout.write(CURSOR_HIDE)
+
+		// Set scroll region: top of terminal to (total rows - status bar height)
+		const scrollBottom = Math.max(1, rows - STATUS_BAR_HEIGHT)
+		this.stdout.write(setScrollRegion(1, scrollBottom))
+
+		// Move cursor to top-left of scroll region
+		this.stdout.write(moveTo(1, 1))
+
+		// Render status bar in the fixed area below scroll region
+		this.renderStatusBar()
+
+		// Start keyboard listener (raw mode)
+		if (this.stdin.isTTY && typeof this.stdin.setRawMode === 'function') {
+			this.stdin.setRawMode(true)
+			this.stdin.resume()
+			this.stdin.on('data', this.onData)
+		}
+
+		// Listen for terminal resize
+		this.stdout.on('resize', this.onResize)
+
+		// Ensure terminal state is restored on unexpected exit (uncaught exceptions, etc.)
+		process.on('exit', this.onProcessExit)
+	}
+
+	/**
+	 * Write server output into the scroll region.
+	 * The scroll region constrains the cursor naturally, so output stays
+	 * above the status bar without explicit cursor repositioning.
+	 */
+	handleOutput(data: Buffer | string): void {
+		if (!this.started || this.cleanedUp) return
+
+		this.stdout.write(data.toString())
+	}
+
+	/**
+	 * Update the status displayed in the status bar.
+	 */
+	updateStatus(status: DevServerStatus): void {
+		this.status = status
+		if (this.started && !this.cleanedUp) {
+			this.renderStatusBar()
+		}
+	}
+
+	/**
+	 * Render the status bar in the fixed area below the scroll region.
+	 */
+	private renderStatusBar(): void {
+		const rows = this.stdout.rows ?? 24
+		const cols = this.stdout.columns ?? 80
+
+		// Guard: terminal too small for status bar
+		if (rows < STATUS_BAR_HEIGHT + 2) return
+
+		// Status bar starts at row (rows - STATUS_BAR_HEIGHT + 1)
+		const barStartRow = rows - STATUS_BAR_HEIGHT + 1
+
+		// Build content segments
+		const urlSegment = ` ${this.url} `
+		const statusIcon = this.status === 'Running' ? '\u25A0' : this.status === 'Stopped' ? '\u25A1' : '\u25C6'
+		const statusSegment = ` ${statusIcon} ${this.status} `
+		const portSegment = this.containerPort
+			? ` Port ${this.containerPort} \u2192 ${this.port} `
+			: ` Port ${this.port} `
+
+		// Build content line with separators
+		const contentParts = `\u2502${urlSegment}\u2502${statusSegment}\u2502${portSegment}\u2502`
+		// Pad content to fill width
+		const contentLine = contentParts.length < cols
+			? contentParts + ' '.repeat(cols - contentParts.length)
+			: contentParts.substring(0, cols)
+
+		// Horizontal border line
+		const innerWidth = Math.max(0, cols - 2)
+		const topBorder = `\u250C${'\u2500'.repeat(innerWidth)}\u2510`
+		const bottomBorder = `\u2514${'\u2500'.repeat(innerWidth)}\u2518`
+
+		// Hint line showing keyboard shortcuts
+		const hintLine = ' [o] Open  [c] Copy URL  [r] Restart  [q] Quit'
+		const paddedHint = hintLine.length < cols
+			? hintLine + ' '.repeat(cols - hintLine.length)
+			: hintLine.substring(0, cols)
+
+		// Save cursor, write status bar, restore cursor
+		this.stdout.write(CURSOR_SAVE)
+
+		// Row 1: top border
+		this.stdout.write(moveTo(barStartRow, 1) + CLEAR_LINE + topBorder)
+		// Row 2: content
+		this.stdout.write(moveTo(barStartRow + 1, 1) + CLEAR_LINE + contentLine)
+		// Row 3: bottom border
+		this.stdout.write(moveTo(barStartRow + 2, 1) + CLEAR_LINE + bottomBorder)
+		// Row 4: hint line
+		this.stdout.write(moveTo(barStartRow + 3, 1) + CLEAR_LINE + paddedHint)
+
+		this.stdout.write(CURSOR_RESTORE)
+	}
+
+	/**
+	 * Handle keyboard input.
+	 */
+	private handleKeypress(data: Buffer): void {
+		const key = data.toString('utf8')
+
+		switch (key) {
+			case 'o':
+			case 'O':
+				void openBrowser(this.url).catch((err: unknown) => {
+					logger.warn(`Failed to open browser: ${err instanceof Error ? err.message : 'Unknown error'}`)
+				})
+				break
+
+			case 'c':
+			case 'C':
+				void this.copyToClipboard(this.url).catch((err: unknown) => {
+					logger.warn(`Failed to copy to clipboard: ${err instanceof Error ? err.message : 'Unknown error'}`)
+				})
+				break
+
+			case 'q':
+			case 'Q':
+			case '\x03': // Ctrl+C
+				if (this.onQuit) {
+					this.onQuit()
+				}
+				break
+
+			case 'r':
+			case 'R':
+				if (this.onRestart) {
+					this.onRestart()
+				}
+				break
+		}
+	}
+
+	/**
+	 * Copy text to clipboard using platform-specific commands.
+	 */
+	private async copyToClipboard(text: string): Promise<void> {
+		const platform = process.platform
+
+		let command: string
+		let args: string[]
+
+		if (platform === 'darwin') {
+			command = 'pbcopy'
+			args = []
+		} else if (platform === 'win32') {
+			command = 'clip'
+			args = []
+		} else {
+			// Linux
+			command = 'xclip'
+			args = ['-selection', 'clipboard']
+		}
+
+		await execa(command, args, { input: text })
+	}
+
+	/**
+	 * Handle terminal resize - re-establish scroll region and re-render status bar.
+	 */
+	private handleResize(): void {
+		if (!this.started || this.cleanedUp) return
+
+		const rows = this.stdout.rows ?? 24
+
+		// Guard: terminal too small for status bar
+		if (rows < STATUS_BAR_HEIGHT + 2) return
+
+		const scrollBottom = Math.max(1, rows - STATUS_BAR_HEIGHT)
+
+		// Re-establish scroll region for new size
+		this.stdout.write(setScrollRegion(1, scrollBottom))
+
+		// Re-render status bar at new position
+		this.renderStatusBar()
+
+		// Move cursor back into scroll region
+		this.stdout.write(moveTo(scrollBottom, 1))
+	}
+
+	/**
+	 * Clean up: restore full scroll region, disable raw mode, restore terminal.
+	 */
+	cleanup(): void {
+		if (this.cleanedUp) return
+		this.cleanedUp = true
+
+		// Remove event listeners
+		if (this.stdin.isTTY && typeof this.stdin.setRawMode === 'function') {
+			this.stdin.removeListener('data', this.onData)
+			this.stdin.setRawMode(false)
+			this.stdin.pause()
+		}
+
+		this.stdout.removeListener('resize', this.onResize)
+		process.removeListener('exit', this.onProcessExit)
+
+		// Reset scroll region to full terminal
+		this.stdout.write(SCROLL_REGION_RESET)
+
+		// Show cursor
+		this.stdout.write(CURSOR_SHOW)
+
+		// Move cursor to bottom of terminal
+		const rows = this.stdout.rows ?? 24
+		this.stdout.write(moveTo(rows, 1))
+		this.stdout.write('\n')
+
+		// Restore terminal state
+		restoreTerminalState()
+	}
+}

--- a/src/lib/DockerDevServerStrategy.ts
+++ b/src/lib/DockerDevServerStrategy.ts
@@ -35,6 +35,8 @@ export interface RunForegroundOptions {
 	onProcessStarted?: ((pid?: number) => void) | undefined
 	/** Additional environment variables to forward into the container */
 	envOverrides?: Record<string, string> | undefined
+	/** Callback for server output when using pipe mode (for TUI). When provided, stdio is piped instead of inherited. */
+	onOutput?: ((data: Buffer) => void) | undefined
 }
 
 /**
@@ -274,7 +276,7 @@ export class DockerDevServerStrategy {
 		const nameId = config.identifier ?? worktreePath
 		const imageName = this.utils.buildImageName(nameId)
 		const containerName = this.utils.buildContainerName(nameId)
-		const { redirectToStderr, onProcessStarted, envOverrides } = opts
+		const { redirectToStderr, onProcessStarted, envOverrides, onOutput } = opts
 
 		// Force-remove any existing container with same name (stale from previous ungraceful exit)
 		await execa('docker', ['rm', '-f', containerName], { reject: false })
@@ -309,9 +311,15 @@ export class DockerDevServerStrategy {
 		const displayProtocol = config.protocol ?? 'http'
 		logger.info(`Running Docker container "${containerName}" in foreground (${displayProtocol}://localhost:${hostPort} → container:${containerPort})...`)
 
-		const stdio = redirectToStderr
-			? [process.stdin, process.stderr, process.stderr] as const
-			: 'inherit' as const
+		// Determine stdio based on mode:
+		// - onOutput (TUI pipe mode): stdin ignored (TUI handles it), stdout/stderr piped to callback
+		// - redirectToStderr: stdout/stderr -> process.stderr, stdin inherited
+		// - default: inherit all stdio
+		const stdio = onOutput
+			? (['ignore', 'pipe', 'pipe'] as const)
+			: redirectToStderr
+				? ([process.stdin, process.stderr, process.stderr] as const)
+				: ('inherit' as const)
 
 		// Signal forwarding: trap SIGINT/SIGTERM and forward to container
 		const forwardSignal = (): void => {
@@ -330,7 +338,15 @@ export class DockerDevServerStrategy {
 		}
 
 		try {
-			await execa('docker', args, { stdio })
+			const dockerProcess = execa('docker', args, { stdio })
+
+			// When onOutput is provided, pipe stdout/stderr to the callback
+			if (onOutput) {
+				dockerProcess.stdout?.on('data', onOutput)
+				dockerProcess.stderr?.on('data', onOutput)
+			}
+
+			await dockerProcess
 		} catch (error) {
 			const execaError = error as ExecaError
 			// When the user presses Ctrl+C, the signal handler calls `docker stop`,

--- a/src/lib/NativeDevServerStrategy.ts
+++ b/src/lib/NativeDevServerStrategy.ts
@@ -92,14 +92,21 @@ export class NativeDevServerStrategy implements DevServerStrategy {
 		port: number,
 		opts: ForegroundOpts
 	): Promise<{ pid?: number }> {
-		const { redirectToStderr = false, onProcessStarted, envOverrides } = opts
+		const { redirectToStderr = false, onProcessStarted, envOverrides, onOutput } = opts
 
 		logger.debug(`Starting dev server in foreground on port ${port}`)
 
-		if (redirectToStderr) {
-			// For redirectToStderr, we need direct execa control for custom stdio
+		if (redirectToStderr || onOutput) {
+			// For redirectToStderr or onOutput (TUI pipe mode), we need direct execa control for custom stdio
 			const devCommand = await buildDevServerCommand(worktreePath)
 			logger.debug(`Starting dev server with command: ${devCommand}`)
+
+			// Determine stdio based on mode:
+			// - redirectToStderr: stdout/stderr -> process.stderr, stdin inherited
+			// - onOutput (TUI mode): stdin ignored (TUI handles it), stdout/stderr piped to callback
+			const stdio = onOutput
+				? (['ignore', 'pipe', 'pipe'] as const)
+				: ([process.stdin, process.stderr, process.stderr] as const)
 
 			const serverProcess = execa('sh', ['-c', devCommand], {
 				cwd: worktreePath,
@@ -108,8 +115,14 @@ export class NativeDevServerStrategy implements DevServerStrategy {
 					...envOverrides,
 					PORT: port.toString(),
 				},
-				stdio: [process.stdin, process.stderr, process.stderr],
+				stdio,
 			})
+
+			// When onOutput is provided, pipe stdout/stderr to the callback
+			if (onOutput) {
+				serverProcess.stdout?.on('data', onOutput)
+				serverProcess.stderr?.on('data', onOutput)
+			}
 
 			const processInfo: { pid?: number } =
 				serverProcess.pid !== undefined ? { pid: serverProcess.pid } : {}
@@ -147,6 +160,7 @@ export class NativeDevServerStrategy implements DevServerStrategy {
 			},
 			foreground: true,
 			...(onProcessStarted && { onStart: onProcessStarted }),
+			...(onOutput !== undefined ? { onOutput } : {}),
 			noCi: true, // Dev servers should not have CI=true
 		})
 	}

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -164,6 +164,8 @@ export interface RunScriptOptions {
   onStart?: (pid?: number) => void
   /** Don't set CI=true (for dev servers, default: false) */
   noCi?: boolean
+  /** Callback for server output when using pipe mode (for TUI). When provided, stdio is piped instead of inherited. */
+  onOutput?: (data: Buffer) => void
 }
 
 /**
@@ -204,14 +206,20 @@ export async function runScript(
     env.CI = 'true'
   }
 
-  // Determine stdio mode
-  const stdio = options.foreground ? 'inherit' : (options.quiet ? 'pipe' : 'inherit')
+  // Determine stdio mode:
+  // - onOutput (TUI pipe mode): stdin ignored, stdout/stderr piped to callback
+  // - foreground: inherit all stdio
+  // - quiet: pipe all stdio (suppress output)
+  // - default: inherit
+  const stdio = options.onOutput
+    ? (['ignore', 'pipe', 'pipe'] as const)
+    : options.foreground ? 'inherit' : (options.quiet ? 'pipe' : 'inherit')
 
   // For foreground mode, register a no-op SIGINT handler to prevent signal-exit
   // (used internally by execa) from re-raising SIGINT and killing the process
   // before finally blocks can run. This ensures terminal state is restored on Ctrl+C.
   const onSigint = (): void => {}
-  if (options.foreground) {
+  if (options.foreground || options.onOutput) {
     process.on('SIGINT', onSigint)
   }
 
@@ -226,7 +234,7 @@ export async function runScript(
       execaProcess = execa('sh', ['-c', `${scriptConfig.command} "$@"`, '--', ...args], {
         cwd,
         stdio,
-        ...(!options.foreground && { timeout: 600000 }), // No timeout for foreground mode
+        ...(!options.foreground && !options.onOutput && { timeout: 600000 }), // No timeout for foreground/TUI mode
         env,
         verbose: isDebugMode,
       })
@@ -238,15 +246,21 @@ export async function runScript(
       execaProcess = execa(packageManager, [...command, ...args], {
         cwd,
         stdio,
-        ...(!options.foreground && { timeout: 600000 }), // No timeout for foreground mode
+        ...(!options.foreground && !options.onOutput && { timeout: 600000 }), // No timeout for foreground/TUI mode
         env,
         verbose: isDebugMode,
       })
     }
 
+    // When onOutput is provided, pipe stdout/stderr to the callback
+    if (options.onOutput) {
+      execaProcess.stdout?.on('data', options.onOutput)
+      execaProcess.stderr?.on('data', options.onOutput)
+    }
+
     // For foreground mode, get PID and call onStart callback immediately
     const result: { pid?: number } = {}
-    if (options.foreground && execaProcess.pid !== undefined) {
+    if ((options.foreground || options.onOutput) && execaProcess.pid !== undefined) {
       result.pid = execaProcess.pid
     }
 
@@ -262,13 +276,13 @@ export async function runScript(
   } catch (error) {
     const execaError = error as ExecaError
     // If the process was killed by SIGINT, the user intentionally cancelled — return silently
-    if (options.foreground && execaError.signal === 'SIGINT') {
+    if ((options.foreground || options.onOutput) && execaError.signal === 'SIGINT') {
       return {}
     }
     const stderr = execaError.stderr ?? execaError.message ?? 'Unknown error'
     throw new Error(`Failed to run script '${scriptName}': ${stderr}`)
   } finally {
-    if (options.foreground) {
+    if (options.foreground || options.onOutput) {
       process.removeListener('SIGINT', onSigint)
       restoreTerminalState()
     }


### PR DESCRIPTION
Fixes #922

## Lightweight TUI for `il dev-server` with sticky URL status bar

## Problem

When running `il dev-server` with Docker, the dev server's build output (especially verbose frameworks like Angular) quickly scrolls the iloom URL banner out of view. Users lose track of the correct external URL (`https://localhost:<assigned-port>`) and have to scroll back or run `il open` to find it.

## Proposed Solution

Replace the current raw stdout passthrough with a lightweight TUI that keeps a sticky status bar visible at all times while container output scrolls in the main area.

### Status Bar

```
┌───────────────────────────────────────────────────────────┐
│ 🌐 https://localhost:3920  │  ■ Running  │  Port 4200 → 3920 │
└───────────────────────────────────────────────────────────┘
```

The status bar should show:
- The correct external URL (with protocol, host, and iloom-assigned port)
- Container status (running, restarting, stopped)
- Port mapping (internal → external)

### Keyboard Shortcuts

Consider adding interactive keybindings:
- `o` — open URL in browser
- `r` — restart container
- `q` — quit (stop container and exit)
- `c` — copy URL to clipboard

### Implementation Approach

Prefer the lightest approach that works:
1. **ANSI escape codes** — reserve the bottom line using cursor save/restore. Zero dependencies.
2. **ink** — React-like terminal rendering. More composable but adds a dependency.
3. **blessed/neo-blessed** — full TUI framework. Likely overkill for this use case.

Option 1 (ANSI escape codes) is recommended to keep dependencies minimal.

## Context

Related to #920 (protocol configuration). Once protocol is configurable, the TUI status bar should display the correct protocol automatically.

---
*This PR was created automatically by iloom.*