### PR TITLE
chore(migration): add global gitignore for .env.local files

### DIFF
--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -222,6 +222,26 @@ describe('migrations', () => {
     })
   })
 
+  describe('v0.13.1 global gitignore for .env.local files', () => {
+    const migration = migrations.find(m => m.version === '0.13.1')
+
+    it('should exist with correct description', () => {
+      expect(migration).toBeDefined()
+      expect(migration?.description).toContain('.env.local')
+    })
+
+    it('calls ensureGlobalGitignorePatterns with env local patterns', async () => {
+      vi.mocked(ensureGlobalGitignorePatterns).mockResolvedValue(undefined)
+
+      await migration?.migrate()
+
+      expect(ensureGlobalGitignorePatterns).toHaveBeenCalledWith([
+        '**/.env.local',
+        '**/.env.*.local',
+      ])
+    })
+  })
+
   describe('v0.10.3 global gitignore path remediation migration', () => {
     const migration = migrations.find(m => m.version === '0.10.3')
 

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -117,4 +117,14 @@ export const migrations: Migration[] = [
       await ensureGlobalGitignorePatterns(allIloomPatterns)
     }
   },
+  {
+    version: '0.13.1',
+    description: 'Add global gitignore for .env.local and .env.*.local files',
+    migrate: async (): Promise<void> => {
+      await ensureGlobalGitignorePatterns([
+        '**/.env.local',
+        '**/.env.*.local',
+      ])
+    }
+  },
 ]


### PR DESCRIPTION
## Summary
- Adds v0.13.1 migration that globally ignores `**/.env.local` and `**/.env.*.local` (e.g., `.env.development.local`, `.env.production.local`)
- Uses `ensureGlobalGitignorePatterns` for idempotent writes to the correct global gitignore path

## Test plan
- [x] Migration tests pass (21 tests)
- [x] `pnpm build` succeeds