### PR TITLE
fix(dev-server): wire up TUI restart key handler

### DIFF
--- a/src/commands/dev-server.ts
+++ b/src/commands/dev-server.ts
@@ -1,10 +1,12 @@
 import path from 'path'
+import { execa } from 'execa'
 import { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
 import { MetadataManager } from '../lib/MetadataManager.js'
 import { ProjectCapabilityDetector } from '../lib/ProjectCapabilityDetector.js'
 import { DevServerManager } from '../lib/DevServerManager.js'
 import { DevServerTUI } from '../lib/DevServerTUI.js'
 import { DockerManager } from '../lib/DockerManager.js'
+import { ProcessManager } from '../lib/process/ProcessManager.js'
 import { SettingsManager } from '../lib/SettingsManager.js'
 import { IdentifierParser } from '../utils/IdentifierParser.js'
 import { loadWorkspaceEnv, isNoEnvFilesFoundError } from '../utils/env.js'
@@ -194,6 +196,7 @@ export class DevServerCommand {
 		const useTui = !input.json && process.stdout.isTTY === true && process.stdin.isTTY === true
 
 		let tui: DevServerTUI | undefined
+		let restartRequested = false
 
 		if (useTui) {
 			tui = new DevServerTUI({
@@ -204,6 +207,26 @@ export class DevServerCommand {
 					// Send SIGINT to self to trigger normal cleanup flow
 					process.kill(process.pid, 'SIGINT')
 				},
+				onRestart: (): void => {
+					restartRequested = true
+					tui?.updateStatus('Restarting')
+
+					if (dockerConfig) {
+						// Docker: stop the container to trigger exit from runServerForeground
+						const containerName = DockerManager.buildContainerName(
+							dockerConfig.identifier ?? ''
+						)
+						void execa('docker', ['stop', containerName], { reject: false })
+					} else {
+						// Native: find and terminate the process on the port
+						const processManager = new ProcessManager()
+						void processManager.detectDevServer(port).then((processInfo) => {
+							if (processInfo?.pid) {
+								process.kill(processInfo.pid, 'SIGTERM')
+							}
+						})
+					}
+				},
 			})
 			tui.start()
 		}
@@ -213,27 +236,36 @@ export class DevServerCommand {
 			: undefined
 
 		try {
-			// This will block until user stops the server (Ctrl+C)
-			// In JSON mode, redirect npm output to stderr so JSON can go to stdout
-			const processInfo = await this.devServerManager.runServerForeground(
-				worktree.path,
-				port,
-				!!input.json,
-				// Callback called immediately when process starts (for JSON output)
-				(pid) => {
-					if (input.json && pid) {
-						finalResult.pid = pid
-						this.outputJson(finalResult)
-					}
-				},
-				envOverrides,
-				dockerConfig,
-				onOutput
-			)
+			do {
+				restartRequested = false
 
-			if (processInfo.pid) {
-				finalResult.pid = processInfo.pid
-			}
+				// This will block until user stops the server (Ctrl+C)
+				// In JSON mode, redirect npm output to stderr so JSON can go to stdout
+				const processInfo = await this.devServerManager.runServerForeground(
+					worktree.path,
+					port,
+					!!input.json,
+					// Callback called immediately when process starts (for JSON output)
+					(pid) => {
+						if (input.json && pid) {
+							finalResult.pid = pid
+							this.outputJson(finalResult)
+						}
+					},
+					envOverrides,
+					dockerConfig,
+					onOutput
+				)
+
+				if (processInfo.pid) {
+					finalResult.pid = processInfo.pid
+				}
+
+				if (restartRequested) {
+					logger.info('Restarting dev server...')
+					tui?.updateStatus('Running')
+				}
+			} while (restartRequested)
 		} finally {
 			if (tui) {
 				tui.cleanup()


### PR DESCRIPTION
## Summary
- The `[r] Restart` key was displayed in the dev-server TUI status bar but pressing it did nothing
- Root cause: `onRestart` callback was never passed to `DevServerTUI` — only `onQuit` was wired up
- Wires up `onRestart` to stop the current Docker container (`docker stop`) or native process (`SIGTERM`), then re-runs the server in a `do...while` loop

## Test plan
- [ ] Run `il dev` with Docker mode, press `r` — container should restart
- [ ] Run `il dev` in native mode, press `r` — process should restart
- [ ] Verify `q` and `o` keys still work as before
- [ ] Verify Ctrl+C still exits cleanly