### PR TITLE
fix(auth): remove CLAUDE_CODE_SIMPLE env var that breaks OAuth auth

### DIFF
--- a/src/lib/CommitManager.test.ts
+++ b/src/lib/CommitManager.test.ts
@@ -637,20 +637,6 @@ describe('CommitManager', () => {
       )
     })
 
-    it('should pass CLAUDE_CODE_SIMPLE env var for minimal mode', async () => {
-      vi.mocked(claude.launchClaude).mockResolvedValue('Add feature')
-      vi.mocked(git.executeGitCommand).mockResolvedValue('')
-
-      await manager.commitChanges(mockWorktreePath, { issuePrefix: '#', dryRun: false })
-
-      const claudeCall = vi.mocked(claude.launchClaude).mock.calls[0]
-      expect(claudeCall[1]).toEqual(
-        expect.objectContaining({
-          env: { CLAUDE_CODE_SIMPLE: '1' },
-        })
-      )
-    })
-
     it('should use structured XML prompt format', async () => {
       vi.mocked(claude.launchClaude).mockResolvedValue('Add feature')
       vi.mocked(git.executeGitCommand).mockResolvedValue('')

--- a/src/lib/CommitManager.ts
+++ b/src/lib/CommitManager.ts
@@ -344,7 +344,6 @@ export class CommitManager {
         timeout: 120000, // 120 second timeout
         appendSystemPrompt: 'Output only the requested content. Never include preamble, analysis, or meta-commentary. Your response is used verbatim.',
         noSessionPersistence: true, // Utility operation - don't persist session
-        env: { CLAUDE_CODE_SIMPLE: '1' }, // Minimal mode - no MCP, hooks, or CLAUDE.md loading
       }
       getLogger().debug('Claude CLI call parameters:', {
         options: claudeOptions,

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -2329,7 +2329,7 @@ describe('claude utils', () => {
 				['-p', '--output-format', 'stream-json', '--verbose', '--model', 'haiku', '--add-dir', '/tmp', '--no-session-persistence'],
 				expect.objectContaining({
 					input: expect.stringContaining(issueTitle),
-					env: expect.objectContaining({ CLAUDE_CODE_SIMPLE: '1' }),
+					env: expect.objectContaining({ CLAUDECODE: '0' }),
 				})
 			)
 		})

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -649,7 +649,6 @@ Generate a git branch name for the following issue:
 			model,
 			headless: true,
 			noSessionPersistence: true, // Utility operation - don't persist session
-			env: { CLAUDE_CODE_SIMPLE: '1' }, // Minimal mode - no MCP, hooks, or CLAUDE.md loading
 		})) as string
 
 		// Normalize to lowercase for consistency (Linear IDs are uppercase but branches should be lowercase)


### PR DESCRIPTION
## Summary
- `CLAUDE_CODE_SIMPLE=1` env var was being passed to `claude -p` invocations for commit message and branch name generation
- This env var disables OAuth credential lookup in Claude CLI, causing "Not logged in" errors when no `ANTHROPIC_API_KEY` is set
- Removes the env var from both `CommitManager.ts` and `claude.ts` (branch name generation), and removes the associated test