### PR TITLE
Implment --bare flag on branch naming and commit message generation claude cli invocations

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1758,7 +1758,7 @@ program
 
 // Test command for GitHub integration
 program
-  .command('test-github')
+  .command('test-github', { hidden: true })
   .description('Test GitHub integration (Issue #3)')
   .argument('<identifier>', 'Issue number or PR number')
   .option('--no-claude', 'Skip Claude for branch name generation')
@@ -1844,7 +1844,7 @@ program
 
 // Test command for Claude integration
 program
-  .command('test-claude')
+  .command('test-claude', { hidden: true })
   .description('Test Claude integration (Issue #10)')
   .option('--detect', 'Test Claude CLI detection')
   .option('--version', 'Get Claude CLI version')
@@ -2032,7 +2032,7 @@ program
 
 // Test command for webserver detection
 program
-  .command('test-webserver')
+  .command('test-webserver', { hidden: true })
   .description('Test if a web server is running on a workspace port')
   .argument('<issue-number>', 'Issue number (port will be calculated as 3000 + issue number)', parseInt)
   .option('--kill', 'Kill the web server if detected')
@@ -2052,7 +2052,7 @@ program
 
 // Test command for Git integration
 program
-  .command('test-git')
+  .command('test-git', { hidden: true })
   .description('Test Git integration - findMainWorktreePath() function (reads .iloom/settings.json)')
   .action(async () => {
     try {
@@ -2070,7 +2070,7 @@ program
 
 // Test command for iTerm2 dual tab functionality
 program
-  .command('test-tabs')
+  .command('test-tabs', { hidden: true })
   .description('Test iTerm2 dual tab functionality - opens two tabs with test commands')
   .action(async () => {
     try {
@@ -2088,7 +2088,7 @@ program
 
 // Test command for worktree prefix configuration
 program
-  .command('test-prefix')
+  .command('test-prefix', { hidden: true })
   .description('[DEPRECATED] Test worktree prefix configuration - preview worktree paths')
   .action(async () => {
     try {
@@ -2097,6 +2097,44 @@ program
       await command.execute()
     } catch (error) {
       logger.error(`Test prefix failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      if (error instanceof Error && error.stack) {
+        logger.debug(error.stack)
+      }
+      process.exit(1)
+    }
+  })
+
+// Test command for bare mode branch name generation
+program
+  .command('test-branch-name', { hidden: true })
+  .description('Test bare mode branch name generation')
+  .option('--title <text>', 'Issue title to use for branch name generation')
+  .option('--description <text>', 'Issue description for additional context')
+  .action(async (options: { title?: string; description?: string }) => {
+    try {
+      const { TestBranchNameCommand } = await import('./commands/test-branch-name.js')
+      const command = new TestBranchNameCommand()
+      await command.execute(options)
+    } catch (error) {
+      logger.error(`Test branch name failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      if (error instanceof Error && error.stack) {
+        logger.debug(error.stack)
+      }
+      process.exit(1)
+    }
+  })
+
+// Test command for bare mode commit message generation
+program
+  .command('test-commit-msg', { hidden: true })
+  .description('Test bare mode commit message generation')
+  .action(async () => {
+    try {
+      const { TestCommitMsgCommand } = await import('./commands/test-commit-msg.js')
+      const command = new TestCommitMsgCommand()
+      await command.execute()
+    } catch (error) {
+      logger.error(`Test commit msg failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
       if (error instanceof Error && error.stack) {
         logger.debug(error.stack)
       }
@@ -2191,7 +2229,7 @@ program
 
 // Test command for Jira integration (hidden from help output)
 const testJiraCommand = program
-  .command('test-jira')
+  .command('test-jira', { hidden: true })
   .description('Test Jira integration methods against a real Jira instance')
 
 testJiraCommand
@@ -2268,7 +2306,7 @@ testJiraCommand
 
 // Test command for Neon integration
 program
-  .command('test-neon')
+  .command('test-neon', { hidden: true })
   .description('Test Neon integration and debug configuration')
   .action(async () => {
     try {

--- a/src/commands/test-branch-name.ts
+++ b/src/commands/test-branch-name.ts
@@ -1,0 +1,39 @@
+import { logger } from '../utils/logger.js'
+import { resolveBareModeConfig, generateBranchName } from '../utils/claude.js'
+
+/**
+ * Test command to demonstrate bare mode branch name generation.
+ * Shows whether bare mode is available and generates a sample branch name.
+ */
+export class TestBranchNameCommand {
+  public async execute(options: { title?: string; description?: string }): Promise<void> {
+    const title = options.title ?? 'Add dark mode support to settings page'
+    const description = options.description ?? 'Users have requested a dark mode toggle in the settings page that persists across sessions.'
+
+    logger.info('Testing Branch Name Generation (Bare Mode)\n')
+
+    // Show bare mode resolution
+    logger.info('Resolving bare mode configuration...')
+    const config = await resolveBareModeConfig()
+
+    if (config.bare && config.oauthToken) {
+      logger.success('Using bare mode with OAuth token')
+    } else if (config.bare) {
+      logger.success('Using bare mode with API key')
+    } else {
+      logger.warn('Using standard mode (no bare)')
+    }
+
+    logger.info('')
+    logger.info(`Title: ${title}`)
+    logger.info(`Description: ${description}`)
+    logger.info('Generating branch name...\n')
+
+    const startTime = Date.now()
+    const branchName = await generateBranchName(title, '999')
+    const duration = Date.now() - startTime
+
+    logger.success(`Branch name: ${branchName}`)
+    logger.info(`Duration: ${duration}ms`)
+  }
+}

--- a/src/commands/test-commit-msg.ts
+++ b/src/commands/test-commit-msg.ts
@@ -1,0 +1,49 @@
+import { logger } from '../utils/logger.js'
+import { resolveBareModeConfig } from '../utils/claude.js'
+import { CommitManager } from '../lib/CommitManager.js'
+
+/**
+ * Test command to demonstrate bare mode commit message generation.
+ * Uses the real CommitManager code path to generate a commit message.
+ */
+export class TestCommitMsgCommand {
+  public async execute(): Promise<void> {
+    logger.info('Testing Commit Message Generation (Bare Mode)\n')
+
+    // Show bare mode resolution
+    logger.info('Resolving bare mode configuration...')
+    const config = await resolveBareModeConfig()
+
+    if (config.bare && config.oauthToken) {
+      logger.success('Using bare mode with OAuth token')
+    } else if (config.bare) {
+      logger.success('Using bare mode with API key')
+    } else {
+      logger.warn('Using standard mode (no bare)')
+    }
+
+    logger.info('')
+    logger.info('Generating commit message via CommitManager...\n')
+
+    const commitManager = new CommitManager()
+    const worktreePath = process.cwd()
+
+    const startTime = Date.now()
+    const result = await commitManager.generateClaudeCommitMessage(
+      worktreePath,
+      undefined,
+      '#'
+    )
+    const duration = Date.now() - startTime
+
+    if (result) {
+      logger.info('Generated commit message:')
+      logger.info('---')
+      logger.info(result)
+      logger.info('---')
+    } else {
+      logger.warn('No commit message generated (Claude unavailable or failed)')
+    }
+    logger.success(`\nDuration: ${duration}ms`)
+  }
+}

--- a/src/lib/CommitManager.test.ts
+++ b/src/lib/CommitManager.test.ts
@@ -728,6 +728,34 @@ describe('CommitManager', () => {
     })
   })
 
+  describe('Claude Integration - Bare Mode (auto-applied by launchClaude)', () => {
+    beforeEach(() => {
+      vi.mocked(claude.detectClaudeCli).mockResolvedValue(true)
+      vi.mocked(claude.launchClaude).mockResolvedValue('Add feature')
+      vi.mocked(git.executeGitCommand).mockResolvedValue('')
+    })
+
+    it('should not pass bare option to launchClaude (bare mode is now auto-applied internally)', async () => {
+      await manager.commitChanges(mockWorktreePath, { issuePrefix: '#', dryRun: false })
+
+      const claudeCall = vi.mocked(claude.launchClaude).mock.calls[0]
+      // CommitManager no longer sets bare - launchClaude auto-applies it when headless + noSessionPersistence
+      expect(claudeCall[1]).not.toHaveProperty('bare')
+    })
+
+    it('should pass headless and noSessionPersistence so launchClaude can auto-apply bare', async () => {
+      await manager.commitChanges(mockWorktreePath, { issuePrefix: '#', dryRun: false })
+
+      const claudeCall = vi.mocked(claude.launchClaude).mock.calls[0]
+      expect(claudeCall[1]).toEqual(
+        expect.objectContaining({
+          headless: true,
+          noSessionPersistence: true,
+        })
+      )
+    })
+  })
+
   describe('Claude Output Acceptance', () => {
     beforeEach(() => {
       vi.mocked(claude.detectClaudeCli).mockResolvedValue(true)

--- a/src/lib/CommitManager.test.ts
+++ b/src/lib/CommitManager.test.ts
@@ -595,18 +595,17 @@ describe('CommitManager', () => {
       expect(commitCall?.[0][3]).not.toContain('Fixes #ENG-456')
     })
 
-    it('should pass worktree path to Claude via addDir option', async () => {
+    it('should embed staged diff in prompt instead of using addDir', async () => {
       vi.mocked(claude.launchClaude).mockResolvedValue('Add feature')
-      vi.mocked(git.executeGitCommand).mockResolvedValue('')
+      vi.mocked(git.executeGitCommand).mockResolvedValue('diff output here')
 
       await manager.commitChanges(mockWorktreePath, { issuePrefix: '#', dryRun: false })
 
       const claudeCall = vi.mocked(claude.launchClaude).mock.calls[0]
-      expect(claudeCall[1]).toEqual(
-        expect.objectContaining({
-          addDir: mockWorktreePath,
-        })
-      )
+      // addDir should NOT be set — diff is embedded in the prompt
+      expect(claudeCall[1]).not.toHaveProperty('addDir')
+      // Prompt should contain the diff
+      expect(claudeCall[0]).toContain('StagedChanges')
     })
 
     it('should use headless mode for Claude execution', async () => {

--- a/src/lib/CommitManager.ts
+++ b/src/lib/CommitManager.ts
@@ -343,7 +343,7 @@ export class CommitManager {
         model: 'claude-haiku-4-5-20251001', // Fast, cost-effective model
         timeout: 120000, // 120 second timeout
         appendSystemPrompt: 'Output only the requested content. Never include preamble, analysis, or meta-commentary. Your response is used verbatim.',
-        noSessionPersistence: true, // Utility operation - don't persist session
+        noSessionPersistence: true, // Utility operation - bare mode auto-applied by launchClaude
       }
       getLogger().debug('Claude CLI call parameters:', {
         options: claudeOptions,

--- a/src/lib/CommitManager.ts
+++ b/src/lib/CommitManager.ts
@@ -296,7 +296,7 @@ export class CommitManager {
    * Claude examines the git repository directly via --add-dir option
    * Returns null if Claude unavailable or fails validation
    */
-  private async generateClaudeCommitMessage(
+  public async generateClaudeCommitMessage(
     worktreePath: string,
     issueNumber: string | number | undefined,
     issuePrefix: string,
@@ -342,7 +342,7 @@ export class CommitManager {
         addDir: worktreePath,
         model: 'claude-haiku-4-5-20251001', // Fast, cost-effective model
         timeout: 120000, // 120 second timeout
-        appendSystemPrompt: 'Output only the requested content. Never include preamble, analysis, or meta-commentary. Your response is used verbatim.',
+        systemPrompt: 'You are a software engineer writing a git commit message. Examine the staged changes in the git repository and generate a concise, meaningful commit message. Use imperative mood. Keep subject line under 72 characters. Your entire response will be used directly as the git commit message — output ONLY the raw commit message with no explanatory text, analysis, or meta-commentary.',
         noSessionPersistence: true, // Utility operation - bare mode auto-applied by launchClaude
       }
       getLogger().debug('Claude CLI call parameters:', {
@@ -448,7 +448,6 @@ ${trailer === 'Fixes' ? 'If the changes appear to resolve the issue, include' : 
 
     const examplePrefix = issuePrefix || ''  // Use empty string for Linear examples
     return `<Task>
-You are a software engineer writing a commit message for this repository.
 Examine the staged changes in the git repository and generate a concise, meaningful commit message.
 </Task>
 

--- a/src/lib/CommitManager.ts
+++ b/src/lib/CommitManager.ts
@@ -322,9 +322,28 @@ export class CommitManager {
     }
     getLogger().debug('Claude CLI is available')
 
-    // Build XML-based structured prompt
+    // Fetch the staged diff upfront so Claude doesn't need to use tools
+    getLogger().debug('Fetching staged diff...')
+    let stagedDiff: string
+    let stagedStat: string
+    try {
+      const statResult = await executeGitCommand(['diff', '--staged', '--stat'], { cwd: worktreePath })
+      stagedStat = statResult.trim()
+      const diffResult = await executeGitCommand(['diff', '--staged'], { cwd: worktreePath })
+      // Truncate large diffs to avoid token limits
+      const maxDiffLength = 50000
+      stagedDiff = diffResult.length > maxDiffLength
+        ? diffResult.substring(0, maxDiffLength) + '\n\n... [diff truncated, showing first 50KB]'
+        : diffResult
+    } catch {
+      getLogger().warn('Failed to fetch staged diff, falling back to Claude tool use')
+      stagedDiff = ''
+      stagedStat = ''
+    }
+
+    // Build XML-based structured prompt with embedded diff
     getLogger().debug('Building commit message prompt...')
-    const prompt = this.buildCommitMessagePrompt(issueNumber, issuePrefix, trailerType)
+    const prompt = this.buildCommitMessagePrompt(issueNumber, issuePrefix, trailerType, stagedStat, stagedDiff)
     getLogger().debug('Prompt built', { promptLength: prompt.length })
 
     // Debug log the actual prompt content for troubleshooting
@@ -339,19 +358,17 @@ export class CommitManager {
       // Debug log the Claude call parameters
       const claudeOptions = {
         headless: true,
-        addDir: worktreePath,
         model: 'claude-haiku-4-5-20251001', // Fast, cost-effective model
         timeout: 120000, // 120 second timeout
-        systemPrompt: 'You are a software engineer writing a git commit message. Examine the staged changes in the git repository and generate a concise, meaningful commit message. Use imperative mood. Keep subject line under 72 characters. Your entire response will be used directly as the git commit message — output ONLY the raw commit message with no explanatory text, analysis, or meta-commentary.',
+        systemPrompt: 'You are a git commit message generator. Generate a concise commit message in imperative mood with subject line under 72 characters. Your entire response is used verbatim as the commit message — output ONLY the raw commit message, no explanatory text.',
         noSessionPersistence: true, // Utility operation - bare mode auto-applied by launchClaude
+        effort: 'low', // Minimize turns for fast commit message generation
       }
       getLogger().debug('Claude CLI call parameters:', {
         options: claudeOptions,
-        worktreePathForAnalysis: worktreePath,
-        addDirContents: 'Will include entire worktree directory for analysis'
       })
 
-      // Launch Claude in headless mode with repository access and shorter timeout for commit messages
+      // Launch Claude in headless mode — diff is embedded in prompt, no addDir needed
       const result = await launchClaude(prompt, claudeOptions)
 
       const claudeDuration = Date.now() - claudeStartTime
@@ -436,7 +453,9 @@ export class CommitManager {
   private buildCommitMessagePrompt(
     issueNumber: string | number | undefined,
     issuePrefix: string,
-    trailerType?: 'Refs' | 'Fixes'
+    trailerType?: 'Refs' | 'Fixes',
+    stagedStat?: string,
+    stagedDiff?: string
   ): string {
     const trailer = trailerType ?? 'Fixes'
     const issueContext = issueNumber
@@ -446,10 +465,22 @@ ${trailer === 'Fixes' ? 'If the changes appear to resolve the issue, include' : 
 </IssueContext>`
       : ''
 
+    const diffSection = stagedStat || stagedDiff
+      ? `\n<StagedChanges>
+<Stat>
+${stagedStat ?? '(not available)'}
+</Stat>
+<Diff>
+${stagedDiff ?? '(not available)'}
+</Diff>
+</StagedChanges>`
+      : ''
+
     const examplePrefix = issuePrefix || ''  // Use empty string for Linear examples
     return `<Task>
-Examine the staged changes in the git repository and generate a concise, meaningful commit message.
+Generate a concise, meaningful commit message for the following staged changes.
 </Task>
+${diffSection}
 
 <Requirements>
 <Format>The first line must be a brief summary of the changes made as a full sentence. If it references an issue, include "${trailer} ${examplePrefix}N" at the end of this line.

--- a/src/lib/SessionSummaryService.test.ts
+++ b/src/lib/SessionSummaryService.test.ts
@@ -810,6 +810,129 @@ describe('SessionSummaryService', () => {
 		})
 	})
 
+	describe('prompt too long retry with opus[1m]', () => {
+		const validSummary = '## iloom Session Summary\n\n**Key Themes:**\n- Theme one about testing\n- Theme two about implementation\n\n### Key Insights\n- Test insight one\n- Test insight two'
+
+		it('should retry with opus[1m] when launchClaude returns "Prompt is too long" as result text', async () => {
+			vi.mocked(launchClaude)
+				.mockResolvedValueOnce('Prompt is too long')
+				.mockResolvedValueOnce(validSummary)
+
+			await service.generateAndPostSummary(defaultInput)
+
+			// Verify launchClaude called twice: first with sonnet, second with opus[1m]
+			expect(launchClaude).toHaveBeenCalledTimes(2)
+			expect(launchClaude).toHaveBeenNthCalledWith(1, expect.any(String), expect.objectContaining({
+				model: 'sonnet',
+				sessionId: 'test-session-id-12345',
+			}))
+			expect(launchClaude).toHaveBeenNthCalledWith(2, expect.any(String), expect.objectContaining({
+				model: 'opus[1m]',
+				sessionId: 'test-session-id-12345',
+			}))
+
+			// Verify comment was posted successfully with the retry result
+			expect(mockIssueProvider.createComment).toHaveBeenCalledWith({
+				number: '123',
+				body: validSummary,
+				type: 'issue',
+			})
+		})
+
+		it('should retry with opus[1m] when launchClaude throws "Prompt is too long" error', async () => {
+			vi.mocked(launchClaude)
+				.mockRejectedValueOnce(new Error('Prompt is too long'))
+				.mockResolvedValueOnce(validSummary)
+
+			await service.generateAndPostSummary(defaultInput)
+
+			// Verify launchClaude called twice
+			expect(launchClaude).toHaveBeenCalledTimes(2)
+			expect(launchClaude).toHaveBeenNthCalledWith(1, expect.any(String), expect.objectContaining({
+				model: 'sonnet',
+			}))
+			expect(launchClaude).toHaveBeenNthCalledWith(2, expect.any(String), expect.objectContaining({
+				model: 'opus[1m]',
+			}))
+
+			// Verify comment was posted
+			expect(mockIssueProvider.createComment).toHaveBeenCalled()
+		})
+
+		it('should not retry when launchClaude fails with a different error', async () => {
+			vi.mocked(launchClaude).mockRejectedValueOnce(new Error('Claude API error'))
+
+			// generateAndPostSummary is non-blocking, should not throw
+			await expect(service.generateAndPostSummary(defaultInput)).resolves.not.toThrow()
+
+			// Verify launchClaude called only once (no retry)
+			expect(launchClaude).toHaveBeenCalledTimes(1)
+			// Comment should not be posted
+			expect(mockIssueProvider.createComment).not.toHaveBeenCalled()
+		})
+
+		it('should retry with opus[1m] in generateSummary when prompt is too long (thrown error)', async () => {
+			vi.mocked(launchClaude)
+				.mockRejectedValueOnce(new Error('Prompt is too long'))
+				.mockResolvedValueOnce(validSummary)
+
+			const result = await service.generateSummary(
+				'/path/to/worktree',
+				'feat/issue-123__test-feature',
+				'issue',
+				123
+			)
+
+			// Verify launchClaude called twice
+			expect(launchClaude).toHaveBeenCalledTimes(2)
+			expect(launchClaude).toHaveBeenNthCalledWith(2, expect.any(String), expect.objectContaining({
+				model: 'opus[1m]',
+			}))
+
+			// Verify returned summary is from the retry call
+			expect(result.summary).toBe(validSummary)
+		})
+
+		it('should retry with opus[1m] in generateSummary when prompt is too long (result string)', async () => {
+			vi.mocked(launchClaude)
+				.mockResolvedValueOnce('Prompt is too long')
+				.mockResolvedValueOnce(validSummary)
+
+			const result = await service.generateSummary(
+				'/path/to/worktree',
+				'feat/issue-123__test-feature',
+				'issue',
+				123
+			)
+
+			// Verify launchClaude called twice
+			expect(launchClaude).toHaveBeenCalledTimes(2)
+			expect(launchClaude).toHaveBeenNthCalledWith(2, expect.any(String), expect.objectContaining({
+				model: 'opus[1m]',
+			}))
+
+			// Verify returned summary is from the retry call
+			expect(result.summary).toBe(validSummary)
+		})
+
+		it('should throw when retry also fails in generateSummary', async () => {
+			vi.mocked(launchClaude)
+				.mockRejectedValueOnce(new Error('Prompt is too long'))
+				.mockRejectedValueOnce(new Error('Opus also failed'))
+
+			// generateSummary throws (not non-blocking like generateAndPostSummary)
+			await expect(service.generateSummary(
+				'/path/to/worktree',
+				'feat/issue-123__test-feature',
+				'issue',
+				123
+			)).rejects.toThrow('Opus also failed')
+
+			// Verify launchClaude called twice
+			expect(launchClaude).toHaveBeenCalledTimes(2)
+		})
+	})
+
 	describe('shouldGenerateSummary - epic type', () => {
 		it('should use issue workflow config for epic loom type', () => {
 			const settings: IloomSettings = {

--- a/src/lib/SessionSummaryService.ts
+++ b/src/lib/SessionSummaryService.ts
@@ -78,6 +78,42 @@ export class SessionSummaryService {
 	}
 
 	/**
+	 * Launch Claude for session summary with automatic retry using opus[1m] if the prompt is too long.
+	 *
+	 * When resuming long sessions, the transcript can exceed Sonnet's 200K context window,
+	 * causing a "Prompt is too long" error. This helper detects that condition (either as a
+	 * thrown error or as a returned result string) and retries with opus[1m] (1M context).
+	 */
+	private async launchSessionSummary(prompt: string, model: string, sessionId: string): Promise<string | void> {
+		const launchOptions = {
+			headless: true,
+			model,
+			sessionId,
+			noSessionPersistence: true,
+		}
+
+		try {
+			const result = await launchClaude(prompt, launchOptions)
+
+			// Check if the result string indicates the prompt was too long
+			if (typeof result === 'string' && result.includes('Prompt is too long')) {
+				logger.warn(`Session too long for ${model}, retrying with Opus (1M context)...`)
+				return await launchClaude(prompt, { ...launchOptions, model: 'opus[1m]' })
+			}
+
+			return result
+		} catch (error) {
+			// Check if the thrown error indicates the prompt was too long
+			const errorMessage = error instanceof Error ? error.message : String(error)
+			if (errorMessage.includes('Prompt is too long')) {
+				logger.warn(`Session too long for ${model}, retrying with Opus (1M context)...`)
+				return await launchClaude(prompt, { ...launchOptions, model: 'opus[1m]' })
+			}
+			throw error
+		}
+	}
+
+	/**
 	 * Generate and post a session summary to the issue
 	 *
 	 * Non-blocking: Catches all errors and logs warnings instead of throwing
@@ -135,12 +171,7 @@ export class SessionSummaryService {
 			// 7. Invoke Claude headless to generate summary
 			// Use --resume with session ID so Claude knows which conversation to summarize
 			const summaryModel = this.settingsManager.getSummaryModel(settings)
-			const summaryResult = await launchClaude(prompt, {
-				headless: true,
-				model: summaryModel,
-				sessionId: sessionId, // Resume this session so Claude has conversation context
-				noSessionPersistence: true, // Don't persist new data after generating summary
-			})
+			const summaryResult = await this.launchSessionSummary(prompt, summaryModel, sessionId)
 
 			if (!summaryResult || typeof summaryResult !== 'string' || summaryResult.trim() === '') {
 				logger.warn('Session summary generation returned empty result')
@@ -339,12 +370,7 @@ export class SessionSummaryService {
 
 		// 6. Invoke Claude headless to generate summary
 		const summaryModel = this.settingsManager.getSummaryModel(settings)
-		const summaryResult = await launchClaude(prompt, {
-			headless: true,
-			model: summaryModel,
-			sessionId: sessionId,
-			noSessionPersistence: true, // Don't persist new data after generating summary
-		})
+		const summaryResult = await this.launchSessionSummary(prompt, summaryModel, sessionId)
 
 		if (!summaryResult || typeof summaryResult !== 'string' || summaryResult.trim() === '') {
 			throw new Error('Session summary generation returned empty result')

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -3120,7 +3120,7 @@ describe('claude utils', () => {
 			expect(result).toBe('feat/issue-123__user-authentication')
 			expect(execa).toHaveBeenCalledWith(
 				'claude',
-				['-p', '--output-format', 'stream-json', '--verbose', '--model', 'haiku', '--add-dir', '/tmp', '--no-session-persistence'],
+				expect.arrayContaining(['-p', '--output-format', 'stream-json', '--verbose', '--model', 'haiku', '--effort', 'low', '--system-prompt', expect.any(String), '--no-session-persistence']),
 				expect.objectContaining({
 					input: expect.stringContaining(issueTitle),
 					env: expect.objectContaining({ CLAUDECODE: '0' }),

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { execa } from 'execa'
 import { existsSync } from 'node:fs'
-import { detectClaudeCli, getClaudeVersion, launchClaude, generateBranchName, launchClaudeInNewTerminalWindow, generateDeterministicSessionId, generateRandomSessionId } from './claude.js'
+import { detectClaudeCli, getClaudeVersion, launchClaude, generateBranchName, launchClaudeInNewTerminalWindow, generateDeterministicSessionId, generateRandomSessionId, shouldUseBareMode } from './claude.js'
 import { logger } from './logger.js'
 
 const mockLogger = {
@@ -2119,6 +2119,213 @@ describe('claude utils', () => {
 				)
 			})
 		})
+
+		describe('bare parameter', () => {
+			it('should add --bare flag when bare is true', async () => {
+				const prompt = 'Test prompt'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'output',
+					exitCode: 0,
+				})
+
+				await launchClaude(prompt, {
+					headless: true,
+					bare: true,
+				})
+
+				expect(execa).toHaveBeenCalledWith(
+					'claude',
+					['--bare', '-p', '--output-format', 'stream-json', '--verbose', '--add-dir', '/tmp'],
+					expect.any(Object)
+				)
+			})
+
+			it('should not add --bare flag when bare is false', async () => {
+				const prompt = 'Test prompt'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'output',
+					exitCode: 0,
+				})
+
+				await launchClaude(prompt, {
+					headless: true,
+					bare: false,
+				})
+
+				const execaCall = mockExeca().mock.calls[0]
+				expect(execaCall[1]).not.toContain('--bare')
+			})
+
+			it('should not add --bare flag when bare is undefined and not headless+noSessionPersistence', async () => {
+				const prompt = 'Test prompt'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'output',
+					exitCode: 0,
+				})
+
+				await launchClaude(prompt, { headless: true })
+
+				const execaCall = mockExeca().mock.calls[0]
+				expect(execaCall[1]).not.toContain('--bare')
+			})
+
+			it('should auto-apply --bare when headless + noSessionPersistence and ANTHROPIC_API_KEY is set', async () => {
+				const originalApiKey = process.env.ANTHROPIC_API_KEY
+				try {
+					process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+					const prompt = 'Test prompt'
+
+					mockExeca().mockResolvedValueOnce({
+						stdout: 'output',
+						exitCode: 0,
+					})
+
+					await launchClaude(prompt, {
+						headless: true,
+						noSessionPersistence: true,
+					})
+
+					expect(execa).toHaveBeenCalledWith(
+						'claude',
+						expect.arrayContaining(['--bare']),
+						expect.any(Object)
+					)
+				} finally {
+					if (originalApiKey !== undefined) {
+						process.env.ANTHROPIC_API_KEY = originalApiKey
+					} else {
+						delete process.env.ANTHROPIC_API_KEY
+					}
+				}
+			})
+
+			it('should not auto-apply --bare when headless + noSessionPersistence but ANTHROPIC_API_KEY is not set', async () => {
+				const originalApiKey = process.env.ANTHROPIC_API_KEY
+				try {
+					delete process.env.ANTHROPIC_API_KEY
+					const prompt = 'Test prompt'
+
+					mockExeca().mockResolvedValueOnce({
+						stdout: 'output',
+						exitCode: 0,
+					})
+
+					await launchClaude(prompt, {
+						headless: true,
+						noSessionPersistence: true,
+					})
+
+					const execaCall = mockExeca().mock.calls[0]
+					expect(execaCall[1]).not.toContain('--bare')
+				} finally {
+					if (originalApiKey !== undefined) {
+						process.env.ANTHROPIC_API_KEY = originalApiKey
+					} else {
+						delete process.env.ANTHROPIC_API_KEY
+					}
+				}
+			})
+
+			it('should not auto-apply --bare when bare is explicitly false even with headless + noSessionPersistence + API key', async () => {
+				const originalApiKey = process.env.ANTHROPIC_API_KEY
+				try {
+					process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+					const prompt = 'Test prompt'
+
+					mockExeca().mockResolvedValueOnce({
+						stdout: 'output',
+						exitCode: 0,
+					})
+
+					await launchClaude(prompt, {
+						headless: true,
+						noSessionPersistence: true,
+						bare: false,
+					})
+
+					const execaCall = mockExeca().mock.calls[0]
+					expect(execaCall[1]).not.toContain('--bare')
+				} finally {
+					if (originalApiKey !== undefined) {
+						process.env.ANTHROPIC_API_KEY = originalApiKey
+					} else {
+						delete process.env.ANTHROPIC_API_KEY
+					}
+				}
+			})
+
+			it('should combine --bare with other options in correct order', async () => {
+				const prompt = 'Test prompt'
+
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'output',
+					exitCode: 0,
+				})
+
+				await launchClaude(prompt, {
+					headless: true,
+					model: 'opus',
+					addDir: '/workspace',
+					bare: true,
+					noSessionPersistence: true,
+				})
+
+				expect(execa).toHaveBeenCalledWith(
+					'claude',
+					[
+						'--bare',
+						'-p',
+						'--output-format',
+						'stream-json',
+						'--verbose',
+						'--model', 'opus',
+						'--add-dir', '/workspace',
+						'--add-dir', '/tmp',
+						'--no-session-persistence',
+					],
+					expect.any(Object)
+				)
+			})
+		})
+	})
+
+	describe('shouldUseBareMode', () => {
+		let originalApiKey: string | undefined
+
+		beforeEach(() => {
+			originalApiKey = process.env.ANTHROPIC_API_KEY
+		})
+
+		afterEach(() => {
+			if (originalApiKey !== undefined) {
+				process.env.ANTHROPIC_API_KEY = originalApiKey
+			} else {
+				delete process.env.ANTHROPIC_API_KEY
+			}
+		})
+
+		it('should return true when ANTHROPIC_API_KEY is set', () => {
+			process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+			expect(shouldUseBareMode()).toBe(true)
+		})
+
+		it('should return false when ANTHROPIC_API_KEY is not set', () => {
+			delete process.env.ANTHROPIC_API_KEY
+			expect(shouldUseBareMode()).toBe(false)
+		})
+
+		it('should return false when ANTHROPIC_API_KEY is empty string', () => {
+			process.env.ANTHROPIC_API_KEY = ''
+			expect(shouldUseBareMode()).toBe(false)
+		})
+
+		it('should return false when ANTHROPIC_API_KEY is whitespace only', () => {
+			process.env.ANTHROPIC_API_KEY = '   '
+			expect(shouldUseBareMode()).toBe(false)
+		})
 	})
 
 	describe.runIf(process.platform === 'darwin')('launchClaudeInNewTerminalWindow', () => {
@@ -2474,6 +2681,72 @@ describe('claude utils', () => {
 
 			// Should accept the lowercase branch name, not fall back
 			expect(result).toBe('feat/issue-mark-1__nextjs-vercel')
+		})
+
+		describe('bare mode (auto-applied by launchClaude)', () => {
+			let originalApiKey: string | undefined
+
+			beforeEach(() => {
+				originalApiKey = process.env.ANTHROPIC_API_KEY
+			})
+
+			afterEach(() => {
+				if (originalApiKey !== undefined) {
+					process.env.ANTHROPIC_API_KEY = originalApiKey
+				} else {
+					delete process.env.ANTHROPIC_API_KEY
+				}
+			})
+
+			it('should auto-apply --bare when ANTHROPIC_API_KEY is set (headless + noSessionPersistence)', async () => {
+				process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+				const issueTitle = 'Add user authentication'
+				const issueNumber = 123
+
+				// Mock Claude CLI detection
+				mockExeca().mockResolvedValueOnce({
+					stdout: '/usr/local/bin/claude',
+					exitCode: 0,
+				})
+
+				// Mock Claude response
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'feat/issue-123__user-authentication',
+					exitCode: 0,
+				})
+
+				await generateBranchName(issueTitle, issueNumber)
+
+				expect(execa).toHaveBeenCalledWith(
+					'claude',
+					expect.arrayContaining(['--bare']),
+					expect.any(Object)
+				)
+			})
+
+			it('should not auto-apply --bare when ANTHROPIC_API_KEY is not set', async () => {
+				delete process.env.ANTHROPIC_API_KEY
+				const issueTitle = 'Add user authentication'
+				const issueNumber = 123
+
+				// Mock Claude CLI detection
+				mockExeca().mockResolvedValueOnce({
+					stdout: '/usr/local/bin/claude',
+					exitCode: 0,
+				})
+
+				// Mock Claude response
+				mockExeca().mockResolvedValueOnce({
+					stdout: 'feat/issue-123__user-authentication',
+					exitCode: 0,
+				})
+
+				await generateBranchName(issueTitle, issueNumber)
+
+				// The second execa call is the launchClaude call
+				const launchClaudeCall = mockExeca().mock.calls[1]
+				expect(launchClaudeCall[1]).not.toContain('--bare')
+			})
 		})
 	})
 

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -2,7 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { execa } from 'execa'
 import { existsSync } from 'node:fs'
-import { detectClaudeCli, getClaudeVersion, launchClaude, generateBranchName, launchClaudeInNewTerminalWindow, generateDeterministicSessionId, generateRandomSessionId, shouldUseBareMode } from './claude.js'
+import { detectClaudeCli, getClaudeVersion, launchClaude, generateBranchName, launchClaudeInNewTerminalWindow, generateDeterministicSessionId, generateRandomSessionId, hasApiKeyForBareMode, extractOAuthToken, resolveBareModeConfig } from './claude.js'
+import { readFile } from 'node:fs/promises'
 import { logger } from './logger.js'
 
 const mockLogger = {
@@ -20,6 +21,7 @@ const mockLogger = {
 
 vi.mock('execa')
 vi.mock('node:fs')
+vi.mock('node:fs/promises')
 vi.mock('./logger.js', () => ({
 	logger: {
 		debug: vi.fn(),
@@ -2011,8 +2013,38 @@ describe('claude utils', () => {
 		})
 
 		describe('noSessionPersistence parameter', () => {
+			let originalApiKey: string | undefined
+			let originalOAuthToken: string | undefined
+
+			beforeEach(() => {
+				originalApiKey = process.env.ANTHROPIC_API_KEY
+				originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+				delete process.env.ANTHROPIC_API_KEY
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			})
+
+			afterEach(() => {
+				if (originalApiKey !== undefined) {
+					process.env.ANTHROPIC_API_KEY = originalApiKey
+				} else {
+					delete process.env.ANTHROPIC_API_KEY
+				}
+				if (originalOAuthToken !== undefined) {
+					process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+				} else {
+					delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+				}
+			})
+
 			it('should add --no-session-persistence flag when noSessionPersistence is true', async () => {
 				const prompt = 'Test prompt'
+
+				// resolveBareModeConfig will try OAuth extraction - make it fail
+				if (process.platform === 'darwin') {
+					mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
+				} else {
+					vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+				}
 
 				mockExeca().mockResolvedValueOnce({
 					stdout: 'output',
@@ -2089,6 +2121,13 @@ describe('claude utils', () => {
 				const prompt = 'Test prompt'
 				const sessionId = '12345678-1234-5678-1234-567812345678'
 
+				// resolveBareModeConfig will try OAuth extraction - make it fail
+				if (process.platform === 'darwin') {
+					mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
+				} else {
+					vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+				}
+
 				mockExeca().mockResolvedValueOnce({
 					stdout: 'output',
 					exitCode: 0,
@@ -2121,6 +2160,30 @@ describe('claude utils', () => {
 		})
 
 		describe('bare parameter', () => {
+			let savedApiKey: string | undefined
+			let savedOAuthToken: string | undefined
+
+			beforeEach(() => {
+				savedApiKey = process.env.ANTHROPIC_API_KEY
+				savedOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+				// Set API key so resolveBareModeConfig() returns early without OAuth extraction
+				process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-for-bare'
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			})
+
+			afterEach(() => {
+				if (savedApiKey !== undefined) {
+					process.env.ANTHROPIC_API_KEY = savedApiKey
+				} else {
+					delete process.env.ANTHROPIC_API_KEY
+				}
+				if (savedOAuthToken !== undefined) {
+					process.env.CLAUDE_CODE_OAUTH_TOKEN = savedOAuthToken
+				} else {
+					delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+				}
+			})
+
 			it('should add --bare flag when bare is true', async () => {
 				const prompt = 'Test prompt'
 
@@ -2202,11 +2265,20 @@ describe('claude utils', () => {
 				}
 			})
 
-			it('should not auto-apply --bare when headless + noSessionPersistence but ANTHROPIC_API_KEY is not set', async () => {
+			it('should not auto-apply --bare when headless + noSessionPersistence but no API key or OAuth token available', async () => {
 				const originalApiKey = process.env.ANTHROPIC_API_KEY
+				const originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
 				try {
 					delete process.env.ANTHROPIC_API_KEY
+					delete process.env.CLAUDE_CODE_OAUTH_TOKEN
 					const prompt = 'Test prompt'
+
+					// On macOS, extractOAuthToken will call security command - make it fail
+					if (process.platform === 'darwin') {
+						mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
+					} else {
+						vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+					}
 
 					mockExeca().mockResolvedValueOnce({
 						stdout: 'output',
@@ -2218,13 +2290,21 @@ describe('claude utils', () => {
 						noSessionPersistence: true,
 					})
 
-					const execaCall = mockExeca().mock.calls[0]
-					expect(execaCall[1]).not.toContain('--bare')
+					// Find the claude call (skip the security call on macOS)
+					const claudeCall = mockExeca().mock.calls.find(
+						(call: unknown[]) => call[0] === 'claude'
+					)
+					expect(claudeCall?.[1]).not.toContain('--bare')
 				} finally {
 					if (originalApiKey !== undefined) {
 						process.env.ANTHROPIC_API_KEY = originalApiKey
 					} else {
 						delete process.env.ANTHROPIC_API_KEY
+					}
+					if (originalOAuthToken !== undefined) {
+						process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+					} else {
+						delete process.env.CLAUDE_CODE_OAUTH_TOKEN
 					}
 				}
 			})
@@ -2292,7 +2372,7 @@ describe('claude utils', () => {
 		})
 	})
 
-	describe('shouldUseBareMode', () => {
+	describe('hasApiKeyForBareMode', () => {
 		let originalApiKey: string | undefined
 
 		beforeEach(() => {
@@ -2309,22 +2389,494 @@ describe('claude utils', () => {
 
 		it('should return true when ANTHROPIC_API_KEY is set', () => {
 			process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
-			expect(shouldUseBareMode()).toBe(true)
+			expect(hasApiKeyForBareMode()).toBe(true)
 		})
 
 		it('should return false when ANTHROPIC_API_KEY is not set', () => {
 			delete process.env.ANTHROPIC_API_KEY
-			expect(shouldUseBareMode()).toBe(false)
+			expect(hasApiKeyForBareMode()).toBe(false)
 		})
 
 		it('should return false when ANTHROPIC_API_KEY is empty string', () => {
 			process.env.ANTHROPIC_API_KEY = ''
-			expect(shouldUseBareMode()).toBe(false)
+			expect(hasApiKeyForBareMode()).toBe(false)
 		})
 
 		it('should return false when ANTHROPIC_API_KEY is whitespace only', () => {
 			process.env.ANTHROPIC_API_KEY = '   '
-			expect(shouldUseBareMode()).toBe(false)
+			expect(hasApiKeyForBareMode()).toBe(false)
+		})
+	})
+
+	describe('extractOAuthToken', () => {
+		let originalApiKey: string | undefined
+		let originalOAuthToken: string | undefined
+		let originalPlatform: string
+
+		beforeEach(() => {
+			originalApiKey = process.env.ANTHROPIC_API_KEY
+			originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+			originalPlatform = process.platform
+			delete process.env.ANTHROPIC_API_KEY
+			delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+		})
+
+		afterEach(() => {
+			if (originalApiKey !== undefined) {
+				process.env.ANTHROPIC_API_KEY = originalApiKey
+			} else {
+				delete process.env.ANTHROPIC_API_KEY
+			}
+			if (originalOAuthToken !== undefined) {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+			} else {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			}
+			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+		})
+
+		it('should return CLAUDE_CODE_OAUTH_TOKEN env var if set', async () => {
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
+			const token = await extractOAuthToken()
+			expect(token).toBe('sk-ant-oat01-test-token')
+		})
+
+		it('should return null when CLAUDE_CODE_OAUTH_TOKEN is empty', async () => {
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = ''
+			// Mock platform-specific fallback to also return nothing
+			Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+			vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+			const token = await extractOAuthToken()
+			expect(token).toBeNull()
+		})
+
+		describe('macOS (darwin)', () => {
+			beforeEach(() => {
+				Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+			})
+
+			it('should extract token from macOS Keychain via security command', async () => {
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-keychain-token',
+						refreshToken: 'rt-test',
+						expiresAt: Date.now() + 3600000,
+					},
+				})
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBe('sk-ant-oat01-keychain-token')
+
+				expect(execa).toHaveBeenCalledWith(
+					'security',
+					['find-generic-password', '-s', 'Claude Code-credentials', '-a', expect.any(String), '-w'],
+					{ timeout: 3000 }
+				)
+			})
+
+			it('should return null when security command fails', async () => {
+				mockExeca().mockRejectedValueOnce(new Error('security: SecKeychainSearchCopyNext: The specified item could not be found'))
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should return null when keychain JSON is malformed', async () => {
+				mockExeca().mockResolvedValueOnce({ stdout: 'not-valid-json', exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should return null when claudeAiOauth.accessToken is missing', async () => {
+				const credJson = JSON.stringify({ someOtherField: 'value' })
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should return null when token is expired', async () => {
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-expired-token',
+						expiresAt: Date.now() - 1000, // expired 1 second ago
+					},
+				})
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should return null when token expires within 60 seconds (buffer)', async () => {
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-expiring-soon',
+						expiresAt: Date.now() + 30_000, // expires in 30s, within 60s buffer
+					},
+				})
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should handle expiresAt in seconds (heuristic: value < 10 billion)', async () => {
+				const nowInSeconds = Math.floor(Date.now() / 1000)
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-seconds-token',
+						expiresAt: nowInSeconds + 3600, // 1 hour from now, in seconds
+					},
+				})
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBe('sk-ant-oat01-seconds-token')
+			})
+
+			it('should treat expired token in seconds format as expired', async () => {
+				const nowInSeconds = Math.floor(Date.now() / 1000)
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-expired-seconds',
+						expiresAt: nowInSeconds - 100, // expired 100 seconds ago, in seconds
+					},
+				})
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should use 3-second timeout on security command', async () => {
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-token',
+						expiresAt: Date.now() + 3600000,
+					},
+				})
+				mockExeca().mockResolvedValueOnce({ stdout: credJson, exitCode: 0 })
+
+				await extractOAuthToken()
+
+				expect(execa).toHaveBeenCalledWith(
+					'security',
+					expect.any(Array),
+					expect.objectContaining({ timeout: 3000 })
+				)
+			})
+		})
+
+		describe('Linux/other platforms', () => {
+			beforeEach(() => {
+				Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+			})
+
+			it('should extract token from ~/.claude/.credentials.json', async () => {
+				const credJson = JSON.stringify({
+					claudeAiOauth: {
+						accessToken: 'sk-ant-oat01-linux-token',
+						refreshToken: 'rt-test',
+						expiresAt: Date.now() + 3600000,
+					},
+				})
+				vi.mocked(readFile).mockResolvedValueOnce(credJson)
+
+				const token = await extractOAuthToken()
+				expect(token).toBe('sk-ant-oat01-linux-token')
+			})
+
+			it('should return null when credentials file does not exist', async () => {
+				vi.mocked(readFile).mockRejectedValueOnce(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+
+			it('should return null when credentials JSON is malformed', async () => {
+				vi.mocked(readFile).mockResolvedValueOnce('not-valid-json')
+
+				const token = await extractOAuthToken()
+				expect(token).toBeNull()
+			})
+		})
+	})
+
+	describe('resolveBareModeConfig', () => {
+		let originalApiKey: string | undefined
+		let originalOAuthToken: string | undefined
+		let originalPlatform: string
+
+		beforeEach(() => {
+			originalApiKey = process.env.ANTHROPIC_API_KEY
+			originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+			originalPlatform = process.platform
+			delete process.env.ANTHROPIC_API_KEY
+			delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+		})
+
+		afterEach(() => {
+			if (originalApiKey !== undefined) {
+				process.env.ANTHROPIC_API_KEY = originalApiKey
+			} else {
+				delete process.env.ANTHROPIC_API_KEY
+			}
+			if (originalOAuthToken !== undefined) {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+			} else {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			}
+			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+		})
+
+		it('should return { bare: true } when ANTHROPIC_API_KEY is set', async () => {
+			process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+			const config = await resolveBareModeConfig()
+			expect(config).toEqual({ bare: true })
+		})
+
+		it('should return { bare: true, settings: ..., oauthToken: ... } when OAuth token is available', async () => {
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
+			const config = await resolveBareModeConfig()
+			expect(config.bare).toBe(true)
+			expect(config.settings).toBeDefined()
+			const parsed = JSON.parse(config.settings!)
+			// Token should NOT appear in settings (passed via env var instead)
+			expect(parsed.apiKeyHelper).toBe('echo $__ILOOM_OAUTH_TOKEN')
+			expect(parsed.apiKeyHelper).not.toContain('sk-ant-oat01-test-token')
+			// Token should be returned separately for env var injection
+			expect(config.oauthToken).toBe('sk-ant-oat01-test-token')
+		})
+
+		it('should return { bare: false } when neither API key nor OAuth token available', async () => {
+			Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+			vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+			const config = await resolveBareModeConfig()
+			expect(config).toEqual({ bare: false })
+		})
+	})
+
+	describe('settings parameter in launchClaude', () => {
+		let savedApiKey: string | undefined
+		let savedOAuthToken: string | undefined
+
+		beforeEach(() => {
+			savedApiKey = process.env.ANTHROPIC_API_KEY
+			savedOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+			// Set API key so resolveBareModeConfig returns early (no OAuth extraction)
+			process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-for-settings'
+			delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+		})
+
+		afterEach(() => {
+			if (savedApiKey !== undefined) {
+				process.env.ANTHROPIC_API_KEY = savedApiKey
+			} else {
+				delete process.env.ANTHROPIC_API_KEY
+			}
+			if (savedOAuthToken !== undefined) {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = savedOAuthToken
+			} else {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			}
+		})
+
+		it('should add --settings flag when settings is provided', async () => {
+			const fakeSubprocess = {
+				stdout: null,
+				on: vi.fn(),
+				kill: vi.fn(),
+			}
+			mockExeca().mockReturnValueOnce(
+				Object.assign(Promise.resolve({ stdout: 'output', exitCode: 0 }), fakeSubprocess)
+			)
+
+			await launchClaude('test prompt', {
+				headless: true,
+				bare: true,
+				settings: '{"apiKeyHelper": "echo token"}',
+			})
+
+			expect(execa).toHaveBeenCalledWith(
+				'claude',
+				expect.arrayContaining(['--settings', '{"apiKeyHelper": "echo token"}']),
+				expect.any(Object)
+			)
+		})
+
+		it('should not add --settings flag when settings is undefined and ANTHROPIC_API_KEY is set', async () => {
+			const fakeSubprocess = {
+				stdout: null,
+				on: vi.fn(),
+				kill: vi.fn(),
+			}
+			mockExeca().mockReturnValueOnce(
+				Object.assign(Promise.resolve({ stdout: 'output', exitCode: 0 }), fakeSubprocess)
+			)
+
+			await launchClaude('test prompt', {
+				headless: true,
+				bare: true,
+			})
+
+			const callArgs = mockExeca().mock.calls[0][1] as string[]
+			expect(callArgs).not.toContain('--settings')
+		})
+	})
+
+	describe('bare mode auth failure retry', () => {
+		let originalApiKey: string | undefined
+		let originalOAuthToken: string | undefined
+
+		beforeEach(() => {
+			originalApiKey = process.env.ANTHROPIC_API_KEY
+			originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+			delete process.env.ANTHROPIC_API_KEY
+		})
+
+		afterEach(() => {
+			if (originalApiKey !== undefined) {
+				process.env.ANTHROPIC_API_KEY = originalApiKey
+			} else {
+				delete process.env.ANTHROPIC_API_KEY
+			}
+			if (originalOAuthToken !== undefined) {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+			} else {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			}
+		})
+
+		it('should retry without --bare when auto-applied bare mode fails with auth error', async () => {
+			// Set up OAuth token so bare mode will be auto-applied
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
+
+			const fakeSubprocess1 = {
+				stdout: null,
+				on: vi.fn(),
+				kill: vi.fn(),
+			}
+
+			const fakeSubprocess2 = {
+				stdout: null,
+				on: vi.fn(),
+				kill: vi.fn(),
+			}
+
+			// First call: fails with auth error (bare mode auto-applied)
+			const authError = Object.assign(new Error('Invalid API Key'), {
+				stderr: 'Invalid API Key',
+				exitCode: 1,
+			})
+			mockExeca().mockReturnValueOnce(
+				Object.assign(Promise.reject(authError), fakeSubprocess1)
+			)
+
+			// Second call: succeeds (retry without bare)
+			mockExeca().mockReturnValueOnce(
+				Object.assign(Promise.resolve({ stdout: 'retry output', exitCode: 0 }), fakeSubprocess2)
+			)
+
+			const result = await launchClaude('test prompt', {
+				headless: true,
+				noSessionPersistence: true,
+			})
+
+			expect(result).toBe('retry output')
+
+			// Verify first call had --bare and --settings
+			const firstCallArgs = mockExeca().mock.calls[0][1] as string[]
+			expect(firstCallArgs).toContain('--bare')
+			expect(firstCallArgs).toContain('--settings')
+
+			// Verify first call passes OAuth token via env var, not in args
+			const firstCallOpts = mockExeca().mock.calls[0][2] as Record<string, unknown>
+			const firstCallEnv = firstCallOpts.env as Record<string, string>
+			expect(firstCallEnv.__ILOOM_OAUTH_TOKEN).toBe('sk-ant-oat01-test-token')
+
+			// Verify settings JSON does NOT contain the actual token
+			const settingsIdx = firstCallArgs.indexOf('--settings')
+			const settingsJson = firstCallArgs[settingsIdx + 1]
+			expect(settingsJson).not.toContain('sk-ant-oat01-test-token')
+			expect(settingsJson).toContain('__ILOOM_OAUTH_TOKEN')
+
+			// Verify second call does NOT have --bare or --settings
+			const secondCallArgs = mockExeca().mock.calls[1][1] as string[]
+			expect(secondCallArgs).not.toContain('--bare')
+			expect(secondCallArgs).not.toContain('--settings')
+
+			// Verify warning was logged
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Bare mode failed'))
+		})
+
+		it('should NOT retry when bare was explicitly set by caller', async () => {
+			// Mock OAuth extraction failure so resolveBareModeConfig can complete
+			// (bare:true without settings triggers resolveBareModeConfig for OAuth)
+			if (process.platform === 'darwin') {
+				mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
+			} else {
+				vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+			}
+
+			const fakeSubprocess = {
+				stdout: null,
+				on: vi.fn(),
+				kill: vi.fn(),
+			}
+
+			const authError = Object.assign(new Error('Invalid API Key'), {
+				stderr: 'Invalid API Key',
+				exitCode: 1,
+			})
+			mockExeca().mockReturnValueOnce(
+				Object.assign(Promise.reject(authError), fakeSubprocess)
+			)
+
+			await expect(
+				launchClaude('test prompt', {
+					headless: true,
+					bare: true,
+				})
+			).rejects.toThrow('Claude CLI error')
+
+			// execa called for OAuth extraction (on macOS) + claude call = 2 on darwin, 1 on linux
+			// Only the claude call matters - verify no retry happened
+			const claudeCalls = mockExeca().mock.calls.filter(
+				(call: unknown[]) => call[0] === 'claude'
+			)
+			expect(claudeCalls).toHaveLength(1)
+		})
+
+		it('should NOT retry for non-auth errors', async () => {
+			// Set up OAuth token so bare mode will be auto-applied
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
+
+			const fakeSubprocess = {
+				stdout: null,
+				on: vi.fn(),
+				kill: vi.fn(),
+			}
+
+			const timeoutError = Object.assign(new Error('Command timed out'), {
+				stderr: 'Command timed out after 30000ms',
+				exitCode: 1,
+			})
+			mockExeca().mockReturnValueOnce(
+				Object.assign(Promise.reject(timeoutError), fakeSubprocess)
+			)
+
+			await expect(
+				launchClaude('test prompt', {
+					headless: true,
+					noSessionPersistence: true,
+				})
+			).rejects.toThrow('Claude CLI error')
+
+			// Should only have been called once (no retry)
+			expect(execa).toHaveBeenCalledTimes(1)
 		})
 	})
 
@@ -2512,6 +3064,38 @@ describe('claude utils', () => {
 	})
 
 	describe('generateBranchName', () => {
+		let originalApiKey: string | undefined
+		let originalOAuthToken: string | undefined
+
+		beforeEach(() => {
+			originalApiKey = process.env.ANTHROPIC_API_KEY
+			originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+			delete process.env.ANTHROPIC_API_KEY
+			delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+		})
+
+		afterEach(() => {
+			if (originalApiKey !== undefined) {
+				process.env.ANTHROPIC_API_KEY = originalApiKey
+			} else {
+				delete process.env.ANTHROPIC_API_KEY
+			}
+			if (originalOAuthToken !== undefined) {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+			} else {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+			}
+		})
+
+		// Helper: mock OAuth extraction failure for macOS (security command) or Linux (readFile)
+		function mockOAuthExtractionFailure(): void {
+			if (process.platform === 'darwin') {
+				mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
+			} else {
+				vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+			}
+		}
+
 		it('should generate branch name using Claude when available', async () => {
 			const issueTitle = 'Add user authentication'
 			const issueNumber = 123
@@ -2521,6 +3105,9 @@ describe('claude utils', () => {
 				stdout: '/usr/local/bin/claude',
 				exitCode: 0,
 			})
+
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
 
 			// Mock Claude response with full branch name
 			mockExeca().mockResolvedValueOnce({
@@ -2565,6 +3152,9 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
+
 			// Mock Claude returning error message
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'API error: rate limit exceeded',
@@ -2585,6 +3175,9 @@ describe('claude utils', () => {
 				stdout: '/usr/local/bin/claude',
 				exitCode: 0,
 			})
+
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
 
 			// Mock Claude returning empty string
 			mockExeca().mockResolvedValueOnce({
@@ -2607,6 +3200,9 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
+
 			// Mock Claude returning properly formatted branch
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'fix/issue-123__authentication-bug',
@@ -2628,6 +3224,9 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
+
 			// Mock Claude returning invalid format (no prefix)
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'add-user-auth',
@@ -2648,6 +3247,9 @@ describe('claude utils', () => {
 				stdout: '/usr/local/bin/claude',
 				exitCode: 0,
 			})
+
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
 
 			// Mock Claude execution fails
 			mockExeca().mockRejectedValueOnce({
@@ -2671,6 +3273,9 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
+			// OAuth extraction will fail (no credentials)
+			mockOAuthExtractionFailure()
+
 			// Mock Claude returning lowercase branch name (correct behavior)
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'feat/issue-mark-1__nextjs-vercel',
@@ -2685,9 +3290,11 @@ describe('claude utils', () => {
 
 		describe('bare mode (auto-applied by launchClaude)', () => {
 			let originalApiKey: string | undefined
+			let originalOAuthToken: string | undefined
 
 			beforeEach(() => {
 				originalApiKey = process.env.ANTHROPIC_API_KEY
+				originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
 			})
 
 			afterEach(() => {
@@ -2695,6 +3302,11 @@ describe('claude utils', () => {
 					process.env.ANTHROPIC_API_KEY = originalApiKey
 				} else {
 					delete process.env.ANTHROPIC_API_KEY
+				}
+				if (originalOAuthToken !== undefined) {
+					process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
+				} else {
+					delete process.env.CLAUDE_CODE_OAUTH_TOKEN
 				}
 			})
 
@@ -2724,8 +3336,9 @@ describe('claude utils', () => {
 				)
 			})
 
-			it('should not auto-apply --bare when ANTHROPIC_API_KEY is not set', async () => {
+			it('should not auto-apply --bare when no API key or OAuth token available', async () => {
 				delete process.env.ANTHROPIC_API_KEY
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
 				const issueTitle = 'Add user authentication'
 				const issueNumber = 123
 
@@ -2735,6 +3348,13 @@ describe('claude utils', () => {
 					exitCode: 0,
 				})
 
+				// On macOS, extractOAuthToken calls security command - make it fail
+				if (process.platform === 'darwin') {
+					mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
+				} else {
+					vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
+				}
+
 				// Mock Claude response
 				mockExeca().mockResolvedValueOnce({
 					stdout: 'feat/issue-123__user-authentication',
@@ -2743,9 +3363,11 @@ describe('claude utils', () => {
 
 				await generateBranchName(issueTitle, issueNumber)
 
-				// The second execa call is the launchClaude call
-				const launchClaudeCall = mockExeca().mock.calls[1]
-				expect(launchClaudeCall[1]).not.toContain('--bare')
+				// Find the launchClaude call (the claude command, not security)
+				const claudeCall = mockExeca().mock.calls.find(
+					(call: unknown[]) => call[0] === 'claude' && (call[1] as string[])?.includes('-p')
+				)
+				expect(claudeCall?.[1]).not.toContain('--bare')
 			})
 		})
 	})

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -731,6 +731,7 @@ Generate a git branch name for the following issue:
 			headless: true,
 			noSessionPersistence: true, // Utility operation - don't persist session
 			systemPrompt: 'You are a git branch name generator. Given an issue title and number, generate a branch name following the exact format and constraints provided. Output only the branch name, nothing else. No preamble, analysis, or meta-commentary.',
+			effort: 'low', // Simple text generation, minimize turns
 		})) as string
 
 		// Normalize to lowercase for consistency (Linear IDs are uppercase but branches should be lowercase)

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -1,6 +1,8 @@
 /* global AbortSignal */
 import { execa, type ExecaChildProcess } from 'execa'
 import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 import { logger } from './logger.js'
@@ -61,6 +63,7 @@ export interface ClaudeCliOptions {
 	branchName?: string // Optional branch name for terminal coloring
 	port?: number // Optional port for terminal window export
 	timeout?: number // Timeout in milliseconds
+	systemPrompt?: string // Full system prompt (replaces default, use with --bare)
 	appendSystemPrompt?: string // System instructions to append to system prompt
 	appendSystemPromptFile?: string // Path to file containing system instructions
 	mcpConfig?: Record<string, unknown>[] // Array of MCP server configurations
@@ -81,6 +84,7 @@ export interface ClaudeCliOptions {
 	env?: Record<string, string> // Additional environment variables to pass to the Claude process
 	signal?: AbortSignal // Optional AbortSignal for graceful termination of the Claude process
 	bare?: boolean // Minimal mode: skip hooks, LSP, plugins, CLAUDE.md auto-discovery. Requires ANTHROPIC_API_KEY (disables OAuth/keychain).
+	settings?: string // JSON settings string for --settings flag (e.g., '{"apiKeyHelper": "echo TOKEN"}')
 }
 
 /**
@@ -153,105 +157,133 @@ export async function launchClaude(
 	prompt: string,
 	options: ClaudeCliOptions = {}
 ): Promise<string | void> {
-	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, effort, env: extraEnv, signal, bare } = options
+	const { model, permissionMode, addDir, headless = false, systemPrompt, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, effort, env: extraEnv, signal, bare, settings } = options
 	const log = getLogger()
 
-	// Build command arguments
-	const args: string[] = []
+	// Resolve bare mode configuration
+	let effectiveBare = bare ?? false
+	let effectiveSettings = settings
+	let bareModeAutoApplied = false
+	let oauthToken: string | undefined
 
 	// Auto-apply bare mode for headless utility operations when not explicitly set
-	const effectiveBare = bare ?? (headless && noSessionPersistence ? shouldUseBareMode() : false)
-
-	if (effectiveBare) {
-		args.push('--bare')
+	if (bare === undefined && headless && noSessionPersistence) {
+		const config = await resolveBareModeConfig()
+		effectiveBare = config.bare
+		effectiveSettings ??= config.settings
+		oauthToken = config.oauthToken
+		bareModeAutoApplied = config.bare // track that WE decided to use bare
 	}
 
-	if (headless) {
-		args.push('-p')
-
-		// Use user-provided outputFormat or default to stream-json for progress tracking
-		const effectiveOutputFormat = outputFormat ?? 'stream-json'
-		args.push('--output-format', effectiveOutputFormat)
-
-		// Use user-provided verbose setting or default to true
-		if (verbose !== false) {
-			args.push('--verbose')
-		}
+	// When caller explicitly sets bare:true without settings, resolve OAuth settings too
+	if (bare === true && !effectiveSettings) {
+		const config = await resolveBareModeConfig()
+		effectiveSettings ??= config.settings
+		oauthToken = config.oauthToken
+		// bareModeAutoApplied stays false - caller explicitly requested bare
 	}
 
-	if (model) {
-		args.push('--model', model)
-	}
-
-	if (effort) {
-		args.push('--effort', effort)
-	}
-
-	if (permissionMode && permissionMode !== 'default') {
-		args.push('--permission-mode', permissionMode)
-	}
-
-	if (addDir) {
-		args.push('--add-dir', addDir)
-	}
-
-	args.push('--add-dir', '/tmp') //TODO: Won't work on Windows
-
-	// Add system prompt flag
-	if (appendSystemPrompt) {
-		args.push('--append-system-prompt', appendSystemPrompt)
-	}
-
-	// Add system prompt file flag
-	if (appendSystemPromptFile) {
-		args.push('--append-system-prompt-file', appendSystemPromptFile)
-	}
-
-	// Add --mcp-config flags for each MCP server configuration
-	if (mcpConfig && mcpConfig.length > 0) {
-		for (const config of mcpConfig) {
-			args.push('--mcp-config', JSON.stringify(config))
-		}
-	}
-
-	// Add --allowed-tools flags if provided
-	if (allowedTools && allowedTools.length > 0) {
-		args.push('--allowed-tools', ...allowedTools)
-	}
-
-	// Add --disallowed-tools flags if provided
-	if (disallowedTools && disallowedTools.length > 0) {
-		args.push('--disallowed-tools', ...disallowedTools)
-	}
-
-	// Add --agents flag if provided
-	if (agents) {
-		args.push('--agents', JSON.stringify(agents))
-	}
-
-	// Add --plugin-dir flag if provided
-	if (pluginDir) {
-		args.push('--plugin-dir', pluginDir)
-	}
-
-	// Add --session-id flag if provided (enables Claude Code session resume)
-	if (sessionId) {
-		args.push('--session-id', sessionId)
-	}
 	const isDebugMode = logger.isDebugEnabled()
-
-	if (isDebugMode) {
-		args.push('--debug') // Enable debug mode for more detailed logs
-	}
-
-	// Add --no-session-persistence flag if requested (for utility operations that don't need session persistence)
-	// Note: --no-session-persistence can only be used with --print mode (-p), which is only added in headless mode
-	if (noSessionPersistence && headless) {
-		args.push('--no-session-persistence')
-	}
 
 	// Set CLAUDECODE=0 to prevent Claude from detecting it's running inside Claude Code
 	const claudeEnv = { ...process.env, CLAUDECODE: '0' }
+
+	// Helper to build common args (avoids duplication between attempts)
+	function buildBaseArgs(includeBare: boolean): string[] {
+		const args: string[] = []
+
+		if (includeBare && effectiveBare) {
+			args.push('--bare')
+		}
+
+		if (includeBare && effectiveSettings) {
+			args.push('--settings', effectiveSettings)
+		}
+
+		if (headless) {
+			args.push('-p')
+			const effectiveOutputFormat = outputFormat ?? 'stream-json'
+			args.push('--output-format', effectiveOutputFormat)
+			if (verbose !== false) {
+				args.push('--verbose')
+			}
+		}
+
+		if (model) {
+			args.push('--model', model)
+		}
+
+		if (effort) {
+			args.push('--effort', effort)
+		}
+
+		if (permissionMode && permissionMode !== 'default') {
+			args.push('--permission-mode', permissionMode)
+		}
+
+		if (addDir) {
+			args.push('--add-dir', addDir)
+		}
+
+		args.push('--add-dir', '/tmp') //TODO: Won't work on Windows
+
+		if (systemPrompt) {
+			args.push('--system-prompt', systemPrompt)
+		}
+
+		if (appendSystemPrompt) {
+			args.push('--append-system-prompt', appendSystemPrompt)
+		}
+
+		if (appendSystemPromptFile) {
+			args.push('--append-system-prompt-file', appendSystemPromptFile)
+		}
+
+		if (mcpConfig && mcpConfig.length > 0) {
+			for (const config of mcpConfig) {
+				args.push('--mcp-config', JSON.stringify(config))
+			}
+		}
+
+		if (allowedTools && allowedTools.length > 0) {
+			args.push('--allowed-tools', ...allowedTools)
+		}
+
+		if (disallowedTools && disallowedTools.length > 0) {
+			args.push('--disallowed-tools', ...disallowedTools)
+		}
+
+		if (agents) {
+			args.push('--agents', JSON.stringify(agents))
+		}
+
+		if (pluginDir) {
+			args.push('--plugin-dir', pluginDir)
+		}
+
+		if (sessionId) {
+			args.push('--session-id', sessionId)
+		}
+
+		if (isDebugMode) {
+			args.push('--debug')
+		}
+
+		if (noSessionPersistence && headless) {
+			args.push('--no-session-persistence')
+		}
+
+		return args
+	}
+
+	// Build environment with optional OAuth token
+	function buildEnv(includeBareEnv: boolean): Record<string, string | undefined> {
+		const env: Record<string, string | undefined> = { ...claudeEnv, ...extraEnv }
+		if (includeBareEnv && oauthToken) {
+			env.__ILOOM_OAUTH_TOKEN = oauthToken
+		}
+		return env
+	}
 
 	// Helper to attach AbortSignal to a subprocess for graceful termination
 	function attachAbortSignal(subprocess: ExecaChildProcess): void {
@@ -265,292 +297,227 @@ export async function launchClaude(
 		})
 	}
 
-	try {
-		if (headless && passthroughStdout) {
-			// Headless + passthrough: Claude's stdout goes directly to process.stdout
-			// Used for --json-stream where JSONL must reach the caller's stdout
-			const subprocess = execa('claude', args, {
-				input: prompt,
-				timeout: 0,
-				...(addDir && { cwd: addDir }),
-				env: { ...claudeEnv, ...extraEnv }, // CLAUDECODE=0 + any extra env vars
-				stdio: ['pipe', 'inherit', 'pipe'], // stdin: pipe (for prompt), stdout: inherit (passthrough), stderr: pipe (capture errors)
-			})
+	// Helper to redact --settings content from error messages to avoid token leakage
+	function redactSettings(msg: string): string {
+		return msg.replace(/--settings\s+'[^']*'/g, "--settings '[REDACTED]'")
+			.replace(/--settings\s+"[^"]*"/g, '--settings "[REDACTED]"')
+			.replace(/--settings\s+\S+/g, '--settings [REDACTED]')
+	}
 
-			attachAbortSignal(subprocess)
-			try {
-				await subprocess
-			} catch (err) {
-				if (signal?.aborted) return
-				throw err
-			}
-			return // No output to return - it went directly to stdout
+	// Helper to run headless subprocess and handle output streaming
+	async function runHeadlessSubprocess(args: string[], env: Record<string, string | undefined>): Promise<string | void> {
+		const execaOptions = {
+			input: prompt,
+			timeout: 0,
+			...(addDir && { cwd: addDir }),
+			verbose: isDebugMode,
+			env,
+			...(isDebugMode && { stdio: ['pipe', 'pipe', 'pipe'] as const }),
 		}
 
-		if (headless) {
-			// Headless mode: capture and return output
+		const subprocess = execa('claude', args, execaOptions)
+		attachAbortSignal(subprocess)
 
-			// Set up execa options based on debug mode
-			const execaOptions = {
-				input: prompt,
-				timeout: 0, // Disable timeout for long responses
-				...(addDir && { cwd: addDir }), // Run Claude in the worktree directory
-				verbose: isDebugMode,
-				env: { ...claudeEnv, ...extraEnv }, // CLAUDECODE=0 + any extra env vars
-				...(isDebugMode && { stdio: ['pipe', 'pipe', 'pipe'] as const }), // Enable streaming in debug mode
-			}
+		const isJsonStreamFormat = args.includes('--output-format') && args.includes('stream-json')
 
-			const subprocess = execa('claude', args, execaOptions)
-			attachAbortSignal(subprocess)
+		let outputBuffer = ''
+		let isStreaming = false
+		let isFirstProgress = true
+		if (subprocess.stdout && typeof subprocess.stdout.on === 'function') {
+			isStreaming = true
+			subprocess.stdout.on('data', (chunk: Buffer) => {
+				const text = chunk.toString()
+				outputBuffer += text
 
-			// Check if JSON streaming format is enabled (always true in headless mode)
-			const isJsonStreamFormat = args.includes('--output-format') && args.includes('stream-json')
-
-			// Handle real-time streaming (enabled for progress tracking)
-			let outputBuffer = ''
-			let isStreaming = false
-			let isFirstProgress = true
-			if (subprocess.stdout && typeof subprocess.stdout.on === 'function') {
-				isStreaming = true
-				subprocess.stdout.on('data', (chunk: Buffer) => {
-					const text = chunk.toString()
-					outputBuffer += text
-
-					if (jsonMode === 'stream') {
-						// --json-stream: Output raw JSONL to stdout immediately
-						process.stdout.write(text)
-					} else if (jsonMode === 'json') {
-						// --json: Suppress all progress output (will return final JSON)
-						// Do nothing - just accumulate in buffer
-					} else if (isDebugMode) {
-						log.stdout.write(text) // Full JSON streaming in debug mode
-					} else {
-						// Progress dots in non-debug mode with robot emoji prefix
-						if (isFirstProgress) {
-							log.stdout.write('🤖 .')
-							isFirstProgress = false
-						} else {
-							log.stdout.write('.')
-						}
-					}
-				})
-			}
-
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			let result: any
-			try {
-				result = await subprocess
-			} catch (subprocessError) {
-				// If aborted intentionally, do not treat as an error
-				if (signal?.aborted) return
-				throw subprocessError
-			}
-
-			// Return streamed output if we were streaming, otherwise use result.stdout
-			if (isStreaming) {
-				const rawOutput = outputBuffer.trim()
-
-				// Clean up progress dots with newline in non-debug mode (skip for json modes)
-				if (!isDebugMode && !jsonMode) {
-					log.stdout.write('\n')
-				}
-
-				return isJsonStreamFormat ? parseJsonStreamOutput(rawOutput) : rawOutput
-			} else {
-				// Fallback for mocked tests or when streaming not available
-				if (isDebugMode) {
-					// In debug mode, write to stdout even if not streaming (old behavior for tests)
-					log.stdout.write(result.stdout)
-					if (result.stdout && !result.stdout.endsWith('\n')) {
-						log.stdout.write('\n')
-					}
+				if (jsonMode === 'stream') {
+					process.stdout.write(text)
+				} else if (jsonMode === 'json') {
+					// Suppress progress output for json mode
+				} else if (isDebugMode) {
+					log.stdout.write(text)
 				} else {
-					// In non-debug mode, show a single progress dot even without streaming (for tests)
-					log.stdout.write('🤖 .')
+					if (isFirstProgress) {
+						log.stdout.write('🤖 .')
+						isFirstProgress = false
+					} else {
+						log.stdout.write('.')
+					}
+				}
+			})
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let result: any
+		try {
+			result = await subprocess
+		} catch (subprocessError) {
+			if (signal?.aborted) return
+			throw subprocessError
+		}
+
+		if (isStreaming) {
+			const rawOutput = outputBuffer.trim()
+			if (!isDebugMode && !jsonMode) {
+				log.stdout.write('\n')
+			}
+			return isJsonStreamFormat ? parseJsonStreamOutput(rawOutput) : rawOutput
+		} else {
+			if (isDebugMode) {
+				log.stdout.write(result.stdout)
+				if (result.stdout && !result.stdout.endsWith('\n')) {
 					log.stdout.write('\n')
 				}
-				const rawOutput = result.stdout.trim()
-				return isJsonStreamFormat ? parseJsonStreamOutput(rawOutput) : rawOutput
+			} else {
+				log.stdout.write('🤖 .')
+				log.stdout.write('\n')
 			}
-		} else {
-			// Simple interactive mode: run Claude in current terminal with stdio inherit
-			// Used for conflict resolution, error fixing, etc.
-			// This is the simple approach: claude -- "prompt"
+			const rawOutput = result.stdout.trim()
+			return isJsonStreamFormat ? parseJsonStreamOutput(rawOutput) : rawOutput
+		}
+	}
 
-			// First attempt: capture stderr to detect session ID conflicts
-			// stdin/stdout inherit for interactivity, stderr captured for error detection
+	// Handle headless + passthrough mode (separate path, no retry)
+	if (headless && passthroughStdout) {
+		const args = buildBaseArgs(true)
+		const subprocess = execa('claude', args, {
+			input: prompt,
+			timeout: 0,
+			...(addDir && { cwd: addDir }),
+			env: buildEnv(true),
+			stdio: ['pipe', 'inherit', 'pipe'],
+		})
+
+		attachAbortSignal(subprocess)
+		try {
+			await subprocess
+		} catch (err) {
+			if (signal?.aborted) return
+			throw err
+		}
+		return
+	}
+
+	// Handle headless mode with retry loop (max 2 attempts)
+	if (headless) {
+		const maxAttempts = bareModeAutoApplied ? 2 : 1
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			const useBare = attempt === 1
+			const args = buildBaseArgs(useBare)
+			const env = buildEnv(useBare)
+
 			try {
-				const interactiveSubprocess = execa('claude', [...args, '--', prompt], {
-					...(addDir && { cwd: addDir }),
-					stdio: ['inherit', 'inherit', 'pipe'], // Capture stderr to detect session conflicts
-					timeout: 0, // Disable timeout
-					verbose: logger.isDebugEnabled(),
-					env: { ...claudeEnv, ...extraEnv }, // CLAUDECODE=0 + any extra env vars
-				})
-				attachAbortSignal(interactiveSubprocess)
-				try {
-					await interactiveSubprocess
-				} catch (err) {
-					if (signal?.aborted) return
-					throw err
-				}
-				return
-			} catch (interactiveError) {
+				return await runHeadlessSubprocess(args, env)
+			} catch (error) {
 				if (signal?.aborted) return
-				const interactiveExecaError = interactiveError as { stderr?: string; message?: string }
+
+				const execaError = error as { stderr?: string; message?: string; exitCode?: number }
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
-				const interactiveErrorMessage = interactiveExecaError.stderr || interactiveExecaError.message || ''
+				const rawErrorMessage = execaError.stderr || execaError.message || 'Unknown Claude CLI error'
+				const errorMessage = redactSettings(rawErrorMessage)
 
-				// Check for session ID conflict
-				const sessionMatch = interactiveErrorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
-				const conflictSessionId = sessionMatch?.[1]
-				if (sessionMatch && sessionId && conflictSessionId) {
-					log.debug(`Session ID ${conflictSessionId} already in use, retrying with --resume`)
+				// On first attempt with auto-applied bare mode, check for auth failure and retry
+				if (attempt === 1 && bareModeAutoApplied) {
+					const isAuthError = /not logged in|unauthorized|authentication|invalid api key|Could not resolve credentials/i.test(rawErrorMessage)
+					if (isAuthError) {
+						logger.warn('Bare mode failed (likely expired OAuth token), retrying without --bare')
+						continue // Retry without bare on next iteration
+					}
+				}
 
-					// Rebuild args with --resume instead of --session-id
+				// Check for "Session ID ... is already in use" error and retry with --resume
+				const sessionInUseMatch = errorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
+				const extractedSessionId = sessionInUseMatch?.[1]
+				if (sessionInUseMatch && sessionId && extractedSessionId) {
+					log.debug(`Session ID ${extractedSessionId} already in use, retrying with --resume`)
+
+					// Build clean args with --resume instead of --session-id
 					const resumeArgs = args.filter((arg, idx) => {
 						if (arg === '--session-id') return false
 						if (idx > 0 && args[idx - 1] === '--session-id') return false
 						return true
 					})
-					resumeArgs.push('--resume', conflictSessionId)
+					resumeArgs.push('--resume', extractedSessionId)
 
-					// Retry with full stdio inherit for proper interactive experience
-					// Note: When using --resume, we omit the prompt since the session already has context
-					const resumeSubprocess = execa('claude', resumeArgs, {
-						...(addDir && { cwd: addDir }),
-						stdio: 'inherit',
-						timeout: 0,
-						verbose: logger.isDebugEnabled(),
-						env: claudeEnv,
-					})
-					attachAbortSignal(resumeSubprocess)
 					try {
-						await resumeSubprocess
-					} catch (err) {
-						if (signal?.aborted) return
-						throw err
+						return await runHeadlessSubprocess(resumeArgs, env)
+					} catch (retryError) {
+						const retryExecaError = retryError as { stderr?: string; message?: string }
+						// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
+						const retryErrorMessage = retryExecaError.stderr || retryExecaError.message || 'Unknown Claude CLI error'
+						throw new Error(`Claude CLI error: ${redactSettings(retryErrorMessage)}`)
 					}
-					return
 				}
 
-				// Not a session conflict, re-throw
-				throw interactiveError
+				throw new Error(`Claude CLI error: ${errorMessage}`)
 			}
 		}
-	} catch (error) {
-		// If aborted intentionally, do not treat as an error
-		if (signal?.aborted) return
+		return
+	}
 
-		// Check for specific Claude CLI errors
-		const execaError = error as {
-			stderr?: string
-			message?: string
-			exitCode?: number
+	// Interactive mode: run Claude in current terminal with stdio inherit
+	// Used for conflict resolution, error fixing, etc.
+	const args = buildBaseArgs(true)
+
+	try {
+		const interactiveSubprocess = execa('claude', [...args, '--', prompt], {
+			...(addDir && { cwd: addDir }),
+			stdio: ['inherit', 'inherit', 'pipe'],
+			timeout: 0,
+			verbose: logger.isDebugEnabled(),
+			env: buildEnv(true),
+		})
+		attachAbortSignal(interactiveSubprocess)
+		try {
+			await interactiveSubprocess
+		} catch (err) {
+			if (signal?.aborted) return
+			throw err
 		}
-
+		return
+	} catch (interactiveError) {
+		if (signal?.aborted) return
+		const interactiveExecaError = interactiveError as { stderr?: string; message?: string }
 		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
-		const errorMessage = execaError.stderr || execaError.message || 'Unknown Claude CLI error'
+		const interactiveErrorMessage = interactiveExecaError.stderr || interactiveExecaError.message || ''
 
-		// Check for "Session ID ... is already in use" error and retry with --resume
-		const sessionInUseMatch = errorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
-		const extractedSessionId = sessionInUseMatch?.[1]
-		if (sessionInUseMatch && sessionId && extractedSessionId) {
-			log.debug(`Session ID ${extractedSessionId} already in use, retrying with --resume`)
+		// Check for session ID conflict
+		const sessionMatch = interactiveErrorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
+		const conflictSessionId = sessionMatch?.[1]
+		if (sessionMatch && sessionId && conflictSessionId) {
+			log.debug(`Session ID ${conflictSessionId} already in use, retrying with --resume`)
 
 			// Rebuild args with --resume instead of --session-id
 			const resumeArgs = args.filter((arg, idx) => {
-				// Filter out --session-id and its value
 				if (arg === '--session-id') return false
 				if (idx > 0 && args[idx - 1] === '--session-id') return false
 				return true
 			})
-			resumeArgs.push('--resume', extractedSessionId)
+			resumeArgs.push('--resume', conflictSessionId)
 
+			// Retry with full stdio inherit for proper interactive experience
+			const resumeSubprocess = execa('claude', resumeArgs, {
+				...(addDir && { cwd: addDir }),
+				stdio: 'inherit',
+				timeout: 0,
+				verbose: logger.isDebugEnabled(),
+				env: claudeEnv,
+			})
+			attachAbortSignal(resumeSubprocess)
 			try {
-				if (headless) {
-					const isDebugMode = logger.isDebugEnabled()
-					// Note: In headless mode, we still need to pass the prompt even with --resume
-					// because there's no interactive input mechanism
-					const execaOptions = {
-						input: prompt,
-						timeout: 0,
-						...(addDir && { cwd: addDir }),
-						verbose: isDebugMode,
-						env: claudeEnv,
-						...(isDebugMode && { stdio: ['pipe', 'pipe', 'pipe'] as const }),
-					}
-
-					const subprocess = execa('claude', resumeArgs, execaOptions)
-					const isJsonStreamFormat = resumeArgs.includes('--output-format') && resumeArgs.includes('stream-json')
-
-					let outputBuffer = ''
-					let isStreaming = false
-					let isFirstProgress = true
-					if (subprocess.stdout && typeof subprocess.stdout.on === 'function') {
-						isStreaming = true
-						subprocess.stdout.on('data', (chunk: Buffer) => {
-							const text = chunk.toString()
-							outputBuffer += text
-							if (jsonMode === 'stream') {
-								process.stdout.write(text)
-							} else if (jsonMode === 'json') {
-								// Suppress progress output for json mode
-							} else if (isDebugMode) {
-								log.stdout.write(text)
-							} else {
-								if (isFirstProgress) {
-									log.stdout.write('🤖 .')
-									isFirstProgress = false
-								} else {
-									log.stdout.write('.')
-								}
-							}
-						})
-					}
-
-					const result = await subprocess
-
-					if (isStreaming) {
-						const rawOutput = outputBuffer.trim()
-						if (!isDebugMode && !jsonMode) {
-							log.stdout.write('\n')
-						}
-						return isJsonStreamFormat ? parseJsonStreamOutput(rawOutput) : rawOutput
-					} else {
-						if (isDebugMode) {
-							log.stdout.write(result.stdout)
-							if (result.stdout && !result.stdout.endsWith('\n')) {
-								log.stdout.write('\n')
-							}
-						} else {
-							log.stdout.write('🤖 .')
-							log.stdout.write('\n')
-						}
-						const rawOutput = result.stdout.trim()
-						return isJsonStreamFormat ? parseJsonStreamOutput(rawOutput) : rawOutput
-					}
-				} else {
-					// Note: When using --resume, we omit the prompt since the session already has context
-					await execa('claude', resumeArgs, {
-						...(addDir && { cwd: addDir }),
-						stdio: 'inherit',
-						timeout: 0,
-						verbose: logger.isDebugEnabled(),
-						env: claudeEnv,
-					})
-					return
-				}
-			} catch (retryError) {
-				const retryExecaError = retryError as { stderr?: string; message?: string }
-				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
-				const retryErrorMessage = retryExecaError.stderr || retryExecaError.message || 'Unknown Claude CLI error'
-				throw new Error(`Claude CLI error: ${retryErrorMessage}`)
+				await resumeSubprocess
+			} catch (err) {
+				if (signal?.aborted) return
+				throw err
 			}
+			return
 		}
 
-		// Re-throw with more context
-		throw new Error(`Claude CLI error: ${errorMessage}`)
+		// Not a session conflict - redact any settings content and re-throw
+		const redactedMessage = redactSettings(interactiveErrorMessage)
+		if (redactedMessage !== interactiveErrorMessage) {
+			throw new Error(`Claude CLI error: ${redactedMessage}`)
+		}
+		throw interactiveError
 	}
 }
 
@@ -615,11 +582,108 @@ export async function launchClaudeInNewTerminalWindow(
 }
 
 /**
- * Check if --bare mode can be used.
+ * Extract an OAuth access token from Claude Code's credential stores.
+ *
+ * Checks in order:
+ * 1. CLAUDE_CODE_OAUTH_TOKEN env var (fastest, used in CI)
+ * 2. macOS Keychain via `security find-generic-password` (darwin only)
+ * 3. ~/.claude/.credentials.json (Linux and other platforms)
+ *
+ * Returns the token string, or null if unavailable/expired/error.
+ */
+export async function extractOAuthToken(): Promise<string | null> {
+	try {
+		// 1. Check CLAUDE_CODE_OAUTH_TOKEN env var (fastest path, used in CI/Actions)
+		const envToken = process.env.CLAUDE_CODE_OAUTH_TOKEN?.trim()
+		if (envToken) {
+			logger.debug('Using OAuth token from CLAUDE_CODE_OAUTH_TOKEN env var')
+			return envToken
+		}
+
+		let credentialsJson: string
+
+		if (process.platform === 'darwin') {
+			// 2. macOS: read from Keychain
+			const username = process.env.USER ?? process.env.LOGNAME ?? 'unknown'
+			const result = await execa('security', [
+				'find-generic-password',
+				'-s', 'Claude Code-credentials',
+				'-a', username,
+				'-w',
+			], { timeout: 3000 })
+			credentialsJson = result.stdout.trim()
+		} else {
+			// 3. Linux/other: read from credentials file
+			const credentialsPath = join(homedir(), '.claude', '.credentials.json')
+			credentialsJson = await readFile(credentialsPath, 'utf-8')
+		}
+
+		const credentials = JSON.parse(credentialsJson)
+		const oauth = credentials?.claudeAiOauth
+		if (!oauth?.accessToken) {
+			logger.debug('No OAuth access token found in credentials')
+			return null
+		}
+
+		// Check token expiry
+		if (oauth.expiresAt && typeof oauth.expiresAt === 'number') {
+			// Heuristic: if expiresAt < 10 billion, it's in seconds; multiply to get ms
+			const expiresAtMs = oauth.expiresAt < 10_000_000_000
+				? oauth.expiresAt * 1000
+				: oauth.expiresAt
+			// Add 60-second buffer to avoid using tokens about to expire
+			if (expiresAtMs <= Date.now() + 60_000) {
+				logger.debug('OAuth token is expired or expiring within 60s')
+				return null
+			}
+		}
+
+		logger.debug('Extracted OAuth token from credential store')
+		return oauth.accessToken
+	} catch (error) {
+		logger.debug('Failed to extract OAuth token', { error })
+		return null
+	}
+}
+
+/**
+ * Resolve bare mode configuration including OAuth-based apiKeyHelper.
+ *
+ * Priority:
+ * 1. ANTHROPIC_API_KEY set -> { bare: true } (no settings needed)
+ * 2. OAuth token available -> { bare: true, settings: '{"apiKeyHelper": "..."}' }
+ * 3. Neither available -> { bare: false }
+ */
+export async function resolveBareModeConfig(): Promise<{ bare: boolean; settings?: string; oauthToken?: string }> {
+	// Fast path: API key is set, bare mode works natively
+	if (process.env.ANTHROPIC_API_KEY?.trim()) {
+		logger.debug('Bare mode enabled via ANTHROPIC_API_KEY')
+		return { bare: true }
+	}
+
+	// Try OAuth token extraction
+	const token = await extractOAuthToken()
+	if (token) {
+		// Pass token via env var (__ILOOM_OAUTH_TOKEN) instead of embedding in args
+		// to avoid exposing it in `ps aux` output
+		const settings = JSON.stringify({ apiKeyHelper: 'echo $__ILOOM_OAUTH_TOKEN' })
+		logger.debug('Bare mode enabled via OAuth token with apiKeyHelper')
+		return { bare: true, settings, oauthToken: token }
+	}
+
+	logger.debug('No API key or OAuth token available, bare mode disabled')
+	return { bare: false }
+}
+
+/**
+ * Check if an API key is available for --bare mode (synchronous check).
  * Bare mode skips hooks, LSP, plugins, and CLAUDE.md auto-discovery for faster startup.
  * It requires ANTHROPIC_API_KEY since --bare disables OAuth/keychain auth.
+ *
+ * Note: For the full async check that includes OAuth token extraction,
+ * use resolveBareModeConfig() instead.
  */
-export function shouldUseBareMode(): boolean {
+export function hasApiKeyForBareMode(): boolean {
 	return !!process.env.ANTHROPIC_API_KEY?.trim()
 }
 
@@ -666,6 +730,7 @@ Generate a git branch name for the following issue:
 			model,
 			headless: true,
 			noSessionPersistence: true, // Utility operation - don't persist session
+			systemPrompt: 'You are a git branch name generator. Given an issue title and number, generate a branch name following the exact format and constraints provided. Output only the branch name, nothing else. No preamble, analysis, or meta-commentary.',
 		})) as string
 
 		// Normalize to lowercase for consistency (Linear IDs are uppercase but branches should be lowercase)

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -80,6 +80,7 @@ export interface ClaudeCliOptions {
 	effort?: string // Effort level to pass via --effort flag (e.g., 'low', 'high', 'max')
 	env?: Record<string, string> // Additional environment variables to pass to the Claude process
 	signal?: AbortSignal // Optional AbortSignal for graceful termination of the Claude process
+	bare?: boolean // Minimal mode: skip hooks, LSP, plugins, CLAUDE.md auto-discovery. Requires ANTHROPIC_API_KEY (disables OAuth/keychain).
 }
 
 /**
@@ -152,11 +153,18 @@ export async function launchClaude(
 	prompt: string,
 	options: ClaudeCliOptions = {}
 ): Promise<string | void> {
-	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, effort, env: extraEnv, signal } = options
+	const { model, permissionMode, addDir, headless = false, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, effort, env: extraEnv, signal, bare } = options
 	const log = getLogger()
 
 	// Build command arguments
 	const args: string[] = []
+
+	// Auto-apply bare mode for headless utility operations when not explicitly set
+	const effectiveBare = bare ?? (headless && noSessionPersistence ? shouldUseBareMode() : false)
+
+	if (effectiveBare) {
+		args.push('--bare')
+	}
 
 	if (headless) {
 		args.push('-p')
@@ -604,6 +612,15 @@ export async function launchClaudeInNewTerminalWindow(
 		includeEnvSetup: hasEnvFile, // source .env only if it exists
 		...(port !== undefined && { port, includePortExport: true }),
 	})
+}
+
+/**
+ * Check if --bare mode can be used.
+ * Bare mode skips hooks, LSP, plugins, and CLAUDE.md auto-discovery for faster startup.
+ * It requires ANTHROPIC_API_KEY since --bare disables OAuth/keychain auth.
+ */
+export function shouldUseBareMode(): boolean {
+	return !!process.env.ANTHROPIC_API_KEY?.trim()
 }
 
 /**


### PR DESCRIPTION
Fixes #977

## Implment --bare flag on branch naming and commit message generation claude cli invocations

<details>
<summary>Issue details</summary>

This one is a long shot due to OAUTH issues. If env.ANTHROPIC_API_KEY is undefined, we will have to use the --settings flag to configure apiKeyHelper to return the Oauth token, and if it fails, just fall back to non --bare mode.

From docs:

  --bare                                            Minimal mode: skip hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, and CLAUDE.md auto-discovery. Sets CLAUDE_CODE_SIMPLE=1. Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read). 3P providers (Bedrock/Vertex/Foundry) use their own credentials. Skills still resolve via /skill-name. Explicitly provide context via: --system-prompt[-file], --append-system-prompt[-file], --add-dir (CLAUDE.md dirs), --mcp-config, --settings, --agents, --plugin-dir.

</details>

---
*This PR was created automatically by iloom.*