### PR TITLE
docs: add hierarchical CLAUDE.md files for agent architecture context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ The telemetry system is in `src/lib/TelemetryService.ts` and event types are def
 
 The `docs/iloom-commands.md` file is the comprehensive command reference. Use it for detailed documentation to avoid flooding README.md. The README.md should remain a concise overview and quick start guide.
 
+- **Subdirectory CLAUDE.md files**: When adding, removing, or changing the responsibility of commands, services, templates, agents, MCP servers, types, or migrations, update the CLAUDE.md in the corresponding directory. See [Component Documentation](#component-documentation) below for the full list.
+
 **Core Commands**:
 
 - `il start <issue-number>` - Create isolated workspace for an issue/PR
@@ -91,49 +93,41 @@ npm run test:single -- <test-file>  # Run specific test file
 
 ## Architecture Overview
 
-**Test-Driven Development (TDD)**: All code must be written test-first with >70% coverage. Use comprehensive mock factories for external dependencies (Git, GitHub CLI, Neon CLI, Claude CLI).
+### Execution Contexts
 
-### Core Module Structure
+iloom operates in three distinct execution contexts. Understanding which context you're working in is critical for targeting the right component:
 
-```
-src/
-├── cli.ts                    # Main CLI entry point
-├── commands/                 # CLI command implementations
-│   ├── start.ts             # Port of new-branch-workflow.sh
-│   ├── finish.ts            # Port of merge-and-clean.sh
-│   ├── cleanup.ts           # Port of cleanup-worktree.sh
-│   ├── list.ts              # Enhanced workspace listing
-├── lib/                     # Core business logic
-│   ├── WorkspaceManager.ts  # Main orchestrator
-│   ├── GitWorktreeManager.ts # Git operations
-│   ├── GitHubService.ts     # GitHub CLI integration
-│   ├── EnvironmentManager.ts # .env file manipulation
-│   ├── DatabaseManager.ts   # Database provider abstraction
-│   └── ClaudeContextManager.ts # Claude context generation
-└── utils/                   # Utility functions
-    ├── git.ts, github.ts, env.ts, database.ts, shell.ts
-```
+1. **Regular mode** (`il start` + `il spin`): A single agent works on one issue in one worktree. Phase agents (analyzer → planner → implementer → reviewer) run sequentially. Prompt: `templates/prompts/issue-prompt.txt`.
+
+2. **Swarm mode** (`il start --epic` + `il spin`): An orchestrator agent manages an epic by spawning parallel child workers — each in its own worktree with its own phase agents. The orchestrator is lean: it parses the dependency DAG, spawns/monitors workers, and merges results. It delegates ALL implementation work (coding, rebasing, conflict resolution) to child agents via the Task tool. Prompt: `templates/prompts/swarm-orchestrator-prompt.txt`. Child workers use `templates/prompts/issue-prompt.txt` with `SWARM_MODE=true`.
+
+3. **Plan mode** (`il plan`): An architect agent decomposes work into issues. No implementation — planning and decomposition only. Can trigger auto-swarm to begin implementation after planning completes. Prompt: `templates/prompts/plan-prompt.txt`.
+
+### Orchestrator vs Child Boundary
+
+The orchestrator and child workers have strictly separated responsibilities. Getting this wrong is a common source of bugs:
+
+- **Orchestrator NEVER**: writes code, runs builds/tests, rebases branches, resolves merge conflicts, creates PRs, manages database branches, runs phase agents
+- **Child worker NEVER**: spawns other agents, merges branches to the epic branch, closes issues, manages the dependency DAG, reads other children's worktrees
 
 ### Key Architectural Patterns
 
-**Dependency Injection**: Core classes accept dependencies through constructor injection for complete test isolation.
+- **Dependency Injection**: Core classes accept dependencies through constructor injection for test isolation
+- **Provider Pattern**: Database (Neon), issue tracker (GitHub, Linear, Jira), VCS (GitHub, BitBucket), dev server (Native, Docker) — all implement pluggable interfaces via factories
+- **Strategy Pattern**: Branch naming (Simple vs Claude), dev server (Native vs Docker)
+- **Configuration Layering**: Defaults → global (`~/.config/iloom-ai/settings.json`) → project (`.iloom/settings.json`) → local (`.iloom/settings.local.json`) → CLI flags
 
-**Provider Pattern**: Database integrations (Neon, Supabase, PlanetScale) implement `DatabaseProvider` interface.
+### Component Documentation
 
-**Command Pattern**: CLI commands are separate classes with full workflow testing.
+Each major directory has its own CLAUDE.md with detailed component documentation. These load automatically when you access files in that directory:
 
-**Mock-First Testing**: All external dependencies (shell commands, APIs) are mocked using factory patterns.
-
-## Bash Script Migration Map
-
-The TypeScript implementation maintains exact functional parity with these bash scripts:
-
-- `bash/new-branch-workflow.sh` → `StartCommand` + `WorkspaceManager.createWorkspace()`
-- `bash/merge-and-clean.sh` → `FinishCommand` + `WorkspaceManager.finishWorkspace()`
-- `bash/cleanup-worktree.sh` → `CleanupCommand` + `WorkspaceManager.cleanupWorkspace()`
-- `bash/utils/env-utils.sh` → `EnvironmentManager`
-- `bash/utils/neon-utils.sh` → `NeonProvider`
-- `bash/utils/worktree-utils.sh` → `GitWorktreeManager`
+- `templates/CLAUDE.md` — Template system, prompt ownership, Handlebars conventions
+- `templates/agents/CLAUDE.md` — Phase agent lifecycle, YAML frontmatter, model overrides
+- `src/commands/CLAUDE.md` — Command layer, CLI flags, delegation to lib/
+- `src/lib/CLAUDE.md` — Service layer, class responsibilities, provider patterns
+- `src/mcp/CLAUDE.md` — MCP servers, exposed tools, routing rules
+- `src/types/CLAUDE.md` — Key interfaces, type organization by domain
+- `src/migrations/CLAUDE.md` — Migration versioning convention and lifecycle
 
 ## Testing Requirements
 
@@ -228,38 +222,8 @@ Uses Neon database branching to create isolated database copies per workspace. E
 
 ## Migration Versioning
 
-Migrations live in `src/migrations/index.ts` and run automatically on CLI startup via `VersionMigrationManager`. Each migration has a `version` field that determines when it runs: it must be greater than `lastMigratedVersion` (stored in `~/.config/iloom-ai/migration-state.json`) and less than or equal to the current package version.
-
-**Versioning convention:** A new migration's version should be one patch version higher than the current `package.json` version. For example, if `package.json` is at `0.10.2`, the next migration should be `0.10.3`. If an unreleased migration already exists at that version (check `git tag` to confirm it hasn't been released), fold new migration logic into it rather than creating a separate entry.
+See `src/migrations/CLAUDE.md` for the full versioning convention. Key rule: new migration version = current `package.json` version + one patch. Fold into existing unreleased migrations rather than creating duplicates.
 
 ## Agent Workflow Todo Lists
 
-The todo list in `templates/prompts/issue-prompt.txt` is critical for ensuring agents follow the implementation plan correctly.
-
-**Why the Todo List Matters:**
-- Agents use the todo list as both a progress tracker and an execution checklist
-- Each numbered item represents a workflow step that must be completed
-- Agents check off items as they complete each step, providing visibility into progress
-- The todo list serves as the source of truth for what steps need to be executed
-
-**When Adding New Workflow Steps:**
-- New workflow steps MUST be added to the todo list to ensure they are executed
-- Position the item appropriately based on when it should run in the workflow
-- Use Handlebars conditionals (e.g., `{{#if FLAG_NAME}}`) when steps are conditional
-- Ensure numbering remains sequential within each conditional branch
-
-**Example - Adding a Conditional Step:**
-```handlebars
-{{#if SOME_MODE}}
-{{#if SOME_FLAG}}
-17. Execute conditional step (STEP X.X)
-18. Next step...
-{{else}}
-17. Next step...
-{{/if}}
-{{else}}
-17. Next step...
-{{/if}}
-```
-
-Without the todo list entry, agents may skip steps even if they are fully documented elsewhere in the prompt.
+See `templates/CLAUDE.md` for the full todo list convention. Key rule: when adding new workflow steps, you MUST add a corresponding todo list entry in `templates/prompts/issue-prompt.txt` or agents will skip the step.

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -1,0 +1,91 @@
+# src/commands/
+
+> **Maintenance:** Keep this file in sync with the directory contents. If you add, remove, or rename a command, update the table below.
+
+Commands handle CLI parsing, flag validation, and user I/O. They delegate all business logic to services in `src/lib/`. Commands should be thin — orchestration logic belongs in lib/.
+
+## Command Registration
+
+Commands are registered in `src/cli.ts` using Commander.js. Each command class has an `execute()` method that receives parsed options.
+
+## Command Reference
+
+### Core Workspace Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `start` | `new`, `create`, `up` | `start.ts` | LoomManager, GitWorktreeManager, DatabaseManager, AgentManager | Create isolated workspace for issue/PR/epic |
+| `finish` | `dn` | `finish.ts` | MergeManager, ValidationRunner, ResourceCleanup, PRManager | Merge branch, cleanup workspace |
+| `cleanup` | `remove`, `clean` | `cleanup.ts` | GitWorktreeManager, ResourceCleanup, LoomManager | Remove worktree(s) |
+| `list` | — | (inline in cli.ts) | LoomManager, GitWorktreeManager | Show active looms |
+
+### Agent & Planning Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `spin` | `ignite` | `ignite.ts` | PromptTemplateManager, SwarmSetupService, AgentManager | Launch Claude with workspace context; swarm orchestrator for epics |
+| `plan` | — | `plan.ts` | PromptTemplateManager, IssueTrackerFactory, AgentManager | Architect-mode decomposition; optional auto-swarm |
+
+### Git & Commit Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `commit` | — | `commit.ts` | CommitManager, ValidationRunner, MetadataManager | Commit with issue reference |
+| `rebase` | — | `rebase.ts` | MergeManager, GitWorktreeManager, BuildRunner | Rebase on main with Claude conflict resolution |
+
+### Issue Management Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `add-issue` | `a` | `add-issue.ts` | IssueEnhancementService, SettingsManager | Create + enhance issue (no workspace) |
+| `enhance` | — | `enhance.ts` | IssueTracker, IssueEnhancementService | Enhance existing issue description |
+| `issues` | — | `issues.ts` | IssueTrackerFactory | List project issues |
+| `projects` | — | `projects.ts` | MetadataManager | List configured iloom projects |
+| `feedback` | `f` | `feedback.ts` | IssueEnhancementService, GitHubService | Submit feedback to iloom-cli repo |
+
+### Development Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `build` | — | `build.ts` | ScriptCommandBase | Run build script in worktree |
+| `lint` | — | `lint.ts` | ScriptCommandBase | Run lint script |
+| `test` | — | `test.ts` | ScriptCommandBase | Run test script |
+| `compile` | `typecheck` | `compile.ts` | ScriptCommandBase | Run TypeScript compiler check |
+| `install-deps` | — | `install-deps.ts` | ScriptCommandBase | Install dependencies |
+| `dev-server` | `dev` | `dev-server.ts` | DevServerManager, DockerManager | Start dev server (foreground) |
+| `open` | — | `open.ts` | DevServerManager, ProjectCapabilityDetector | Open workspace in browser |
+| `run` | — | `run.ts` | DevServerManager, ProjectCapabilityDetector | Run CLI tool or open browser |
+
+### Session & Environment Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `shell` | `terminal` | `shell.ts` | GitWorktreeManager, MetadataManager | Open shell with workspace env |
+| `vscode` | — | `vscode.ts` | GitWorktreeManager | Open workspace in VS Code |
+| `summary` | — | `summary.ts` | SessionSummaryService, PRManager | Generate session summary |
+| `recap` | — | `recap.ts` | GitWorktreeManager | Show loom recap |
+| `contribute` | — | `contribute.ts` | GitHub CLI, Git | Fork + clone external repo for contribution |
+
+### Setup & Utility Commands
+
+| Command | Aliases | File | Delegates To | Key Purpose |
+|---------|---------|------|-------------|-------------|
+| `init` | `config` | `init.ts` | PromptTemplateManager, AgentManager, ShellCompletion | Initialize iloom configuration |
+| `update` | — | `update.ts` | Installation detector | Update iloom to latest version |
+| `telemetry` | — | (inline in cli.ts) | TelemetryService | Enable/disable/check telemetry status |
+
+### Global Flags
+
+Available on all commands:
+- `--debug` — Enable debug output
+- `--set <key=value>` — Override any setting using dot notation (repeatable)
+
+### Key Flags by Command
+
+**`start`**: `--epic` (epic loom), `--one-shot <mode>` (automation level), `--complexity <level>` (override triage), `--create-only` (skip Claude/IDE/terminal), `--child-loom` (force child)
+
+**`finish`**: `--merge-strategy <local|pr|draft-pr>`, `--rebase` (rebase before merge), `--build`/`--test` (pre-merge validation)
+
+**`spin`**: `--one-shot <mode>`, `--complexity <level>`, `--json-stream` (headless JSONL output), `--print` (print mode for headless)
+
+**`plan`**: `--planner <claude|gemini|codex>`, `--reviewer <claude|gemini|codex|none>`

--- a/src/lib/CLAUDE.md
+++ b/src/lib/CLAUDE.md
@@ -1,0 +1,114 @@
+# src/lib/
+
+> **Maintenance:** Keep this file in sync with the directory contents. If you add, remove, or change the responsibility of a service, update the relevant section below.
+
+This is the service layer — all business logic lives here. Commands in `src/commands/` delegate to these services. Services accept dependencies via constructor injection for testability.
+
+## Orchestrator vs Child Boundary
+
+This is the most common source of architectural mistakes. Memorize these rules:
+
+**Orchestrator (swarm-orchestrator-prompt.txt) NEVER:**
+- Writes code or runs phase agents (analyzer, planner, implementer, reviewer)
+- Runs builds, tests, or linting
+- Rebases branches or resolves merge conflicts
+- Creates PRs or manages database branches
+- It stays lean: parse DAG → spawn workers → monitor → merge → finalize
+
+**Child worker (issue-prompt.txt with SWARM_MODE=true) NEVER:**
+- Spawns other agents or manages the team
+- Merges branches to the epic branch (orchestrator merges via git)
+- Closes issues (orchestrator closes after successful merge)
+- Reads other children's worktrees or manages the dependency DAG
+- It focuses: receive assignment → implement → report done/failed
+
+## Service Responsibilities
+
+### Workspace & Loom Lifecycle
+
+| Service | Responsibility | Used By |
+|---------|---------------|---------|
+| **LoomManager** | Orchestrate loom creation: worktree + env + deps + capabilities + metadata | `start` command |
+| **GitWorktreeManager** | Git worktree CRUD: list, create, find, remove | All workspace commands |
+| **MetadataManager** | Loom metadata persistence to `~/.config/iloom-ai/looms/` | All commands needing loom state |
+| **ResourceCleanup** | Teardown: kill processes, delete database branch, remove worktree | `finish`, `cleanup` |
+| **MergeManager** | Git rebase, merge target resolution, conflict detection | `finish`, `rebase` |
+| **CommitManager** | Git commit with issue references, message generation | `commit` |
+| **ValidationRunner** | Run lint/test scripts as pre-merge validation | `finish`, `commit` |
+| **BuildRunner** | Execute project build scripts | `finish`, `rebase`, `build` |
+| **BranchNamingService** | Generate branch names via strategy pattern (Simple or Claude) | `start` |
+
+### Claude Integration
+
+| Service | Responsibility | Used By |
+|---------|---------------|---------|
+| **ClaudeService** | Claude CLI invocation, permission mode resolution | `start`, `spin` |
+| **ClaudeContextManager** | Prepare Claude context with workspace info | `start` |
+| **PromptTemplateManager** | Handlebars template rendering for prompts and agents | `spin`, `plan`, `init` |
+| **AgentManager** | Load agent templates from markdown, apply model overrides | `spin`, `plan`, `start` |
+| **SwarmSetupService** | Render swarm agents/skills to `.claude/agents/` and `.claude/skills/` | `spin` (epic only) |
+| **ClaudeHookManager** | Hook execution for Claude CLI events | Swarm child |
+| **SwarmReportCollector** | Collect and aggregate swarm worker outputs | Swarm orchestrator |
+
+### Issue & Version Control
+
+| Service | Responsibility | Used By |
+|---------|---------------|---------|
+| **IssueTrackerFactory** | Create IssueTracker for configured provider (GitHub/Linear/Jira) | Commands needing issues |
+| **GitHubService** | GitHub-specific issue/PR operations via `gh` CLI | GitHub projects |
+| **LinearService** | Linear issue operations via `@linear/sdk` | Linear projects |
+| **PRManager** | GitHub PR create/check/merge (legacy, pre-VCS-factory) | `finish`, `start` |
+| **VCSProviderFactory** | Create VCS provider (BitBucket); GitHub uses PRManager | Multi-VCS projects |
+| **IssueEnhancementService** | Enhance issue descriptions with AI-generated context | `add-issue`, `enhance` |
+
+### Environment & Infrastructure
+
+| Service | Responsibility | Used By |
+|---------|---------------|---------|
+| **SettingsManager** | Hierarchical settings resolution with Zod validation | All commands |
+| **DatabaseManager** | Conditional database branching orchestration | `start`, `cleanup` |
+| **EnvironmentManager** | .env file read/write, DATABASE_URL management | `start`, `cleanup` |
+| **DevServerManager** | Dev server lifecycle via strategy (Native or Docker) | `open`, `run`, `dev-server` |
+| **DockerManager** | Docker build/run/inspect utility functions | Docker dev server |
+| **ProjectCapabilityDetector** | Detect project capabilities (cli, web) from package.json | `start`, `open`, `run` |
+| **CLIIsolationManager** | Symlink project CLI into worktree for agent use | `start` (cli capability) |
+| **ProcessManager** | Process detection/termination (cross-platform) | Dev server, cleanup |
+
+### Telemetry & Sessions
+
+| Service | Responsibility | Used By |
+|---------|---------------|---------|
+| **TelemetryService** | Anonymous event tracking (fire-and-forget, never breaks workflows) | All commands |
+| **SessionSummaryService** | Generate session summaries from Claude transcripts | `finish`, `summary` |
+
+## Configuration Layering
+
+Settings resolve in this order (highest priority wins):
+
+1. **CLI flags** — `--set key.nested.value` or typed flags like `--merge-strategy pr`
+2. **Local** — `.iloom/settings.local.json` (per-developer, gitignored)
+3. **Project** — `.iloom/settings.json` (shared, committed)
+4. **Global** — `~/.config/iloom-ai/settings.json` (user home)
+5. **Defaults** — Hardcoded in Zod schema
+
+Scalar values: higher priority fully overrides. Objects/arrays: deep-merged via `deepmerge`.
+
+## Provider Patterns
+
+Four provider abstractions with factory/strategy implementations:
+
+| Abstraction | Interface | Implementations | Factory |
+|------------|-----------|-----------------|---------|
+| Database | `DatabaseProvider` | NeonProvider | DatabaseManager detects provider |
+| Issue Tracker | `IssueTracker` | GitHubService, LinearService, JiraIssueTracker | `IssueTrackerFactory.create()` |
+| Version Control | `VersionControlProvider` | BitBucketVCSProvider (GitHub uses PRManager) | `VCSProviderFactory.create()` |
+| Dev Server | `DevServerStrategy` | NativeDevServerStrategy, DockerDevServerStrategy | DevServerManager selects by config |
+
+### providers/ subdirectory
+
+| File | Provider | Purpose |
+|------|----------|---------|
+| `NeonProvider.ts` | Neon | Database branching via Neon CLI |
+| `jira/JiraIssueTracker.ts` | Jira | Issue tracking via Jira API |
+| `jira/JiraApiClient.ts` | Jira | Low-level Jira REST API |
+| `BitBucketVCSProvider.ts` | BitBucket | PR/MR operations via BitBucket API |

--- a/src/mcp/CLAUDE.md
+++ b/src/mcp/CLAUDE.md
@@ -1,0 +1,56 @@
+# src/mcp/
+
+> **Maintenance:** Keep this file in sync with the directory contents. If you add, remove, or change an MCP server or its tools, update the relevant section below.
+
+This directory contains MCP (Model Context Protocol) servers that expose tools to Claude during agent workflows. These run as sidecar processes alongside Claude sessions.
+
+## MCP Servers
+
+### issue-management-server.ts
+
+Exposes issue/PR operations to agents. Provider-agnostic — routes to GitHub, Linear, or Jira based on `ISSUE_PROVIDER` env var.
+
+**Tools (27):** `get_issue`, `get_pr`, `get_review_comments`, `get_comment`, `create_comment`, `update_comment`, `create_issue`, `create_child_issue`, `create_dependency`, `get_dependencies`, `remove_dependency`, `get_child_issues`, `close_issue`, `reopen_issue`, `edit_issue`, and more.
+
+**Used by:** All execution contexts (regular, swarm child, swarm orchestrator).
+
+**Routing:** Provider determined by `ISSUE_PROVIDER` env var. PR comment operations always route through GitHub regardless of issue provider. Jira Wiki markup is auto-converted to GFM.
+
+### recap-server.ts
+
+Manages the recap system — structured knowledge capture (decisions, insights, risks, artifacts) displayed in the VS Code sidebar.
+
+**Tools:** `set_goal`, `set_complexity`, `add_entry`, `add_artifact`, `get_recap`, `set_loom_state`, `get_loom_state`
+
+**Used by:** All execution contexts.
+
+**Routing (critical for swarm):** Recap entries are routed by `worktreePath` parameter. When provided, entries write to `~/.config/iloom-ai/recaps/[slugified-path].json`. In swarm mode, child workers MUST pass `worktreePath` on every recap call — otherwise entries go to the epic's recap instead of the child's. This is a common bug source.
+
+**Deduplication:** `add_entry` skips if type+content already exists. `add_artifact` replaces if `primaryUrl` matches.
+
+### harness-server.ts
+
+One-way signaling from Claude to the iloom harness process (e.g., plan mode auto-swarm).
+
+**Tools:** `signal`
+
+**Used by:** Plan mode (signal "done" to trigger auto-swarm), child workers in swarm.
+
+**Routing:** Via Unix domain socket at `ILOOM_HARNESS_SOCKET` env var.
+
+## Provider Implementations
+
+MCP issue management uses its own provider layer (separate from `src/lib/` issue trackers):
+
+| File | Provider | Purpose |
+|------|----------|---------|
+| `GitHubIssueManagementProvider.ts` | GitHub | Issue/PR ops via `gh` CLI |
+| `LinearIssueManagementProvider.ts` | Linear | Issue ops via Linear SDK |
+| `JiraIssueManagementProvider.ts` | Jira | Issue ops via Jira API |
+
+Factory: `IssueManagementProviderFactory` creates the right provider based on settings.
+
+## Type Definitions
+
+`types.ts` — Input/output schemas for all MCP operations.
+`recap-types.ts` — `RecapFile`, `RecapEntry`, `RecapArtifact`, `RecapComplexity`.

--- a/src/migrations/CLAUDE.md
+++ b/src/migrations/CLAUDE.md
@@ -1,0 +1,50 @@
+# src/migrations/
+
+> **Maintenance:** Keep this file in sync when adding new migrations.
+
+Migrations run automatically on CLI startup via `VersionMigrationManager`. They handle one-time setup tasks that can't be done at install time (e.g., global gitignore entries).
+
+## How Migrations Work
+
+1. State stored in `~/.config/iloom-ai/migration-state.json` → `lastMigratedVersion`
+2. On startup, `VersionMigrationManager` runs migrations where: `lastMigratedVersion < migration.version <= currentPackageVersion`
+3. After all migrations run, `lastMigratedVersion` is updated to the current package version
+
+## Versioning Convention
+
+A new migration's version should be **one patch version higher** than the current `package.json` version.
+
+Example: if `package.json` is at `0.13.1`, the next migration should be `0.13.2`.
+
+**Before creating a new migration**, check if an unreleased migration already exists at that version (`git tag` to confirm). If so, fold your logic into the existing migration rather than creating a duplicate.
+
+## Writing a Migration
+
+Migrations are defined in `index.ts` as objects in the `migrations` array:
+
+```typescript
+{
+  version: '0.13.2',
+  description: 'Brief description of what this migration does',
+  migrate: async () => {
+    // Migration logic here
+  }
+}
+```
+
+**Requirements:**
+- **Idempotent**: Safe to run multiple times. Check before modifying (e.g., check if gitignore entry already exists before adding).
+- **No user interaction**: Migrations run silently on startup.
+- **Fail gracefully**: Log warnings but don't crash the CLI.
+
+## Existing Migrations
+
+| Version | Description |
+|---------|-------------|
+| 0.6.1 | Global gitignore for `.iloom/settings.local.json` |
+| 0.7.1 | Global gitignore for `.iloom/package.iloom.local.json` |
+| 0.9.3 | Global gitignore for `.claude/agents/iloom-*`, `.claude/skills/iloom-*`, MCP config |
+| 0.10.3 | Remediate gitignore path (supports custom `core.excludesFile`) |
+| 0.13.1 | Global gitignore for `.env.local`, `.env.*.local` |
+
+Common pattern: most migrations use `ensureGlobalGitignorePatterns()` to add entries to the global gitignore, handling both XDG default and custom `core.excludesFile` paths.

--- a/src/types/CLAUDE.md
+++ b/src/types/CLAUDE.md
@@ -1,0 +1,26 @@
+# src/types/
+
+> **Maintenance:** Keep this file in sync with the directory contents. If you add a new type file or move key interfaces, update the table below.
+
+Type definitions organized by domain. When adding new types, put them in the file that matches their domain rather than dumping everything in `index.ts`.
+
+## Type Files by Domain
+
+| File | Domain | Key Types |
+|------|--------|-----------|
+| `index.ts` | Top-level command I/O | `StartResult`, `FinishResult`, `Workspace`, `Issue`, `PullRequest`, `Config`, `DatabaseProvider` interface |
+| `loom.ts` | Loom lifecycle | `Loom`, `CreateLoomInput`, `LaunchMode`, `ProjectCapability`, `LoomType` |
+| `worktree.ts` | Git worktree ops | `GitWorktree`, `WorktreeCreateOptions`, `WorktreeValidation`, `WorktreeStatus` |
+| `telemetry.ts` | Telemetry events | `TelemetryConfig`, `TelemetryEventMap`, per-event property interfaces (14 event types) |
+| `environment.ts` | .env management | `EnvVariable`, `EnvFileOptions`, `PortAssignmentOptions` |
+| `cleanup.ts` | Workspace teardown | `ResourceCleanupOptions`, `CleanupResult`, `SafetyCheck` |
+| `branch-naming.ts` | Branch generation | `BranchNameStrategy`, `BranchGenerationOptions` |
+| `github.ts` | GitHub API models | `GitHubIssue`, `GitHubPullRequest`, `GitHubProject`, `GitHubInputDetection` |
+| `linear.ts` | Linear API models | Linear-specific response types |
+| `process.ts` | Process management | Process detection and lifecycle types |
+
+## Conventions
+
+- **Error handling**: Exception-based. Do NOT add `Result<T, E>` wrapper types — functions either return successfully or throw.
+- **New telemetry events**: Define the property interface in `telemetry.ts` and add it to `TelemetryEventMap`.
+- **Provider interfaces**: `DatabaseProvider` is in `index.ts`. Issue tracker and VCS provider interfaces are in their respective service files in `src/lib/`.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,0 +1,66 @@
+# templates/
+
+> **Maintenance:** Keep this file in sync with the directory contents. If you add, remove, or change the responsibility of a template, update the relevant section below.
+
+This directory contains the template system that generates prompts and agent definitions for Claude Code sessions. Templates are rendered by `PromptTemplateManager` using Handlebars and copied to `dist/templates/` at build time.
+
+## Prompt Ownership Table
+
+Each prompt template belongs to exactly one execution context. Editing the wrong template is a common mistake — check this table first:
+
+| Template | Execution Context | Used By | Purpose |
+|----------|------------------|---------|---------|
+| `prompts/issue-prompt.txt` | Regular + Swarm child | `il spin` (single issue) | Main workflow: phase agents execute analysis → planning → implementation → review |
+| `prompts/swarm-orchestrator-prompt.txt` | Swarm orchestrator only | `il spin` (epic) | 5-phase orchestration: parse children, spawn workers, monitor, merge, finalize |
+| `prompts/plan-prompt.txt` | Plan mode only | `il plan` | Architect agent: decompose work into issues, no implementation |
+| `prompts/pr-prompt.txt` | Regular (PR workflow) | `il spin` (PR) | PR-specific instructions for reviewing and implementing PR feedback |
+| `prompts/regular-prompt.txt` | Regular (branch workflow) | `il spin` (branch) | Ad-hoc branch work without an issue |
+| `prompts/init-prompt.txt` | Setup | `il init` | First-run project configuration |
+| `prompts/session-summary-prompt.txt` | Regular (finish) | `il finish` | Generate session recap on loom completion |
+| `prompts/epic-report-prompt.txt` | Swarm (post-completion) | Orchestrator | Epic completion report after all children finish |
+
+## Handlebars Conventions
+
+- **Variables**: `{{VARIABLE_NAME}}` — uppercase with underscores, defined in `TemplateVariables` interface
+- **Conditionals**: `{{#if FLAG_NAME}}...{{/if}}` and `{{#unless FLAG_NAME}}...{{/unless}}`
+- **Raw blocks**: `{{{{raw}}}}{{VARIABLE}}{{{{/raw}}}}` — for JSON content that contains literal braces
+- **Variable source**: `PromptTemplateManager.renderTemplate()` accepts a `TemplateVariables` object with 100+ fields. Check the interface definition before adding new variables.
+
+## Swarm Mode in issue-prompt.txt
+
+`issue-prompt.txt` serves double duty — it's used for both regular single-issue work and swarm child workers. The `SWARM_MODE` flag controls the differences:
+
+- **`SWARM_MODE=false` (regular)**: Full interactive workflow, optional user checkpoints, recap writes to loom's recap file
+- **`SWARM_MODE=true` (swarm child)**: Fully autonomous, no user interaction, MUST pass `worktreePath` on all recap calls, single comment output at end, reports success/failure back to orchestrator
+
+## Agent Workflow Todo Lists
+
+The todo list in `prompts/issue-prompt.txt` is critical for ensuring agents follow the implementation plan correctly.
+
+**Why the Todo List Matters:**
+- Agents use the todo list as both a progress tracker and an execution checklist
+- Each numbered item represents a workflow step that must be completed
+- Agents check off items as they complete each step, providing visibility into progress
+- The todo list serves as the source of truth for what steps need to be executed
+
+**When Adding New Workflow Steps:**
+- New workflow steps MUST be added to the todo list to ensure they are executed
+- Position the item appropriately based on when it should run in the workflow
+- Use Handlebars conditionals (e.g., `{{#if FLAG_NAME}}`) when steps are conditional
+- Ensure numbering remains sequential within each conditional branch
+
+**Example — Adding a Conditional Step:**
+```handlebars
+{{#if SOME_MODE}}
+{{#if SOME_FLAG}}
+17. Execute conditional step (STEP X.X)
+18. Next step...
+{{else}}
+17. Next step...
+{{/if}}
+{{else}}
+17. Next step...
+{{/if}}
+```
+
+Without the todo list entry, agents may skip steps even if they are fully documented elsewhere in the prompt.

--- a/templates/agents/CLAUDE.md
+++ b/templates/agents/CLAUDE.md
@@ -1,0 +1,68 @@
+# templates/agents/
+
+> **Maintenance:** Keep this file in sync with the directory contents. If you add, remove, or change an agent's role, update the relevant section below.
+
+This directory contains phase agent definitions as Markdown files with YAML frontmatter. They are loaded by `AgentManager`, rendered to `.claude/agents/` in worktrees, and invoked as skills during workflows.
+
+## Phase Agent Lifecycle
+
+Agents execute in a fixed sequence during issue workflows. Each phase has a single responsibility:
+
+```
+complexity-evaluator → analyzer (or analyze-and-plan for SIMPLE) → planner → implementer → code-reviewer
+```
+
+- **SIMPLE tasks** (< 5 files, < 200 LOC): Use `analyze-and-plan` which combines analysis + planning into one step, then `implementer`
+- **COMPLEX tasks**: Full pipeline: `analyzer` → `planner` → `implementer`
+- **Code review**: `code-reviewer` runs after implementation (swarm mode only; in regular mode, review is optional)
+- **Wave verification**: `wave-verifier` is an epic-level agent that verifies a wave of completed children
+
+## Agent Files
+
+| Agent | Phase | Model | Used In | Responsibility |
+|-------|-------|-------|---------|---------------|
+| `iloom-issue-complexity-evaluator.md` | Triage | haiku | Regular + Swarm | Classify task as SIMPLE or COMPLEX |
+| `iloom-issue-analyzer.md` | Analysis | opus | Regular + Swarm | Deep research for COMPLEX tasks |
+| `iloom-issue-analyze-and-plan.md` | Analysis + Planning | opus | Regular + Swarm | Combined phase for SIMPLE tasks |
+| `iloom-issue-planner.md` | Planning | opus | Regular + Swarm | Detailed implementation plan (COMPLEX only) |
+| `iloom-issue-implementer.md` | Implementation | opus | Regular + Swarm | Execute the plan, run typecheck/lint/tests |
+| `iloom-code-reviewer.md` | Review | opus | Swarm | Autonomous code review, no human gates |
+| `iloom-issue-enhancer.md` | Enhancement | — | Regular | Enhance issue descriptions with context |
+| `iloom-wave-verifier.md` | Verification | — | Swarm (epic) | Verify a wave of completed children |
+| `iloom-framework-detector.md` | Setup | — | Regular | Detect project frameworks/capabilities |
+| `iloom-artifact-reviewer.md` | Review | — | Regular | Review generated artifacts |
+
+## YAML Frontmatter Format
+
+```yaml
+---
+name: iloom-issue-implementer
+description: One-line description of this agent's role
+model: opus          # Default model (can be overridden by settings)
+color: green         # Optional: terminal color for status display
+tools:               # Optional: restrict available tools
+  - Read
+  - Edit
+  - Bash
+---
+
+Agent prompt content in Markdown...
+```
+
+## Model Override Rules
+
+Agent models resolve in this order (highest priority first):
+1. **CLI flag**: `--set agents.iloom-issue-implementer.model=sonnet`
+2. **Settings**: `settings.agents["iloom-issue-implementer"].model`
+3. **Swarm model defaults**: `SwarmSetupService` applies swarm-specific defaults (e.g., haiku for complexity evaluator)
+4. **Frontmatter**: The `model` field in the YAML above
+
+Do NOT hardcode model choices in agent templates to work around performance issues — use the settings system instead.
+
+## Swarm Agent Rendering
+
+In swarm mode, `SwarmSetupService.renderSwarmAgents()` copies these templates to the epic worktree as:
+- `.claude/agents/iloom-swarm-<phase>.md` (agent definitions)
+- `.claude/skills/iloom-swarm-<phase>/SKILL.md` (skill wrappers that invoke agents)
+
+The swarm worker agent (`iloom-swarm-worker.md`) is rendered separately and invokes these skills in sequence.


### PR DESCRIPTION
## Summary

- Replace outdated Architecture Overview in root CLAUDE.md (bash migration map, incomplete module structure) with a concise mental model covering 3 execution contexts (regular, swarm, plan) and orchestrator/child boundary rules
- Add 7 subdirectory CLAUDE.md files that load contextually when agents access files in that directory:
  - `templates/CLAUDE.md` — prompt ownership table, Handlebars conventions, todo list rules
  - `templates/agents/CLAUDE.md` — phase agent lifecycle, YAML frontmatter, model override resolution
  - `src/commands/CLAUDE.md` — full command reference with aliases, delegation targets, key flags
  - `src/lib/CLAUDE.md` — service responsibilities, orchestrator/child boundary rules, provider patterns
  - `src/mcp/CLAUDE.md` — MCP server tools, routing rules, recap worktreePath gotcha
  - `src/types/CLAUDE.md` — type files by domain, conventions
  - `src/migrations/CLAUDE.md` — versioning convention, migration writing guide
- Add maintenance rule to Documentation Requirements for keeping subdirectory CLAUDE.md files in sync

**Motivation:** Agents developing iloom were confusing the orchestrator with child agents, hallucinating capabilities, and targeting the wrong components — because the architecture docs were outdated and lacked the component model. Hierarchical CLAUDE.md files solve this by loading context exactly when needed.

## Test plan

- [ ] Verify root CLAUDE.md is coherent and all section references resolve
- [ ] Verify each subdirectory CLAUDE.md accurately reflects its directory contents
- [ ] Spot-check that Claude Code loads subdirectory CLAUDE.md when accessing files in that directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)