### PR TITLE
fix(port): return base port for main worktree

### DIFF
--- a/src/commands/dev-server.ts
+++ b/src/commands/dev-server.ts
@@ -133,11 +133,13 @@ export class DevServerCommand {
 		// 5. Get port for workspace
 		const cliOverrides = extractSettingsOverrides()
 		const settingsForPort = await this.settingsManager.loadSettings(undefined, cliOverrides)
+		const isMainWorktree = await this.gitWorktreeManager.isMainWorktree(worktree, this.settingsManager)
 		const port = await getWorkspacePort({
 			worktreePath: worktree.path,
 			worktreeBranch: worktree.branch,
 			basePort: settingsForPort.capabilities?.web?.basePort,
 			checkEnvFile: true,
+			isMainWorktree,
 		})
 		const url = `http://localhost:${port}`
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -219,11 +219,13 @@ export class OpenCommand {
 	private async openWebBrowser(worktree: GitWorktree): Promise<void> {
 		const cliOverrides = extractSettingsOverrides()
 		const settings = await this.settingsManager.loadSettings(undefined, cliOverrides)
+		const isMainWorktree = await this.gitWorktreeManager.isMainWorktree(worktree, this.settingsManager)
 		const port = await getWorkspacePort({
 			worktreePath: worktree.path,
 			worktreeBranch: worktree.branch,
 			basePort: settings.capabilities?.web?.basePort,
 			checkEnvFile: true,
+			isMainWorktree,
 		})
 
 		// Extract Docker configuration if Docker mode is enabled

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -261,11 +261,13 @@ export class RunCommand {
 	private async openWebBrowser(worktree: GitWorktree): Promise<void> {
 		const cliOverrides = extractSettingsOverrides()
 		const settings = await this.settingsManager.loadSettings(undefined, cliOverrides)
+		const isMainWorktree = await this.gitWorktreeManager.isMainWorktree(worktree, this.settingsManager)
 		const port = await getWorkspacePort({
 			worktreePath: worktree.path,
 			worktreeBranch: worktree.branch,
 			basePort: settings.capabilities?.web?.basePort,
 			checkEnvFile: true,
+			isMainWorktree,
 		})
 
 		// Extract Docker configuration if Docker mode is enabled

--- a/src/utils/port.test.ts
+++ b/src/utils/port.test.ts
@@ -469,5 +469,77 @@ describe('Port utilities', () => {
 			expect(port).toBeGreaterThanOrEqual(3001)
 			expect(port).toBeLessThanOrEqual(65535)
 		})
+
+		it('should return basePort when isMainWorktree is true', async () => {
+			const port = await getWorkspacePort({
+				worktreePath: '/path/to/main',
+				worktreeBranch: 'main',
+				isMainWorktree: true,
+			})
+
+			expect(port).toBe(3000)
+		})
+
+		it('should return custom basePort when isMainWorktree is true', async () => {
+			const port = await getWorkspacePort({
+				worktreePath: '/path/to/main',
+				worktreeBranch: 'main',
+				basePort: 8080,
+				isMainWorktree: true,
+			})
+
+			expect(port).toBe(8080)
+		})
+
+		it('should return basePort when mainWorktreePath matches worktreePath', async () => {
+			const port = await getWorkspacePort({
+				worktreePath: '/path/to/main',
+				worktreeBranch: 'main',
+				mainWorktreePath: '/path/to/main',
+			})
+
+			expect(port).toBe(3000)
+		})
+
+		it('should calculate normally when mainWorktreePath does not match', async () => {
+			mockFileExists.mockResolvedValue(false)
+
+			const port = await getWorkspacePort(
+				{
+					worktreePath: '/path/to/issue-42-feature',
+					worktreeBranch: 'feat/issue-42-feature',
+					mainWorktreePath: '/path/to/main',
+				},
+				{
+					fileExists: mockFileExists,
+					readFile: mockReadFile,
+				}
+			)
+
+			expect(port).toBe(3042)
+		})
+
+		it('should still check env file before returning basePort for main worktree', async () => {
+			mockFileExists.mockImplementation(async (path) => {
+				return path.includes('.env.development.local')
+			})
+			mockReadFile.mockResolvedValue('PORT=5000\nOTHER=value')
+
+			const port = await getWorkspacePort(
+				{
+					worktreePath: '/path/to/main',
+					worktreeBranch: 'main',
+					isMainWorktree: true,
+					checkEnvFile: true,
+				},
+				{
+					fileExists: mockFileExists,
+					readFile: mockReadFile,
+				}
+			)
+
+			// env file PORT should take precedence even for main worktree
+			expect(port).toBe(5000)
+		})
 	})
 })

--- a/src/utils/port.ts
+++ b/src/utils/port.ts
@@ -120,6 +120,10 @@ export interface GetWorkspacePortOptions {
 	worktreeBranch: string
 	/** If true, check .env files for PORT override before calculating. Defaults to false. */
 	checkEnvFile?: boolean
+	/** If true, this is the main worktree and should use basePort directly. */
+	isMainWorktree?: boolean
+	/** Path to the main worktree — if it matches worktreePath, basePort is returned. Alternative to isMainWorktree. */
+	mainWorktreePath?: string
 }
 
 export interface GetWorkspacePortDependencies {
@@ -181,6 +185,13 @@ export async function getWorkspacePort(
 		}
 
 		logger.debug('PORT not found in any dotenv-flow file, calculating from workspace identifier')
+	}
+
+	// Main worktree uses basePort directly
+	const isMain = options.isMainWorktree ?? (options.mainWorktreePath != null && options.mainWorktreePath === options.worktreePath)
+	if (isMain) {
+		logger.debug(`Using base port for main worktree: ${basePort}`)
+		return basePort
 	}
 
 	// Calculate based on workspace identifier


### PR DESCRIPTION
## Summary
- Main worktree now returns the base port (default 3000) instead of a hash-derived offset port
- Added `isMainWorktree` and `mainWorktreePath` options to `getWorkspacePort`
- Updated `dev-server`, `open`, and `run` commands to detect main worktree before port calculation
- Added 5 tests covering main worktree port behavior

## Test plan
- [x] All 48 port utility tests pass
- [x] All 80 command tests pass (dev-server, open, run)
- [x] Build compiles successfully
- [x] Pre-commit hooks pass (lint + compile + tests)