### PR TITLE
fix(finish): fall back to GitHubService for PRs on Linear/Jira projects

### DIFF
--- a/src/commands/finish.pr-workflow.test.ts
+++ b/src/commands/finish.pr-workflow.test.ts
@@ -48,6 +48,11 @@ vi.mock('../../src/utils/remote.js', () => ({
 	getConfiguredRepoFromSettings: vi.fn().mockResolvedValue('owner/repo'),
 }))
 
+// Auto-mock the GitHubService module so the fallback path in fetchPullRequest()
+// (used when the configured issue tracker doesn't support PRs, e.g. Linear) can be
+// intercepted via `GitHubService.prototype.fetchPR` without touching the network.
+vi.mock('../../src/lib/GitHubService.js')
+
 // Mock SettingsManager to prevent reading actual settings files
 vi.mock('../../src/lib/SettingsManager.js', () => {
 	return {
@@ -1140,3 +1145,146 @@ describe('FinishCommand - Issue Workflow (Regression Tests)', () => {
 	})
 })
 
+describe('FinishCommand - Linear issue tracker with GitHub PRs', () => {
+	let finishCommand: FinishCommand
+	let mockLinearTracker: {
+		supportsPullRequests: boolean
+		providerName: string
+		fetchIssue: ReturnType<typeof vi.fn>
+		fetchPR?: ReturnType<typeof vi.fn>
+	}
+	let mockGitWorktreeManager: GitWorktreeManager
+	let mockCommitManager: CommitManager
+	let mockMergeManager: MergeManager
+	let mockIdentifierParser: IdentifierParser
+	let mockResourceCleanup: ResourceCleanup
+
+	const mockWorktree: GitWorktree = {
+		path: '/test/worktree/fix-issue-web-2290__add-project-ids-to-analytics_pr_4008',
+		branch: 'fix-issue-web-2290__add-project-ids-to-analytics',
+		commit: 'abc123',
+		bare: false,
+		detached: false,
+		locked: false,
+	}
+
+	beforeEach(() => {
+		// Linear doesn't support PRs; PRs live on GitHub (the VCS)
+		mockLinearTracker = {
+			supportsPullRequests: false,
+			providerName: 'linear',
+			fetchIssue: vi.fn(),
+			// Note: no fetchPR on Linear
+		}
+
+		mockGitWorktreeManager = {
+			findWorktreeForPR: vi.fn().mockResolvedValue(mockWorktree),
+			findWorktreeForIssue: vi.fn().mockResolvedValue(mockWorktree),
+			findWorktreeForBranch: vi.fn().mockResolvedValue(mockWorktree),
+			getRepoInfo: vi.fn().mockResolvedValue({
+				root: '/test/repo',
+				currentBranch: 'main',
+			}),
+		} as unknown as GitWorktreeManager
+
+		mockCommitManager = {
+			detectUncommittedChanges: vi.fn().mockResolvedValue({
+				hasUncommittedChanges: false,
+				unstagedFiles: [],
+				stagedFiles: [],
+				currentBranch: mockWorktree.branch,
+				isAheadOfRemote: false,
+				isBehindRemote: false,
+			}),
+			commitChanges: vi.fn().mockResolvedValue(undefined),
+		} as unknown as CommitManager
+
+		mockMergeManager = {
+			rebaseOnMain: vi.fn().mockResolvedValue(undefined),
+			performFastForwardMerge: vi.fn().mockResolvedValue(undefined),
+		} as unknown as MergeManager
+
+		mockIdentifierParser = {
+			parseForPatternDetection: vi.fn().mockResolvedValue({
+				type: 'pr',
+				number: 4008,
+				originalInput: '4008',
+			}),
+		} as unknown as IdentifierParser
+
+		mockResourceCleanup = {
+			cleanupWorktree: vi.fn().mockResolvedValue({
+				identifier: '4008',
+				success: true,
+				operations: [],
+				errors: [],
+				rollbackRequired: false,
+			}),
+		} as unknown as ResourceCleanup
+
+		finishCommand = new FinishCommand(
+			mockLinearTracker as unknown as GitHubService,
+			mockGitWorktreeManager,
+			{ runValidations: vi.fn().mockResolvedValue(undefined) } as unknown as ValidationRunner,
+			mockCommitManager,
+			mockMergeManager,
+			mockIdentifierParser,
+			mockResourceCleanup
+		)
+	})
+
+	it('should fall back to GitHubService.fetchPR when issue tracker does not support PRs (numeric identifier)', async () => {
+		const mockOpenPR: PullRequest = {
+			number: 4008,
+			title: 'Add project IDs to analytics',
+			body: '',
+			state: 'open',
+			branch: mockWorktree.branch,
+			baseBranch: 'main',
+			url: 'https://github.com/owner/repo/pull/4008',
+			isDraft: false,
+		}
+
+		const MockedGitHubService = vi.mocked(GitHubService)
+		MockedGitHubService.prototype.fetchPR = vi.fn().mockResolvedValue(mockOpenPR)
+
+		await expect(
+			finishCommand.execute({
+				identifier: '4008',
+				options: { noCleanup: true },
+			})
+		).resolves.not.toThrow()
+
+		// Called twice (once in validateInput, once in execute()'s main branch)
+		expect(MockedGitHubService.prototype.fetchPR).toHaveBeenCalledWith(4008)
+		expect(MockedGitHubService.prototype.fetchPR).toHaveBeenCalledTimes(2)
+		expect(pushBranchToRemote).toHaveBeenCalled()
+	})
+
+	it('should fall back to GitHubService.fetchPR when --pr flag is used on Linear project', async () => {
+		const mockMergedPR: PullRequest = {
+			number: 4008,
+			title: 'Add project IDs to analytics',
+			body: '',
+			state: 'merged',
+			branch: mockWorktree.branch,
+			baseBranch: 'main',
+			url: 'https://github.com/owner/repo/pull/4008',
+			isDraft: false,
+		}
+
+		const MockedGitHubService = vi.mocked(GitHubService)
+		MockedGitHubService.prototype.fetchPR = vi.fn().mockResolvedValue(mockMergedPR)
+
+		await expect(
+			finishCommand.execute({
+				identifier: undefined,
+				options: { pr: 4008, noCleanup: true },
+			})
+		).resolves.not.toThrow()
+
+		expect(MockedGitHubService.prototype.fetchPR).toHaveBeenCalledWith(4008)
+		// PR workflow for merged state triggers cleanup
+		expect(mockResourceCleanup.cleanupWorktree).toHaveBeenCalled()
+	})
+})

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '../utils/logger-context.js'
 import { IssueManagementProviderFactory } from '../mcp/IssueManagementProviderFactory.js'
 import type { IssueTracker } from '../lib/IssueTracker.js'
+import { GitHubService } from '../lib/GitHubService.js'
 import { GitWorktreeManager } from '../lib/GitWorktreeManager.js'
 import { ValidationRunner } from '../lib/ValidationRunner.js'
 import { CommitManager } from '../lib/CommitManager.js'
@@ -59,6 +60,7 @@ export class FinishCommand {
 	private settingsManager: SettingsManager
 	private loomManager?: LoomManager
 	private sessionSummaryService?: SessionSummaryService
+	private githubService: GitHubService | null = null
 
 	constructor(
 		issueTracker: IssueTracker,
@@ -101,6 +103,22 @@ export class FinishCommand {
 		if (loomManager) {
 			this.loomManager = loomManager
 		}
+	}
+
+	/**
+	 * Fetch a PR using the issue tracker if it supports PRs, otherwise fall back to GitHubService.
+	 * Mirrors the pattern used in StartCommand for Linear/Jira projects where PRs live on GitHub.
+	 */
+	private async fetchPullRequest(prNumber: number, repo?: string): Promise<PullRequest> {
+		if (this.issueTracker.supportsPullRequests && this.issueTracker.fetchPR) {
+			return repo === undefined
+				? await this.issueTracker.fetchPR(prNumber)
+				: await this.issueTracker.fetchPR(prNumber, repo)
+		}
+		this.githubService ??= new GitHubService()
+		return repo === undefined
+			? await this.githubService.fetchPR(prNumber)
+			: await this.githubService.fetchPR(prNumber, repo)
 	}
 
 	/**
@@ -274,11 +292,11 @@ export class FinishCommand {
 			if (!parsed.number) {
 				throw new Error('Invalid PR number')
 			}
-			// Check if provider supports PRs before calling PR methods
-			if (!this.issueTracker.supportsPullRequests || !this.issueTracker.fetchPR) {
-				throw new Error('Issue tracker does not support pull requests')
+			const prNumber = typeof parsed.number === 'number' ? parsed.number : Number(parsed.number)
+			if (isNaN(prNumber) || !isFinite(prNumber)) {
+				throw new Error(`Invalid PR number: ${parsed.number}. PR numbers must be numeric.`)
 			}
-			const pr = await this.issueTracker.fetchPR(parsed.number, repo)
+			const pr = await this.fetchPullRequest(prNumber, repo)
 			await this.executePRWorkflow(parsed, input.options, worktree, pr, result)
 		} else {
 			// Execute traditional issue/branch workflow
@@ -493,14 +511,13 @@ export class FinishCommand {
 				if (!parsed.number) {
 					throw new Error('Invalid PR number')
 				}
-
-				// Check if provider supports PRs before calling PR methods
-				if (!this.issueTracker.supportsPullRequests || !this.issueTracker.fetchPR) {
-					throw new Error('Issue tracker does not support pull requests')
+				const prNumber = typeof parsed.number === 'number' ? parsed.number : Number(parsed.number)
+				if (isNaN(prNumber) || !isFinite(prNumber)) {
+					throw new Error(`Invalid PR number: ${parsed.number}. PR numbers must be numeric.`)
 				}
 
-				// Fetch PR from GitHub
-				const pr = await this.issueTracker.fetchPR(parsed.number)
+				// Fetch PR (from issue tracker if supported, otherwise GitHub)
+				const pr = await this.fetchPullRequest(prNumber)
 
 				// For PRs, we allow closed/merged state (cleanup-only mode)
 				// But we still validate it exists


### PR DESCRIPTION
## Summary

- `il finish <pr-number>` on a Linear-configured project failed with `Issue tracker does not support pull requests` because finish guarded the PR path on `issueTracker.supportsPullRequests`.
- For projects that track issues in Linear/Jira but still use GitHub as the VCS, PRs live on GitHub — not on the issue tracker.
- Mirrored the fallback pattern already used by `StartCommand`: when the configured issue tracker doesn't support PRs, fetch the PR via a locally-instantiated `GitHubService`.
- Tightened numeric validation on the parsed PR number in both code paths.

## Test plan

- [x] New unit tests in `finish.pr-workflow.test.ts` cover both entry points on Linear projects:
  - [x] `il finish 4008` (explicit numeric identifier detected as PR via worktree suffix)
  - [x] `il finish --pr 4008` (explicit PR flag)
- [x] Full `finish` suite passes (146/146)
- [x] Verified live on the Linear-configured project that originally failed