### PR TITLE
feat(swarm): pass epic dev server port to orchestrator

### DIFF
--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -3648,6 +3648,179 @@ describe('IgniteCommand', () => {
 		})
 	})
 
+	describe('swarm PORT passthrough for web-capable epics', () => {
+		let launchClaudeSpy: ReturnType<typeof vi.spyOn>
+		let findMainWorktreePathSpy: ReturnType<typeof vi.spyOn>
+		let originalCwd: typeof process.cwd
+		let mockSetupSwarm: ReturnType<typeof vi.fn>
+
+		beforeEach(async () => {
+			launchClaudeSpy = vi.spyOn(claudeUtils, 'launchClaude').mockResolvedValue(undefined)
+			findMainWorktreePathSpy = vi.spyOn(gitUtils, 'findMainWorktreePathWithSettings').mockResolvedValue('/test/main')
+			originalCwd = process.cwd
+			process.cwd = vi.fn().mockReturnValue('/path/to/feat/issue-100__epic')
+
+			mockSetupSwarm = vi.fn().mockResolvedValue({
+				epicWorktreePath: '/path/to/epic',
+				epicBranch: 'feat/issue-100__epic',
+				skillsRendered: [],
+				renderedAgents: [],
+				workerAgentRendered: true,
+				verifierAgentRendered: false,
+			})
+
+			const { SwarmSetupService } = await import('../lib/SwarmSetupService.js')
+			vi.mocked(SwarmSetupService).mockImplementation(() => ({
+				setupSwarm: mockSetupSwarm,
+			}) as unknown as SwarmSetupService)
+		})
+
+		afterEach(() => {
+			process.cwd = originalCwd
+			launchClaudeSpy.mockRestore()
+			findMainWorktreePathSpy.mockRestore()
+		})
+
+		it('should pass PORT to orchestrator template when epic has web capability', async () => {
+			const childIssues = [
+				{ number: '#201', title: 'Child 1', body: 'Body 1' },
+			]
+
+			const readMetadataMock = vi.fn()
+			// First call: initial metadata read (with web capability)
+			readMetadataMock.mockResolvedValueOnce({
+				description: 'Epic loom',
+				created_at: '2025-01-01T00:00:00Z',
+				branchName: 'feat/issue-100__epic',
+				worktreePath: '/path/to/epic',
+				issueType: 'epic',
+				issue_numbers: ['100'],
+				childIssues,
+				capabilities: ['web'],
+				sessionId: 'epic-session-id',
+			})
+			// Second call: fresh metadata re-read for swarm mode
+			readMetadataMock.mockResolvedValueOnce({
+				description: 'Epic loom',
+				created_at: '2025-01-01T00:00:00Z',
+				branchName: 'feat/issue-100__epic',
+				worktreePath: '/path/to/epic',
+				issueType: 'epic',
+				issue_numbers: ['100'],
+				childIssues,
+				capabilities: ['web'],
+				dependencyMap: {},
+				sessionId: 'epic-session-id',
+			})
+			// Child filtering call: no existing metadata
+			readMetadataMock.mockResolvedValueOnce(null)
+			// Telemetry call
+			readMetadataMock.mockResolvedValueOnce(null)
+
+			vi.mocked(MetadataManager).mockImplementationOnce(() => ({
+				readMetadata: readMetadataMock,
+				getMetadataFilePath: vi.fn().mockReturnValue('/path/to/metadata.json'),
+				updateMetadata: vi.fn().mockResolvedValue(undefined),
+				listFinishedMetadata: vi.fn().mockResolvedValue([]),
+			}) as unknown as MetadataManager)
+
+			const cmd = new IgniteCommand(
+				mockTemplateManager,
+				{
+					getRepoInfo: vi.fn().mockResolvedValue({
+						currentBranch: 'feat/issue-100__epic',
+					}),
+				} as unknown as GitWorktreeManager,
+				{
+					loadAndPrepare: vi.fn().mockResolvedValue({}),
+				} as never,
+				{
+					loadSettings: vi.fn().mockResolvedValue({
+						issueTracker: { provider: 'github' },
+					}),
+					getSpinModel: vi.fn().mockReturnValue('opus'),
+				} as never,
+			)
+
+			await cmd.execute()
+
+			const templateCall = vi.mocked(mockTemplateManager.getPrompt).mock.calls.find(
+				(call) => call[0] === 'swarm-orchestrator',
+			)
+			expect(templateCall).toBeDefined()
+			// PORT should be 3000 + 100 = 3100
+			expect(templateCall![1].PORT).toBe(3100)
+		})
+
+		it('should not pass PORT to orchestrator template when epic has no web capability', async () => {
+			const childIssues = [
+				{ number: '#201', title: 'Child 1', body: 'Body 1' },
+			]
+
+			const readMetadataMock = vi.fn()
+			// First call: initial metadata read (no capabilities)
+			readMetadataMock.mockResolvedValueOnce({
+				description: 'Epic loom',
+				created_at: '2025-01-01T00:00:00Z',
+				branchName: 'feat/issue-100__epic',
+				worktreePath: '/path/to/epic',
+				issueType: 'epic',
+				issue_numbers: ['100'],
+				childIssues,
+				sessionId: 'epic-session-id',
+			})
+			// Second call: fresh metadata re-read for swarm mode
+			readMetadataMock.mockResolvedValueOnce({
+				description: 'Epic loom',
+				created_at: '2025-01-01T00:00:00Z',
+				branchName: 'feat/issue-100__epic',
+				worktreePath: '/path/to/epic',
+				issueType: 'epic',
+				issue_numbers: ['100'],
+				childIssues,
+				dependencyMap: {},
+				sessionId: 'epic-session-id',
+			})
+			// Child filtering call
+			readMetadataMock.mockResolvedValueOnce(null)
+			// Telemetry call
+			readMetadataMock.mockResolvedValueOnce(null)
+
+			vi.mocked(MetadataManager).mockImplementationOnce(() => ({
+				readMetadata: readMetadataMock,
+				getMetadataFilePath: vi.fn().mockReturnValue('/path/to/metadata.json'),
+				updateMetadata: vi.fn().mockResolvedValue(undefined),
+				listFinishedMetadata: vi.fn().mockResolvedValue([]),
+			}) as unknown as MetadataManager)
+
+			const cmd = new IgniteCommand(
+				mockTemplateManager,
+				{
+					getRepoInfo: vi.fn().mockResolvedValue({
+						currentBranch: 'feat/issue-100__epic',
+					}),
+				} as unknown as GitWorktreeManager,
+				{
+					loadAndPrepare: vi.fn().mockResolvedValue({}),
+				} as never,
+				{
+					loadSettings: vi.fn().mockResolvedValue({
+						issueTracker: { provider: 'github' },
+					}),
+					getSpinModel: vi.fn().mockReturnValue('opus'),
+				} as never,
+			)
+
+			await cmd.execute()
+
+			const templateCall = vi.mocked(mockTemplateManager.getPrompt).mock.calls.find(
+				(call) => call[0] === 'swarm-orchestrator',
+			)
+			expect(templateCall).toBeDefined()
+			expect(templateCall![1].PORT).toBeUndefined()
+		})
+	})
+
 	describe('swarm telemetry', () => {
 		// Helper to create an IgniteCommand that enters swarm mode
 		function createSwarmCommand(

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -293,6 +293,7 @@ export class IgniteCommand {
 						context.branchName ?? '',
 						metadataManager,
 						skipCleanup,
+						context.port,
 					)
 					return
 				}
@@ -878,6 +879,7 @@ export class IgniteCommand {
 		epicBranch: string,
 		metadataManager: MetadataManager,
 		skipCleanup?: boolean,
+		epicPort?: number,
 	): Promise<void> {
 		if (!this.settings) {
 			throw new Error('Settings not loaded. Cannot enter swarm mode.')
@@ -1078,6 +1080,7 @@ export class IgniteCommand {
 			ISSUE_PREFIX: issuePrefix,
 			...(skipCleanup && { NO_CLEANUP: true }),
 			...(postSwarmReview && { POST_SWARM_REVIEW: true }),
+			...(epicPort !== undefined && { PORT: epicPort }),
 		}
 
 		// Set draft PR mode flags for swarm orchestrator (same logic as buildTemplateVariables)

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -3,6 +3,9 @@
 You are the swarm orchestrator for epic #{{EPIC_ISSUE_NUMBER}}. Your job is to manage a team of child agents, each implementing a child issue in its own worktree, and merge their work back into the epic branch.
 
 **Epic Worktree:** `{{EPIC_WORKTREE_PATH}}`
+{{#if PORT}}
+**Dev Server Port:** `{{PORT}}` — This is the port assigned to the epic worktree. After merging child work into the epic branch, you can verify web output by running `curl http://localhost:{{PORT}}` or using Chrome DevTools MCP tools against this port. This is useful for checking that the integrated result works correctly.
+{{/if}}
 
 You are running with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. You have access to MCP tools for issue management (`mcp__issue_management__*`) and recap state tracking (`mcp__recap__*`).
 


### PR DESCRIPTION
## Summary

- Pass the epic worktree's calculated web port through to the swarm orchestrator template variables
- Add `{{#if PORT}}` block to the orchestrator prompt so it knows how to verify web output via `curl` or Chrome DevTools MCP after merging child work
- Add tests for PORT passthrough (web-capable vs non-web epics)

## Test plan

- [x] All 118 ignite tests pass
- [x] New test: PORT=3100 passed when epic has `capabilities: ['web']`
- [x] New test: PORT undefined when epic has no web capability
- [x] Build passes (lint + compile + tests via pre-commit hook)