### PR TITLE
fix(rebase): pre-grant read-only tools for conflict resolution

### DIFF
--- a/src/lib/MergeManager.test.ts
+++ b/src/lib/MergeManager.test.ts
@@ -1585,13 +1585,17 @@ describe('MergeManager', () => {
 
 			await manager.rebaseOnMain('/test/worktree', { force: true })
 
-			// Verify allowedTools contains essential git commands for rebase
+			// Verify allowedTools contains core file tools and essential git commands for rebase
 			// Note: git reset and git checkout are intentionally excluded as they can be destructive
 			const options = vi.mocked(claude.launchClaude).mock.calls[0][1]
 			expect(options?.allowedTools).toEqual(expect.arrayContaining([
+				'Read',
+				'Grep',
+				'Glob',
 				'Bash(git status:*)',
 				'Bash(git diff:*)',
 				'Bash(git log:*)',
+				'Bash(git show:*)',
 				'Bash(git add:*)',
 				'Bash(git rebase:*)',
 			]))

--- a/src/lib/MergeManager.ts
+++ b/src/lib/MergeManager.ts
@@ -483,13 +483,18 @@ export class MergeManager {
 		const prompt =
 			`Help me with this rebase please.`
 
-		// Git commands to auto-approve during rebase conflict resolution
-		// These are the essential commands Claude needs to analyze and resolve conflicts
+		// Tools to auto-approve during rebase conflict resolution
+		// Includes core file tools for reading/editing conflicted files,
+		// plus the essential git commands Claude needs to analyze and resolve conflicts
 		// Note: git reset and git checkout are intentionally excluded as they can be destructive
 		const rebaseAllowedTools = [
+			'Read',
+			'Grep',
+			'Glob',
 			'Bash(git status:*)',
 			'Bash(git diff:*)',
 			'Bash(git log:*)',
+			'Bash(git show:*)',
 			'Bash(git add:*)',
 			'Bash(git rebase:*)',
 			'Bash(GIT_EDITOR=true git rebase:*)',
@@ -503,8 +508,8 @@ export class MergeManager {
 				appendSystemPrompt: systemPrompt,
 				addDir: worktreePath,
 				headless: options.jsonStream ? true : false,
+				...(options.jsonStream && { permissionMode: 'bypassPermissions' as const }),
 				...(options.jsonStream && {
-					permissionMode: 'bypassPermissions' as const,
 					passthroughStdout: true,
 				}),
 				allowedTools: rebaseAllowedTools,


### PR DESCRIPTION
## Summary
- Add `Read`, `Grep`, `Glob` to the rebase conflict resolution allowed tools so Claude doesn't prompt for read-only file operations
- Add `Bash(git show:*)` for inspecting commits during conflict analysis
- Update tests to match

## Test plan
- [x] All 4947 tests pass
- [x] Build succeeds