### PR TITLE
fix: draft PR body missing issue context at creation time

### DIFF
--- a/src/lib/LoomManager.test.ts
+++ b/src/lib/LoomManager.test.ts
@@ -699,6 +699,11 @@ describe('LoomManager', testOptions, () => {
         expectedPath // worktree path
       )
 
+      // Verify issue title and body are included in the PR body
+      const prBodyArg = mockCreateDraftPR.mock.calls[0][2] as string
+      expect(prBodyArg).toContain('Test Linear Issue')
+      expect(prBodyArg).toContain('Test description')
+
       // Verify draft PR number was stored in metadata
       expect(mockWriteMetadata).toHaveBeenCalledWith(
         expectedPath,
@@ -913,6 +918,79 @@ describe('LoomManager', testOptions, () => {
         'feature/parent-branch', // base branch should be parent's branch
         expectedPath // worktree path
       )
+
+      // Verify issue title and body are included in the PR body
+      const prBodyArg = mockCreateDraftPR.mock.calls[0][2] as string
+      expect(prBodyArg).toContain('Child Issue')
+      expect(prBodyArg).toContain('Child description')
+    })
+
+    it('should handle empty issue body gracefully in draft-pr mode', async () => {
+      mockCreateDraftPR.mockResolvedValue({ number: 99, url: 'https://github.com/owner/repo/pull/99' })
+      mockCheckForExistingPR.mockResolvedValue(null)
+
+      vi.mocked(mockSettings.loadSettings).mockResolvedValue({
+        mainBranch: 'main',
+        worktreeDir: '/test/worktrees',
+        mergeBehavior: { mode: 'draft-pr' },
+      })
+
+      vi.mocked(mockGitHub.fetchIssue).mockResolvedValue({
+        number: 123,
+        title: 'Issue With No Body',
+        body: '',
+        state: 'open',
+        labels: [],
+        assignees: [],
+        url: 'https://github.com/owner/repo/issues/123',
+      })
+
+      const expectedPath = '/test/worktree-issue-123'
+      vi.mocked(mockGitWorktree.generateWorktreePath).mockReturnValue(expectedPath)
+      vi.mocked(mockGitWorktree.createWorktree).mockResolvedValue(expectedPath)
+      vi.mocked(mockEnvironment.calculatePort).mockReturnValue(3123)
+
+      await manager.createIloom(baseInput)
+
+      const prBodyArg = mockCreateDraftPR.mock.calls[0][2] as string
+      expect(prBodyArg).toContain('Fixes #123')
+      expect(prBodyArg).toContain('Issue With No Body')
+      expect(prBodyArg).not.toContain('<details>')
+    })
+
+    it('should include issue body in collapsible details in draft-pr mode', async () => {
+      mockCreateDraftPR.mockResolvedValue({ number: 99, url: 'https://github.com/owner/repo/pull/99' })
+      mockCheckForExistingPR.mockResolvedValue(null)
+
+      vi.mocked(mockSettings.loadSettings).mockResolvedValue({
+        mainBranch: 'main',
+        worktreeDir: '/test/worktrees',
+        mergeBehavior: { mode: 'draft-pr' },
+      })
+
+      vi.mocked(mockGitHub.fetchIssue).mockResolvedValue({
+        number: 123,
+        title: 'Issue With Body',
+        body: '## Problem\n\nSomething is broken.',
+        state: 'open',
+        labels: [],
+        assignees: [],
+        url: 'https://github.com/owner/repo/issues/123',
+      })
+
+      const expectedPath = '/test/worktree-issue-123'
+      vi.mocked(mockGitWorktree.generateWorktreePath).mockReturnValue(expectedPath)
+      vi.mocked(mockGitWorktree.createWorktree).mockResolvedValue(expectedPath)
+      vi.mocked(mockEnvironment.calculatePort).mockReturnValue(3123)
+
+      await manager.createIloom(baseInput)
+
+      const prBodyArg = mockCreateDraftPR.mock.calls[0][2] as string
+      expect(prBodyArg).toContain('Fixes #123')
+      expect(prBodyArg).toContain('<details>')
+      expect(prBodyArg).toContain('Issue With Body')
+      expect(prBodyArg).toContain('Something is broken.')
+      expect(prBodyArg).toContain('iloom')
     })
 
     it('should reuse existing PR instead of creating new one in draft-pr mode', async () => {

--- a/src/lib/LoomManager.ts
+++ b/src/lib/LoomManager.ts
@@ -290,8 +290,37 @@ export class LoomManager {
           const prTitle = issueData?.title ?? `Work on ${branchName}`
           let prBody: string
           if (input.type === 'issue' || input.type === 'epic') {
-            const issueBody = issueData?.body ? `\n\n## ${issueData.title}\n\n${issueData.body}` : ''
-            prBody = `Fixes ${prManager.issuePrefix}${input.identifier}${issueBody}\n\n---\n*This PR was created automatically by iloom.*`
+            const issueRef = `Fixes ${prManager.issuePrefix}${input.identifier}`
+            const issueBodyContent = issueData?.body?.trim()
+
+            const issueTitle = issueData?.title ?? `Issue ${input.identifier}`
+
+            if (issueBodyContent) {
+              prBody = [
+                issueRef,
+                '',
+                `## ${issueTitle}`,
+                '',
+                '<details>',
+                '<summary>Issue details</summary>',
+                '',
+                issueBodyContent,
+                '',
+                '</details>',
+                '',
+                '---',
+                '*This PR was created automatically by iloom.*',
+              ].join('\n')
+            } else {
+              prBody = [
+                issueRef,
+                '',
+                `## ${issueTitle}`,
+                '',
+                '---',
+                '*This PR was created automatically by iloom.*',
+              ].join('\n')
+            }
           } else {
             prBody = `Branch: ${branchName}\n\n---\n*This PR was created automatically by iloom.*`
           }


### PR DESCRIPTION
Fixes #953

## Draft PR body is generic/useless — should include issue context

## Problem

When creating a draft PR in `draft-pr` mode during `il start`, the PR body is generic and unhelpful:

> Fixes #948
>
> ---
> *This PR was created automatically by iloom.*

The code at `src/lib/LoomManager.ts:292-294` does attempt to include the issue body:

```typescript
const issueBody = issueData?.body ? `\n\n## ${issueData.title}\n\n${issueData.body}` : ''
prBody = `Fixes ${prManager.issuePrefix}${input.identifier}${issueBody}\n\n---\n*This PR was created automatically by iloom.*`
```

But there are two issues:

1. **Possible regression**: The issue body may not be getting populated at fetch time, resulting in the empty-body fallback (just `Fixes #N`).
2. **Even when working, the content is low-value**: Dumping raw issue text into a PR body isn't very useful. By the time a draft PR is created, we have the issue context — we could generate a more meaningful initial description.

## Investigation needed

- Confirm whether `fetchIssueData()` is returning the body correctly at draft PR creation time
- If it is, determine why the body isn't appearing in the PR
- If it isn't, fix the data fetching

## Location

- `src/lib/LoomManager.ts` lines 286-297 — draft PR body generation
- `src/lib/LoomManager.ts` line 92 — `fetchIssueData()` call
- `src/lib/LoomManager.ts` lines 618-637 — `fetchIssueData()` implementation

---
*This PR was created automatically by iloom.*