### PR TITLE
feat(docker): add dockerRunEnv setting and --env CLI flag

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -723,7 +723,16 @@ il open 25
 # For CLI projects, run with arguments
 il open 25 --help
 il open 25 --version
+
+# Pass environment variables to the dev server
+il open 25 --env DEBUG=true --env API_URL=http://localhost:8080
 ```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-e, --env <KEY=VALUE>` | Environment variable to pass to the dev server (repeatable). Same behavior as `il dev-server --env`. |
 
 ---
 
@@ -807,6 +816,13 @@ il dev-server 25
 il dev-server feat/my-branch
 ```
 
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output result as JSON |
+| `-e, --env <KEY=VALUE>` | Environment variable to pass to the dev server (repeatable). In Docker mode, these become `--env` flags on `docker run`; in native mode, they are injected into the process environment. CLI `--env` values override settings-level `dockerRunEnv` for the same key. |
+
 **Notes:**
 - Runs in foreground to see server output and errors
 - Use Ctrl+C to stop the server
@@ -838,7 +854,10 @@ Set `capabilities.web.devServer` to `"docker"` in your `.iloom/settings.json`:
       "dockerBuildSecrets": {
         "npmrc": "~/.npmrc"
       },
-      "dockerRunArgs": ["-v", "./src:/app/src"]
+      "dockerRunArgs": ["-v", "./src:/app/src"],
+      "dockerRunEnv": {
+        "DEBUG": "true"
+      }
     }
   }
 }
@@ -854,7 +873,8 @@ Set `capabilities.web.devServer` to `"docker"` in your `.iloom/settings.json`:
 | `containerPort` | `number` | Auto-detected | Port the application listens on inside the Docker container. If not set, iloom attempts to detect it from `EXPOSE` directives in the built Docker image (via `docker image inspect`), falling back to Dockerfile parsing. |
 | `dockerBuildArgs` | `Record<string, string>` | - | Build arguments passed to `docker build` (e.g., `{"NODE_ENV": "development"}`). |
 | `dockerBuildSecrets` | `Record<string, string>` | - | Secret files to mount during `docker build` via BuildKit `--secret` flag. Keys are secret IDs, values are source file paths (supports `~` expansion). Example: `{"npmrc": "~/.npmrc"}` translates to `--secret id=npmrc,src=$HOME/.npmrc`. |
-| `dockerRunArgs` | `string[]` | - | Additional flags passed to `docker run`. Use this for volume mounts, environment variables, user mapping, and other Docker options. |
+| `dockerRunArgs` | `string[]` | - | Additional flags passed to `docker run`. Use this for volume mounts, user mapping, and other Docker options. |
+| `dockerRunEnv` | `Record<string, string>` | - | Environment variables passed as `--env` to `docker run` (e.g., `{"NODE_ENV": "development"}`). These can be overridden at invocation time with `il dev-server --env KEY=VALUE`. |
 
 **How Port Mapping Works:**
 
@@ -875,10 +895,10 @@ Containers are named `iloom-dev-<identifier>` where the identifier is derived fr
 **Known Limitations:**
 
 - **Single-container only:** Docker mode runs a single container from your Dockerfile. Docker Compose (`docker-compose.yml`) multi-service stacks are not yet supported. If your app depends on external services (Redis, Postgres, etc.), run them separately or use a self-contained Dockerfile.
-- **macOS file watching:** Docker Desktop on macOS uses VirtioFS for bind mounts. Hot reload frameworks may not detect file changes reliably through VirtioFS. If your dev server's hot reload stops working, enable polling mode via `dockerRunArgs`:
+- **macOS file watching:** Docker Desktop on macOS uses VirtioFS for bind mounts. Hot reload frameworks may not detect file changes reliably through VirtioFS. If your dev server's hot reload stops working, enable polling mode via `dockerRunEnv`:
   ```json
   {
-    "dockerRunArgs": ["-e", "CHOKIDAR_USEPOLLING=true"]
+    "dockerRunEnv": { "CHOKIDAR_USEPOLLING": "true" }
   }
   ```
   This is a Docker Desktop limitation, not an iloom limitation.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,23 @@ function parseIssueIdentifier(value: string): string | number {
   return !isNaN(parsed) && String(parsed) === value ? parsed : value
 }
 
+/**
+ * Commander custom parse function for collecting repeatable KEY=VALUE options into a Record.
+ * Used for --env flags that can be specified multiple times.
+ */
+function collectKeyValue(value: string, previous: Record<string, string>): Record<string, string> {
+  const equalsIndex = value.indexOf('=')
+  if (equalsIndex === -1) {
+    throw new Error(`Invalid format: "${value}". Expected KEY=VALUE`)
+  }
+  const key = value.substring(0, equalsIndex)
+  const val = value.substring(equalsIndex + 1)
+  if (!key) {
+    throw new Error(`Invalid format: "${value}". Key cannot be empty`)
+  }
+  return { ...previous, [key]: val }
+}
+
 program
   .name('iloom')
   .description(packageJson.description)
@@ -862,15 +879,17 @@ program
   .command('open')
   .description('Open workspace in browser or run CLI tool')
   .argument('[identifier]', 'Issue number, PR number, or branch name (auto-detected if omitted)')
+  .option('-e, --env <KEY=VALUE>', 'Environment variable for the dev server (repeatable)', collectKeyValue, {})
   .allowUnknownOption()
-  .action(async (identifier?: string, _options?: Record<string, unknown>, command?: Command) => {
+  .action(async (identifier?: string, options?: { env?: Record<string, string> }, command?: Command) => {
     try {
       // Extract additional arguments - everything after identifier
       const args = command?.args ? command.args.slice(identifier ? 1 : 0) : []
+      const env = options?.env && Object.keys(options.env).length > 0 ? options.env : undefined
 
       const { OpenCommand } = await import('./commands/open.js')
       const cmd = new OpenCommand()
-      const input = identifier ? { identifier, args } : { args }
+      const input = identifier ? { identifier, args, env } : { args, env }
       await cmd.execute(input)
     } catch (error) {
       logger.error(`Failed to open: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -882,15 +901,17 @@ program
   .command('run')
   .description('Run CLI tool or open workspace in browser')
   .argument('[identifier]', 'Issue number, PR number, or branch name (auto-detected if omitted)')
+  .option('-e, --env <KEY=VALUE>', 'Environment variable for the dev server (repeatable)', collectKeyValue, {})
   .allowUnknownOption()
-  .action(async (identifier?: string, _options?: Record<string, unknown>, command?: Command) => {
+  .action(async (identifier?: string, options?: { env?: Record<string, string> }, command?: Command) => {
     try {
       // Extract additional arguments - everything after identifier
       const args = command?.args ? command.args.slice(identifier ? 1 : 0) : []
+      const env = options?.env && Object.keys(options.env).length > 0 ? options.env : undefined
 
       const { RunCommand } = await import('./commands/run.js')
       const cmd = new RunCommand()
-      const input = identifier ? { identifier, args } : { args }
+      const input = identifier ? { identifier, args, env } : { args, env }
       await cmd.execute(input)
     } catch (error) {
       logger.error(`Failed to run: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -919,11 +940,13 @@ program
   .description('Start dev server for workspace (foreground)')
   .argument('[identifier]', 'Issue number, PR number, or branch name (auto-detected if omitted)')
   .option('--json', 'Output as JSON')
-  .action(async (identifier?: string, options?: { json?: boolean }) => {
+  .option('-e, --env <KEY=VALUE>', 'Environment variable for the dev server (repeatable)', collectKeyValue, {})
+  .action(async (identifier?: string, options?: { json?: boolean; env?: Record<string, string> }) => {
     try {
       const { DevServerCommand } = await import('./commands/dev-server.js')
       const cmd = new DevServerCommand()
-      await cmd.execute({ identifier, json: options?.json })
+      const env = options?.env && Object.keys(options.env).length > 0 ? options.env : undefined
+      await cmd.execute({ identifier, json: options?.json, env })
     } catch (error) {
       logger.error(`Failed to start dev server: ${error instanceof Error ? error.message : 'Unknown error'}`)
       process.exit(1)

--- a/src/commands/dev-server.test.ts
+++ b/src/commands/dev-server.test.ts
@@ -655,6 +655,32 @@ describe('DevServerCommand', () => {
 			const envArg = vi.mocked(mockDevServerManager.runServerForeground).mock.calls[0]?.[4]
 			expect(envArg).not.toHaveProperty('ILOOM_COLOR_HEX')
 		})
+
+		it('should merge CLI --env into envOverrides', async () => {
+			await command.execute({ identifier: '87', env: { API_KEY: 'secret', DEBUG: 'true' } })
+
+			const envArg = vi.mocked(mockDevServerManager.runServerForeground).mock.calls[0]?.[4]
+			expect(envArg).toHaveProperty('API_KEY', 'secret')
+			expect(envArg).toHaveProperty('DEBUG', 'true')
+			// Internal vars should still be present
+			expect(envArg).toHaveProperty('ILOOM_LOOM', '87')
+		})
+
+		it('should let CLI --env override .env file values for same key', async () => {
+			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValue({
+				sourceEnvOnStart: true,
+			})
+			vi.mocked(loadWorkspaceEnv).mockReturnValue({
+				parsed: { DEBUG: 'false', API_KEY: 'from-env-file' },
+			})
+
+			await command.execute({ identifier: '87', env: { DEBUG: 'true' } })
+
+			const envArg = vi.mocked(mockDevServerManager.runServerForeground).mock.calls[0]?.[4]
+			expect(envArg).toHaveProperty('DEBUG', 'true')
+			// Env file value for API_KEY should still be present
+			expect(envArg).toHaveProperty('API_KEY', 'from-env-file')
+		})
 	})
 
 	describe('Docker mode', () => {

--- a/src/commands/dev-server.ts
+++ b/src/commands/dev-server.ts
@@ -18,6 +18,7 @@ import type { GitWorktree } from '../types/worktree.js'
 export interface DevServerCommandInput {
 	identifier?: string | undefined
 	json?: boolean | undefined
+	env?: Record<string, string> | undefined
 }
 
 export interface DevServerResult {
@@ -107,6 +108,11 @@ export class DevServerCommand {
 		const metadata = await this.metadataManager.readMetadata(worktree.path)
 		if (metadata?.colorHex) {
 			envOverrides.ILOOM_COLOR_HEX = metadata.colorHex
+		}
+
+		// 3d. Merge CLI --env overrides (highest priority for environment variables)
+		if (input.env) {
+			Object.assign(envOverrides, input.env)
 		}
 
 		// 4. Detect project capabilities

--- a/src/commands/open.test.ts
+++ b/src/commands/open.test.ts
@@ -660,6 +660,7 @@ describe('OpenCommand', () => {
 			expect(mockDevServerManager.ensureServerRunning).toHaveBeenCalledWith(
 				mockWorktree.path,
 				3087,
+				undefined,
 				undefined
 			)
 		})
@@ -691,6 +692,7 @@ describe('OpenCommand', () => {
 			expect(mockDevServerManager.ensureServerRunning).toHaveBeenCalledWith(
 				mockWorktree.path,
 				3087,
+				undefined,
 				undefined
 			)
 		})
@@ -708,6 +710,7 @@ describe('OpenCommand', () => {
 			expect(mockDevServerManager.ensureServerRunning).toHaveBeenCalledWith(
 				mockWorktree.path,
 				4500,
+				undefined,
 				undefined
 			)
 		})

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -18,6 +18,7 @@ import type { GitWorktree } from '../types/worktree.js'
 export interface OpenCommandInput {
 	identifier?: string
 	args?: string[]
+	env?: Record<string, string> | undefined
 }
 
 interface ParsedOpenInput {
@@ -62,7 +63,7 @@ export class OpenCommand {
 
 		// 4. Execute based on capabilities (web first, CLI fallback)
 		if (capabilities.includes('web')) {
-			await this.openWebBrowser(worktree)
+			await this.openWebBrowser(worktree, input.env)
 		} else if (capabilities.includes('cli')) {
 			await this.runCLITool(worktree.path, binEntries, input.args ?? [])
 		} else {
@@ -217,7 +218,7 @@ export class OpenCommand {
 	 * Open web browser with workspace URL
 	 * Auto-starts dev server if not already running
 	 */
-	private async openWebBrowser(worktree: GitWorktree): Promise<void> {
+	private async openWebBrowser(worktree: GitWorktree, env?: Record<string, string>): Promise<void> {
 		const cliOverrides = extractSettingsOverrides()
 		const settings = await this.settingsManager.loadSettings(undefined, cliOverrides)
 		const isMainWorktree = await this.gitWorktreeManager.isMainWorktree(worktree, this.settingsManager)
@@ -247,7 +248,8 @@ export class OpenCommand {
 		const serverReady = await this.devServerManager.ensureServerRunning(
 			worktree.path,
 			port,
-			dockerConfig
+			dockerConfig,
+			env
 		)
 
 		if (!serverReady) {

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -595,6 +595,7 @@ describe('RunCommand', () => {
 			expect(mockDevServerManager.ensureServerRunning).toHaveBeenCalledWith(
 				mockWorktree.path,
 				3087,
+				undefined,
 				undefined
 			)
 		})

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -18,6 +18,7 @@ import type { GitWorktree } from '../types/worktree.js'
 export interface RunCommandInput {
 	identifier?: string
 	args?: string[]
+	env?: Record<string, string> | undefined
 }
 
 interface ParsedRunInput {
@@ -62,9 +63,9 @@ export class RunCommand {
 
 		// 4. Execute based on capabilities (CLI first, web fallback)
 		if (capabilities.includes('cli')) {
-			await this.runCLITool(worktree.path, binEntries, input.args ?? [])
+			await this.runCLITool(worktree.path, binEntries, input.args ?? [], input.env)
 		} else if (capabilities.includes('web')) {
-			await this.openWebBrowser(worktree)
+			await this.openWebBrowser(worktree, input.env)
 		} else {
 			throw new Error(
 				`No CLI or web capabilities detected for workspace at ${worktree.path}`
@@ -219,7 +220,8 @@ export class RunCommand {
 	private async runCLITool(
 		worktreePath: string,
 		binEntries: Record<string, string>,
-		args: string[]
+		args: string[],
+		env?: Record<string, string>
 	): Promise<void> {
 		// Validate binEntries exist
 		if (Object.keys(binEntries).length === 0) {
@@ -251,7 +253,7 @@ export class RunCommand {
 		await execa('node', [binFilePath, ...args], {
 			stdio: 'inherit', // Allow interactive CLIs (prompts, colors, etc.)
 			cwd: worktreePath, // Execute in worktree context
-			env: process.env, // Inherit environment
+			env: env ? { ...process.env, ...env } : process.env,
 		})
 	}
 
@@ -259,7 +261,7 @@ export class RunCommand {
 	 * Open web browser with workspace URL
 	 * Auto-starts dev server if not already running
 	 */
-	private async openWebBrowser(worktree: GitWorktree): Promise<void> {
+	private async openWebBrowser(worktree: GitWorktree, env?: Record<string, string>): Promise<void> {
 		const cliOverrides = extractSettingsOverrides()
 		const settings = await this.settingsManager.loadSettings(undefined, cliOverrides)
 		const isMainWorktree = await this.gitWorktreeManager.isMainWorktree(worktree, this.settingsManager)
@@ -289,7 +291,8 @@ export class RunCommand {
 		const serverReady = await this.devServerManager.ensureServerRunning(
 			worktree.path,
 			port,
-			dockerConfig
+			dockerConfig,
+			env
 		)
 
 		if (!serverReady) {

--- a/src/lib/DevServerManager.test.ts
+++ b/src/lib/DevServerManager.test.ts
@@ -673,7 +673,8 @@ describe('DevServerManager', () => {
 					expect.objectContaining({
 						dockerFile: './Dockerfile',
 						containerPort: 4200,
-					})
+					}),
+					undefined
 				)
 			})
 
@@ -738,7 +739,8 @@ describe('DevServerManager', () => {
 					4200,
 					expect.objectContaining({
 						runArgs: ['-v', './src:/app/src'],
-					})
+					}),
+					undefined
 				)
 			})
 
@@ -751,6 +753,53 @@ describe('DevServerManager', () => {
 
 				// Process-based detection should NOT be called in Docker mode
 				expect(mockProcessManager.detectDevServer).not.toHaveBeenCalled()
+			})
+
+			it('should pass envOverrides through to runContainerDetached', async () => {
+				const port = 3548
+				const envOverrides = { API_KEY: 'test-key', DEBUG: 'true' }
+
+				mockStrategyInstance.isContainerRunning.mockResolvedValue(false)
+				mockStrategyInstance.buildImage.mockResolvedValue(undefined)
+				mockStrategyInstance.resolveContainerPort.mockResolvedValue(4200)
+				mockStrategyInstance.runContainerDetached.mockResolvedValue('iloom-dev-548')
+				mockStrategyInstance.waitForReady.mockResolvedValue(true)
+
+				await manager.ensureServerRunning(mockWorktreePath, port, dockerConfig, envOverrides)
+
+				expect(mockStrategyInstance.runContainerDetached).toHaveBeenCalledWith(
+					mockWorktreePath,
+					port,
+					4200,
+					expect.any(Object),
+					envOverrides
+				)
+			})
+
+			it('should pass dockerRunEnv through toStrategyConfig as runEnv', async () => {
+				const port = 3548
+				const configWithEnv: typeof dockerConfig = {
+					...dockerConfig,
+					dockerRunEnv: { NODE_ENV: 'development' },
+				}
+
+				mockStrategyInstance.isContainerRunning.mockResolvedValue(false)
+				mockStrategyInstance.buildImage.mockResolvedValue(undefined)
+				mockStrategyInstance.resolveContainerPort.mockResolvedValue(4200)
+				mockStrategyInstance.runContainerDetached.mockResolvedValue('iloom-dev-548')
+				mockStrategyInstance.waitForReady.mockResolvedValue(true)
+
+				await manager.ensureServerRunning(mockWorktreePath, port, configWithEnv)
+
+				expect(mockStrategyInstance.runContainerDetached).toHaveBeenCalledWith(
+					mockWorktreePath,
+					port,
+					4200,
+					expect.objectContaining({
+						runEnv: { NODE_ENV: 'development' },
+					}),
+					undefined
+				)
 			})
 		})
 

--- a/src/lib/DevServerManager.ts
+++ b/src/lib/DevServerManager.ts
@@ -63,6 +63,7 @@ function toStrategyConfig(config: DockerConfig): StrategyDockerConfig {
 		buildArgs: config.dockerBuildArgs,
 		buildSecrets: config.dockerBuildSecrets,
 		runArgs: config.dockerRunArgs,
+		runEnv: config.dockerRunEnv,
 		identifier: config.identifier,
 		protocol: config.protocol,
 	}
@@ -115,7 +116,7 @@ export class DevServerManager {
 	 * @param dockerConfig - Optional Docker configuration for container-based server
 	 * @returns true if server is ready, false if startup failed/timed out
 	 */
-	async ensureServerRunning(worktreePath: string, port: number, dockerConfig?: DockerConfig): Promise<boolean> {
+	async ensureServerRunning(worktreePath: string, port: number, dockerConfig?: DockerConfig, envOverrides?: Record<string, string>): Promise<boolean> {
 		logger.debug(`Checking if dev server is running on port ${port}...`)
 
 		// Docker mode: check if container is already running
@@ -130,7 +131,7 @@ export class DevServerManager {
 
 			logger.info(`Docker dev server not running on port ${port}, starting...`)
 			try {
-				await this.startDockerServer(worktreePath, port, dockerConfig, strategy)
+				await this.startDockerServer(worktreePath, port, dockerConfig, strategy, envOverrides)
 				return true
 			} catch (error) {
 				logger.error(
@@ -172,7 +173,8 @@ export class DevServerManager {
 		worktreePath: string,
 		port: number,
 		dockerConfig: DockerConfig,
-		strategy: DockerDevServerStrategy
+		strategy: DockerDevServerStrategy,
+		envOverrides?: Record<string, string>
 	): Promise<void> {
 		const strategyConfig = toStrategyConfig(dockerConfig)
 		const imageName = dockerUtils.buildImageName(dockerConfig.identifier)
@@ -193,7 +195,8 @@ export class DevServerManager {
 			worktreePath,
 			port,
 			containerPort,
-			strategyConfig
+			strategyConfig,
+			envOverrides
 		)
 
 		// Track for cleanup

--- a/src/lib/DockerDevServerStrategy.test.ts
+++ b/src/lib/DockerDevServerStrategy.test.ts
@@ -311,6 +311,39 @@ describe('DockerDevServerStrategy', () => {
 			]))
 		})
 
+		it('should forward config.runEnv as -e flags', async () => {
+			await strategy.runContainerDetached(WORKTREE, 3742, 4200, {
+				...config,
+				runEnv: { NODE_ENV: 'development', DEBUG: 'true' },
+			})
+
+			expect(execa).toHaveBeenCalledWith('docker', expect.arrayContaining([
+				'-e', 'NODE_ENV=development',
+				'-e', 'DEBUG=true',
+			]))
+		})
+
+		it('should place config.runEnv before envOverrides so envOverrides win for same key', async () => {
+			await strategy.runContainerDetached(WORKTREE, 3742, 4200, {
+				...config,
+				runEnv: { DEBUG: 'false' },
+			}, { DEBUG: 'true' })
+
+			const args = vi.mocked(execa).mock.calls.find(
+				(call) => Array.isArray(call[1]) && (call[1] as string[]).includes('run')
+			)?.[1] as string[]
+
+			// Both should be present; Docker uses last -e for same key, so envOverrides wins
+			const debugIndices = args.reduce<number[]>((acc, arg, i) => {
+				if (arg === 'DEBUG=false' || arg === 'DEBUG=true') acc.push(i)
+				return acc
+			}, [])
+			expect(debugIndices).toHaveLength(2)
+			// envOverrides (DEBUG=true) should come after config.runEnv (DEBUG=false)
+			expect(args[debugIndices[0]!]).toBe('DEBUG=false')
+			expect(args[debugIndices[1]!]).toBe('DEBUG=true')
+		})
+
 		it('should append runArgs to docker run command', async () => {
 			await strategy.runContainerDetached(WORKTREE, 3742, 4200, {
 				...config,
@@ -525,6 +558,38 @@ describe('DockerDevServerStrategy', () => {
 			const result = await strategy.runContainerForeground(WORKTREE, 3742, 4200, config)
 
 			expect(result).toEqual({})
+		})
+
+		it('should forward config.runEnv as -e flags', async () => {
+			await strategy.runContainerForeground(WORKTREE, 3742, 4200, {
+				...config,
+				runEnv: { NODE_ENV: 'development', DEBUG: 'true' },
+			})
+
+			expect(execa).toHaveBeenCalledWith(
+				'docker',
+				expect.arrayContaining(['-e', 'NODE_ENV=development', '-e', 'DEBUG=true']),
+				expect.any(Object)
+			)
+		})
+
+		it('should place config.runEnv before envOverrides so envOverrides win for same key', async () => {
+			await strategy.runContainerForeground(WORKTREE, 3742, 4200, {
+				...config,
+				runEnv: { DEBUG: 'false' },
+			}, { envOverrides: { DEBUG: 'true' } })
+
+			const args = vi.mocked(execa).mock.calls.find(
+				(call) => Array.isArray(call[1]) && (call[1] as string[]).includes('run')
+			)?.[1] as string[]
+
+			const debugIndices = args.reduce<number[]>((acc, arg, i) => {
+				if (arg === 'DEBUG=false' || arg === 'DEBUG=true') acc.push(i)
+				return acc
+			}, [])
+			expect(debugIndices).toHaveLength(2)
+			expect(args[debugIndices[0]!]).toBe('DEBUG=false')
+			expect(args[debugIndices[1]!]).toBe('DEBUG=true')
 		})
 
 		it('should append config.runArgs to the docker run command', async () => {

--- a/src/lib/DockerDevServerStrategy.ts
+++ b/src/lib/DockerDevServerStrategy.ts
@@ -19,6 +19,8 @@ export interface DockerConfig {
 	buildSecrets?: Record<string, string> | undefined
 	/** Additional docker run flags */
 	runArgs?: string[] | undefined
+	/** Environment variables passed as --env to docker run */
+	runEnv?: Record<string, string> | undefined
 	/** Identifier for naming containers/images (issue number, branch name). Falls back to worktreePath if not set. */
 	identifier?: string | undefined
 	/** Protocol for displayed URLs (http or https, default http) */
@@ -251,7 +253,14 @@ export class DockerDevServerStrategy {
 			'-e', `PORT=${containerPort}`,
 		]
 
-		// Forward additional environment variables
+		// Forward settings-level environment variables (overridable by envOverrides)
+		if (config.runEnv) {
+			for (const [key, value] of Object.entries(config.runEnv)) {
+				args.push('-e', `${key}=${value}`)
+			}
+		}
+
+		// Forward additional environment variables (overrides settings-level env for same keys)
 		if (envOverrides) {
 			for (const [key, value] of Object.entries(envOverrides)) {
 				args.push('-e', `${key}=${value}`)
@@ -319,7 +328,14 @@ export class DockerDevServerStrategy {
 			'-e', `PORT=${containerPort}`,
 		]
 
-		// Forward additional environment variables
+		// Forward settings-level environment variables (overridable by envOverrides)
+		if (config.runEnv) {
+			for (const [key, value] of Object.entries(config.runEnv)) {
+				args.push('-e', `${key}=${value}`)
+			}
+		}
+
+		// Forward additional environment variables (overrides settings-level env for same keys)
 		if (envOverrides) {
 			for (const [key, value] of Object.entries(envOverrides)) {
 				args.push('-e', `${key}=${value}`)

--- a/src/lib/DockerManager.test.ts
+++ b/src/lib/DockerManager.test.ts
@@ -952,6 +952,7 @@ describe('DockerManager', () => {
 				dockerBuildArgs: undefined,
 				dockerBuildSecrets: undefined,
 				dockerRunArgs: undefined,
+				dockerRunEnv: undefined,
 				identifier: '548',
 			})
 		})
@@ -982,8 +983,21 @@ describe('DockerManager', () => {
 				dockerBuildArgs: { NODE_ENV: 'development' },
 				dockerBuildSecrets: undefined,
 				dockerRunArgs: ['-v', './src:/app/src'],
+				dockerRunEnv: undefined,
 				identifier: 'my-branch',
 			})
+		})
+
+		it('should pass through dockerRunEnv when provided', () => {
+			const result = DockerManager.buildDockerConfigFromSettings(
+				{
+					devServer: 'docker',
+					dockerRunEnv: { NODE_ENV: 'development', DEBUG: 'true' },
+				},
+				'548'
+			)
+
+			expect(result?.dockerRunEnv).toEqual({ NODE_ENV: 'development', DEBUG: 'true' })
 		})
 
 		it('should pass through dockerBuildSecrets when provided', () => {

--- a/src/lib/DockerManager.ts
+++ b/src/lib/DockerManager.ts
@@ -29,6 +29,8 @@ export interface DockerConfig {
 	dockerBuildSecrets?: Record<string, string> | undefined
 	/** Additional docker run flags (e.g., volume mounts) */
 	dockerRunArgs?: string[] | undefined
+	/** Environment variables passed as --env to docker run */
+	dockerRunEnv?: Record<string, string> | undefined
 	/** Identifier for container naming (issue number, branch name) */
 	identifier: string
 	/** Protocol for dev server URLs (http or https) */
@@ -47,6 +49,7 @@ interface WebSettings {
 	dockerBuildArgs?: Record<string, string> | undefined
 	dockerBuildSecrets?: Record<string, string> | undefined
 	dockerRunArgs?: string[] | undefined
+	dockerRunEnv?: Record<string, string> | undefined
 	protocol?: 'http' | 'https' | undefined
 }
 
@@ -430,6 +433,7 @@ export class DockerManager {
 			dockerBuildArgs: webSettings.dockerBuildArgs,
 			dockerBuildSecrets: webSettings.dockerBuildSecrets,
 			dockerRunArgs: webSettings.dockerRunArgs,
+			dockerRunEnv: webSettings.dockerRunEnv,
 			identifier,
 			protocol: webSettings.protocol,
 		}

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -242,6 +242,10 @@ export const CapabilitiesSettingsSchema = z
 					.array(z.string())
 					.optional()
 					.describe('Additional arguments for docker run (e.g., ["-v", "./src:/app/src"] for volume mounts)'),
+				dockerRunEnv: z
+					.record(z.string())
+					.optional()
+					.describe('Environment variables to pass to docker run (e.g., {"NODE_ENV": "development", "DEBUG": "true"})'),
 			})
 			.optional()
 			.describe('Web dev server settings. To declare a project as a web project, add "web" to the capabilities array in .iloom/package.iloom.json or .iloom/package.iloom.local.json.'),
@@ -302,6 +306,10 @@ export const CapabilitiesSettingsSchemaNoDefaults = z
 					.array(z.string())
 					.optional()
 					.describe('Additional arguments for docker run (e.g., ["-v", "./src:/app/src"] for volume mounts)'),
+				dockerRunEnv: z
+					.record(z.string())
+					.optional()
+					.describe('Environment variables to pass to docker run (e.g., {"NODE_ENV": "development", "DEBUG": "true"})'),
 			})
 			.optional()
 			.describe('Web dev server settings. To declare a project as a web project, add "web" to the capabilities array in .iloom/package.iloom.json or .iloom/package.iloom.local.json.'),
@@ -360,6 +368,10 @@ export const DevServerSettingsSchema = z.object({
 				.array(z.string())
 				.optional()
 				.describe('Additional arguments for docker run'),
+			runEnv: z
+				.record(z.string(), z.string())
+				.optional()
+				.describe('Environment variables to pass to docker run'),
 		})
 		.optional(),
 })
@@ -406,6 +418,10 @@ export const DevServerSettingsSchemaNoDefaults = z.object({
 				.array(z.string())
 				.optional()
 				.describe('Additional arguments for docker run'),
+			runEnv: z
+				.record(z.string(), z.string())
+				.optional()
+				.describe('Environment variables to pass to docker run'),
 		})
 		.optional(),
 })


### PR DESCRIPTION
## Summary
- Add `dockerRunEnv` (`Record<string, string>`) to settings schemas for persistent Docker runtime environment variables
- Add repeatable `-e, --env KEY=VALUE` CLI flag to `il dev-server`, `il open`, and `il run` commands
- Thread env overrides through `ensureServerRunning` → `startDockerServer` → `runContainerDetached` for background Docker containers (used by `open`/`run`)
- Settings-level `dockerRunEnv` is expanded to `--env` flags in DockerDevServerStrategy before `envOverrides`, so CLI `--env` takes precedence for same keys

## Precedence (last wins)
1. `dockerRunEnv` from settings (lowest)
2. `.env` files + internal vars (`ILOOM_LOOM`, `ILOOM_COLOR_HEX`)
3. CLI `--env` flags (highest)

## Test plan
- [x] 9 new tests across 4 test files covering runEnv expansion, precedence ordering, passthrough, and CLI merge behavior
- [x] All 4951 existing tests pass
- [x] TypeScript compiles clean (`pnpm compile`)
- [x] Build succeeds (`pnpm build`)