### PR TITLE
fix(list): detect capabilities at runtime for main worktree

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { VCSProviderFactory } from './lib/VCSProviderFactory.js'
 import { IssueEnhancementService } from './lib/IssueEnhancementService.js'
 import { AgentManager } from './lib/AgentManager.js'
 import { GitHubService } from './lib/GitHubService.js'
+import { ProjectCapabilityDetector } from './lib/ProjectCapabilityDetector.js'
 import { MetadataManager, type LoomMetadata } from './lib/MetadataManager.js'
 import { StartCommand } from './commands/start.js'
 import { AddIssueCommand } from './commands/add-issue.js'
@@ -1293,6 +1294,19 @@ program
               status: 'active' as const,
               finishedAt: null,
             }))
+
+            // Detect capabilities at runtime for worktrees without metadata (e.g., main worktree)
+            const capabilityDetector = new ProjectCapabilityDetector()
+            for (const loom of activeJson) {
+              if ((!loom.capabilities || loom.capabilities.length === 0) && loom.worktreePath) {
+                try {
+                  const { capabilities } = await capabilityDetector.detectCapabilities(loom.worktreePath)
+                  loom.capabilities = capabilities
+                } catch {
+                  // Non-fatal: leave capabilities empty if detection fails
+                }
+              }
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- `il list --json` returned empty capabilities for the main worktree because it reads from loom metadata, but the main worktree has no metadata (never created via `il start`)
- Now detects capabilities at runtime via `ProjectCapabilityDetector` for any worktree with empty/missing capabilities
- Uses the same detection logic as `il dev-server`

## Test plan
- [x] `il list --json` in a web project shows `["web"]` for the main worktree
- [x] Build passes
- [x] Pre-commit hooks pass (lint, compile, test)