### PR TITLE
fix(dev-server): respect iloom config, fix Docker name conflicts, clear TUI screen

### DIFF
--- a/src/lib/DevServerTUI.ts
+++ b/src/lib/DevServerTUI.ts
@@ -19,6 +19,8 @@ const CURSOR_HIDE = `${CSI}?25l`
 const CURSOR_SHOW = `${CSI}?25h`
 /** Clear from cursor to end of line */
 const CLEAR_LINE = `${CSI}K`
+/** Clear entire screen and reset cursor to top-left */
+const CLEAR_SCREEN = `${CSI}2J${CSI}H`
 /** Reset scroll region to full terminal */
 const SCROLL_REGION_RESET = `${CSI}r`
 
@@ -103,6 +105,10 @@ export class DevServerTUI {
 
 		// Hide cursor during TUI operation
 		this.stdout.write(CURSOR_HIDE)
+
+		// Clear the screen so previous output (build logs, startup messages) doesn't
+		// bleed through the scroll region and create a confusing mix of old and new text
+		this.stdout.write(CLEAR_SCREEN)
 
 		// Set scroll region: top of terminal to (total rows - status bar height)
 		const scrollBottom = Math.max(1, rows - STATUS_BAR_HEIGHT)

--- a/src/lib/DockerDevServerStrategy.test.ts
+++ b/src/lib/DockerDevServerStrategy.test.ts
@@ -268,22 +268,27 @@ describe('DockerDevServerStrategy', () => {
 			vi.mocked(utils.buildContainerName).mockReturnValue('iloom-dev-test')
 			vi.mocked(execa)
 				.mockResolvedValueOnce({ exitCode: 0 } as never) // rm -f
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found = removed)
 				.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123' } as never) // docker run
 		})
 
-		it('should force-remove existing container before running', async () => {
+		it('should force-remove existing container and verify removal before running', async () => {
 			await strategy.runContainerDetached(WORKTREE, 3742, 4200, config)
 
 			expect(execa).toHaveBeenNthCalledWith(
 				1,
 				'docker', ['rm', '-f', 'iloom-dev-test'], { reject: false }
 			)
+			expect(execa).toHaveBeenNthCalledWith(
+				2,
+				'docker', ['container', 'inspect', 'iloom-dev-test'], { reject: false }
+			)
 		})
 
 		it('should run detached with correct port mapping and volume mounts', async () => {
 			await strategy.runContainerDetached(WORKTREE, 3742, 4200, config)
 
-			expect(execa).toHaveBeenNthCalledWith(2, 'docker', [
+			expect(execa).toHaveBeenCalledWith('docker', [
 				'run', '-d',
 				'--name', 'iloom-dev-test',
 				'-p', '3742:4200',
@@ -300,7 +305,7 @@ describe('DockerDevServerStrategy', () => {
 				DEBUG: 'true',
 			})
 
-			expect(execa).toHaveBeenNthCalledWith(2, 'docker', expect.arrayContaining([
+			expect(execa).toHaveBeenCalledWith('docker', expect.arrayContaining([
 				'-e', 'DATABASE_URL=postgres://localhost/test',
 				'-e', 'DEBUG=true',
 			]))
@@ -312,7 +317,7 @@ describe('DockerDevServerStrategy', () => {
 				runArgs: ['--memory', '512m', '--cpus', '0.5'],
 			})
 
-			expect(execa).toHaveBeenNthCalledWith(2, 'docker', expect.arrayContaining([
+			expect(execa).toHaveBeenCalledWith('docker', expect.arrayContaining([
 				'--memory', '512m', '--cpus', '0.5',
 			]))
 		})
@@ -327,6 +332,7 @@ describe('DockerDevServerStrategy', () => {
 			vi.mocked(execa)
 				.mockReset()
 				.mockResolvedValueOnce({ exitCode: 0 } as never) // rm -f
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(new Error('port already allocated'))
 
 			await expect(
@@ -339,8 +345,14 @@ describe('DockerDevServerStrategy', () => {
 	// runContainerForeground
 	// ---------------------------------------------------------------------------
 	describe('runContainerForeground', () => {
+		/** Default execa mock: returns exitCode 0 for all calls except container inspect (exitCode 1 = not found) */
 		const setupExeca = () => {
-			vi.mocked(execa).mockResolvedValue({ exitCode: 0 } as never)
+			vi.mocked(execa).mockImplementation((_cmd: string, args?: readonly string[]) => {
+				if (args?.[0] === 'container' && args?.[1] === 'inspect') {
+					return Promise.resolve({ exitCode: 1 }) as never
+				}
+				return Promise.resolve({ exitCode: 0 }) as never
+			})
 		}
 
 		/** Helper to create an ExecaError-like object with exitCode and/or signal */
@@ -442,6 +454,7 @@ describe('DockerDevServerStrategy', () => {
 		it('should remove signal handlers even when docker run throws', async () => {
 			vi.mocked(execa)
 				.mockResolvedValueOnce({} as never) // rm -f (stale cleanup)
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(new Error('container crashed'))
 			const removeSpy = vi.spyOn(process, 'removeListener')
 
@@ -456,6 +469,7 @@ describe('DockerDevServerStrategy', () => {
 		it('should silently swallow exit code 143 (SIGTERM via docker stop)', async () => {
 			vi.mocked(execa)
 				.mockResolvedValueOnce({} as never) // rm -f (stale cleanup)
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(makeExecaError({ exitCode: 143 }))
 
 			await expect(
@@ -466,6 +480,7 @@ describe('DockerDevServerStrategy', () => {
 		it('should silently swallow exit code 130 (SIGINT)', async () => {
 			vi.mocked(execa)
 				.mockResolvedValueOnce({} as never) // rm -f (stale cleanup)
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(makeExecaError({ exitCode: 130 }))
 
 			await expect(
@@ -476,6 +491,7 @@ describe('DockerDevServerStrategy', () => {
 		it('should silently swallow signal SIGTERM', async () => {
 			vi.mocked(execa)
 				.mockResolvedValueOnce({} as never) // rm -f (stale cleanup)
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(makeExecaError({ signal: 'SIGTERM' }))
 
 			await expect(
@@ -486,6 +502,7 @@ describe('DockerDevServerStrategy', () => {
 		it('should silently swallow signal SIGINT', async () => {
 			vi.mocked(execa)
 				.mockResolvedValueOnce({} as never) // rm -f (stale cleanup)
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(makeExecaError({ signal: 'SIGINT' }))
 
 			await expect(
@@ -496,6 +513,7 @@ describe('DockerDevServerStrategy', () => {
 		it('should re-throw unexpected errors (non-signal exit codes)', async () => {
 			vi.mocked(execa)
 				.mockResolvedValueOnce({} as never) // rm -f (stale cleanup)
+				.mockResolvedValueOnce({ exitCode: 1 } as never) // container inspect (not found)
 				.mockRejectedValueOnce(makeExecaError({ exitCode: 1, message: 'container failed' }))
 
 			await expect(

--- a/src/lib/DockerDevServerStrategy.ts
+++ b/src/lib/DockerDevServerStrategy.ts
@@ -99,6 +99,31 @@ export class DockerDevServerStrategy {
 	}
 
 	/**
+	 * Force-remove a container and verify it's gone before returning.
+	 * Handles the known Docker race where `docker rm -f` returns success but the
+	 * name isn't immediately released, causing subsequent `docker run --name` to
+	 * fail with "name already in use".
+	 */
+	private async ensureContainerRemoved(containerName: string, maxRetries = 3): Promise<void> {
+		for (let attempt = 0; attempt < maxRetries; attempt++) {
+			await execa('docker', ['rm', '-f', containerName], { reject: false })
+
+			// Verify container is gone (inspect exits non-zero when container doesn't exist)
+			const check = await execa('docker', ['container', 'inspect', containerName], { reject: false })
+			if (check.exitCode !== 0) {
+				return
+			}
+
+			if (attempt < maxRetries - 1) {
+				logger.debug(`Container "${containerName}" still exists after rm -f, retrying (attempt ${attempt + 1}/${maxRetries})...`)
+				await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 500))
+			}
+		}
+
+		logger.warn(`Container "${containerName}" still exists after ${maxRetries} removal attempts`)
+	}
+
+	/**
 	 * Resolve the container port using 3-tier fallback:
 	 *   1. config.containerPort (explicit)
 	 *   2. inspectImagePorts(imageName) (from built image)
@@ -210,8 +235,8 @@ export class DockerDevServerStrategy {
 		const imageName = this.utils.buildImageName(nameId)
 		const containerName = this.utils.buildContainerName(nameId)
 
-		// Force-remove any existing container with same name
-		await execa('docker', ['rm', '-f', containerName], { reject: false })
+		// Force-remove any existing container with same name and verify it's gone
+		await this.ensureContainerRemoved(containerName)
 
 		const args = [
 			'run', '-d',
@@ -279,7 +304,7 @@ export class DockerDevServerStrategy {
 		const { redirectToStderr, onProcessStarted, envOverrides, onOutput } = opts
 
 		// Force-remove any existing container with same name (stale from previous ungraceful exit)
-		await execa('docker', ['rm', '-f', containerName], { reject: false })
+		await this.ensureContainerRemoved(containerName)
 
 		const args = [
 			'run', '--rm',

--- a/src/utils/dev-server.test.ts
+++ b/src/utils/dev-server.test.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildDevServerCommand, buildDevServerUrl, getDevServerLaunchCommand } from './dev-server.js'
 import * as packageManager from './package-manager.js'
+import * as packageJson from './package-json.js'
 
 // Mock package-manager module
 vi.mock('./package-manager.js', () => ({
 	detectPackageManager: vi.fn(),
 }))
 
+// Mock package-json module
+vi.mock('./package-json.js', () => ({
+	getPackageScripts: vi.fn(),
+}))
+
 describe('buildDevServerCommand', () => {
 	beforeEach(() => {
-		vi.clearAllMocks()
+		// Default: no iloom-config scripts, fall through to package manager
+		vi.mocked(packageJson.getPackageScripts).mockResolvedValue({})
 	})
 
 	it('should build pnpm dev command for pnpm projects', async () => {
@@ -55,11 +62,34 @@ describe('buildDevServerCommand', () => {
 
 		expect(command).toBe('npm run dev')
 	})
+
+	it('should use iloom-config dev script when available', async () => {
+		vi.mocked(packageJson.getPackageScripts).mockResolvedValue({
+			dev: { command: 'cargo watch -x run', source: 'iloom-config' },
+		})
+
+		const command = await buildDevServerCommand('/Users/test/workspace')
+
+		expect(command).toBe('cargo watch -x run')
+		expect(packageManager.detectPackageManager).not.toHaveBeenCalled()
+	})
+
+	it('should fall through to package manager when dev script is from package-manager source', async () => {
+		vi.mocked(packageJson.getPackageScripts).mockResolvedValue({
+			dev: { command: 'next dev', source: 'package-manager' },
+		})
+		vi.mocked(packageManager.detectPackageManager).mockResolvedValue('pnpm')
+
+		const command = await buildDevServerCommand('/Users/test/workspace')
+
+		expect(command).toBe('pnpm dev')
+	})
 })
 
 describe('getDevServerLaunchCommand', () => {
 	beforeEach(() => {
-		vi.clearAllMocks()
+		// Default: no iloom-config scripts
+		vi.mocked(packageJson.getPackageScripts).mockResolvedValue({})
 	})
 
 	it('should build complete terminal command with PORT export for web projects', async () => {

--- a/src/utils/dev-server.ts
+++ b/src/utils/dev-server.ts
@@ -1,4 +1,5 @@
 import { detectPackageManager } from './package-manager.js'
+import { getPackageScripts } from './package-json.js'
 import { logger } from './logger.js'
 import type { Capability } from '../types/loom.js'
 
@@ -16,6 +17,15 @@ export function buildDevServerUrl(port: number, protocol: 'http' | 'https' = 'ht
 export async function buildDevServerCommand(
 	workspacePath: string
 ): Promise<string> {
+	// Check for iloom config dev script first (package.iloom.json / package.iloom.local.json)
+	const scripts = await getPackageScripts(workspacePath)
+	const devScript = scripts['dev']
+
+	if (devScript?.source === 'iloom-config') {
+		logger.debug(`Dev server command (from iloom config): ${devScript.command}`)
+		return devScript.command
+	}
+
 	const packageManager = await detectPackageManager(workspacePath)
 
 	let devCommand: string


### PR DESCRIPTION
## Summary
- **iloom config ignored in TUI mode**: `buildDevServerCommand()` now checks `package.iloom.local.json` / `package.iloom.json` before falling back to package manager detection. Previously the TUI code path (default for `il dev`) bypassed iloom config entirely.
- **Docker container name conflict**: Added `ensureContainerRemoved()` that verifies container removal via `docker container inspect` with retry logic, preventing "name already in use" errors when running multiple looms concurrently.
- **TUI overwrites existing terminal content**: Added `CLEAR_SCREEN` on TUI start so previous output (build logs, startup messages) doesn't bleed through the scroll region.

## Test plan
- [x] `dev-server.test.ts` — 16 tests pass (new tests for iloom-config and package-manager source)
- [x] `DockerDevServerStrategy.test.ts` — 46 tests pass (updated mocks for ensureContainerRemoved)
- [x] `DevServerManager.test.ts` — 41 tests pass
- [x] `DevServerTUI.test.ts` — 29 tests pass
- [x] `pnpm build` succeeds