### PR TITLE
fix(mcp): add type param to get_comment tool

### DIFF
--- a/src/mcp/issue-management-server.ts
+++ b/src/mcp/issue-management-server.ts
@@ -441,6 +441,10 @@ server.registerTool(
 					'Optional repository in "owner/repo" format or full GitHub URL. ' +
 					'When not provided, uses the current repository. GitHub only.'
 				),
+			type: z
+				.enum(['issue', 'pr'])
+				.optional()
+				.describe('Optional type to route PR comments to GitHub regardless of configured provider'),
 		},
 		outputSchema: {
 			id: z.string().describe('Comment identifier'),
@@ -452,15 +456,15 @@ server.registerTool(
 			updated_at: z.string().optional().describe('Comment last updated timestamp'),
 		},
 	},
-	async ({ commentId, number, repo }: GetCommentInput) => {
-		console.error(`Fetching comment ${commentId} from issue ${number}${repo ? ` in ${repo}` : ''}`)
+	async ({ commentId, number, repo, type }: GetCommentInput) => {
+		console.error(`Fetching comment ${commentId} from ${type === 'pr' ? 'PR' : 'issue'} ${number}${repo ? ` in ${repo}` : ''}`)
 
 		try {
-			const provider = IssueManagementProviderFactory.create(
-				process.env.ISSUE_PROVIDER as IssueProvider,
-				settings
-			)
-			const result = await provider.getComment({ commentId, number, repo })
+			// Route PR comments to GitHub regardless of configured provider
+			// (mirrors create_comment / update_comment behavior for Linear/Jira projects)
+			const providerType = type === 'pr' ? 'github' : (process.env.ISSUE_PROVIDER as IssueProvider)
+			const provider = IssueManagementProviderFactory.create(providerType, settings)
+			const result = await provider.getComment({ commentId, number, repo, type })
 
 			console.error(`Comment fetched successfully: ${result.id}`)
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -68,6 +68,7 @@ export interface GetCommentInput {
 	commentId: string // Comment identifier to fetch
 	number: string // Issue or PR identifier (context for providers that need it)
 	repo?: string | undefined // Optional repository in "owner/repo" format or full GitHub URL (GitHub only)
+	type?: 'issue' | 'pr' | undefined // Optional type to route PR comments to GitHub regardless of configured provider
 }
 
 /**


### PR DESCRIPTION
## Summary

- `get_comment` MCP tool had no `type` param, so on Linear/Jira projects it always routed to the configured issue provider and failed when given a GitHub PR comment ID.
- Added optional `type: 'issue' | 'pr'` param that force-routes PR comments to the GitHub provider regardless of `ISSUE_PROVIDER`, mirroring the existing pattern in `create_comment` and `update_comment`.

## Test plan

- [x] `pnpm compile` clean
- [x] `pnpm vitest run src/mcp` — all 181 MCP tests pass
- [x] Pre-commit hooks (lint + typecheck + tests + build) pass