### PR TITLE
Plan: Configurable default labels for issue tracker integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,13 +42,14 @@ coverage/
 *.tmp
 *.temp
 .cache/
+tmp/
 
 # Logs
 logs/
 *.log
 
-tmp/
-.vscode/
+# AI
+.claude/settings.local.json
 
 # Added by iloom CLI
 .iloom/settings.local.json

--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -2272,6 +2272,15 @@ il init "configure neon database with project ID abc-123"
 - Base port for development servers
 - Environment variable names
 
+**GitHub Advanced Settings:**
+
+The following GitHub settings can be configured in `.iloom/settings.json` under `issueManagement.github`:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `remote` | string | `"origin"` | Git remote name used for GitHub operations |
+| `defaultLabels` | string[] | `[]` | Labels to automatically apply to issues created by iloom agents. Merged with any labels the agent supplies (configured first, then agent-supplied, case-sensitive dedupe). Example: `["ai-generated", "needs-triage"]`. Labels must already exist on the target repository — `gh` errors if an unknown label is supplied. |
+
 **Jira Advanced Settings:**
 
 The following Jira settings can be configured in `.iloom/settings.json` under `issueManagement.jira`:
@@ -2287,6 +2296,7 @@ The following Jira settings can be configured in `.iloom/settings.json` under `i
 | `defaultIssueType` | string | `"Task"` | Issue type name for creating issues (e.g., `"Task"`, `"Story"`, `"Bug"`) |
 | `defaultSubtaskType` | string | `"Subtask"` | Issue type name for creating child issues (e.g., `"Subtask"`, `"Sub-task"`) |
 | `doneStatuses` | string[] | `["Done"]` | Status names to exclude from `il issues` output |
+| `defaultLabels` | string[] | `[]` | Labels to automatically apply to issues created by iloom agents. Merged with any labels the agent supplies (configured first, then agent-supplied, case-sensitive dedupe). Example: `["ai-generated", "needs-triage"]`. Jira labels cannot contain whitespace — iloom rejects offending labels with a clear error before calling the API. |
 
 **Note:** Different Jira instances may use different issue type names. If issue creation fails with a 400 error, check your Jira project's available issue types and configure `defaultIssueType` and `defaultSubtaskType` accordingly.
 

--- a/src/lib/SettingsManager.defaultLabels.test.ts
+++ b/src/lib/SettingsManager.defaultLabels.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { IloomSettingsSchema, IloomSettingsSchemaNoDefaults } from './SettingsManager.js'
+
+/**
+ * Focused tests for the `defaultLabels` Zod schema additions on
+ * issueManagement.github and issueManagement.jira.
+ *
+ * Covers both the main schema (which applies defaults) and the non-defaulting
+ * variant used during pre-merge validation — the dual-schema pattern is easy
+ * to get wrong, so we explicitly assert behavior on both.
+ */
+
+describe('IloomSettingsSchema - github.defaultLabels', () => {
+	it('accepts a valid array of label strings', () => {
+		const parsed = IloomSettingsSchema.parse({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: ['ai-generated', 'needs-triage'],
+				},
+			},
+		})
+		expect(parsed.issueManagement?.github?.defaultLabels).toEqual([
+			'ai-generated',
+			'needs-triage',
+		])
+	})
+
+	it('defaults to [] when omitted', () => {
+		const parsed = IloomSettingsSchema.parse({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+				},
+			},
+		})
+		expect(parsed.issueManagement?.github?.defaultLabels).toEqual([])
+	})
+
+	it('rejects empty-string labels', () => {
+		expect(() =>
+			IloomSettingsSchema.parse({
+				issueManagement: {
+					github: {
+						remote: 'origin',
+						defaultLabels: ['bug', ''],
+					},
+				},
+			})
+		).toThrow()
+	})
+})
+
+describe('IloomSettingsSchema - jira.defaultLabels', () => {
+	const jiraBase = {
+		host: 'https://example.atlassian.net',
+		username: 'user@example.com',
+		apiToken: 'token',
+		projectKey: 'PROJ',
+	}
+
+	it('accepts a valid array of label strings', () => {
+		const parsed = IloomSettingsSchema.parse({
+			issueManagement: {
+				jira: {
+					...jiraBase,
+					defaultLabels: ['ai-generated', 'needs-triage'],
+				},
+			},
+		})
+		expect(parsed.issueManagement?.jira?.defaultLabels).toEqual([
+			'ai-generated',
+			'needs-triage',
+		])
+	})
+
+	it('defaults to [] when omitted', () => {
+		const parsed = IloomSettingsSchema.parse({
+			issueManagement: {
+				jira: jiraBase,
+			},
+		})
+		expect(parsed.issueManagement?.jira?.defaultLabels).toEqual([])
+	})
+
+	it('rejects empty-string labels', () => {
+		expect(() =>
+			IloomSettingsSchema.parse({
+				issueManagement: {
+					jira: {
+						...jiraBase,
+						defaultLabels: ['', 'bug'],
+					},
+				},
+			})
+		).toThrow()
+	})
+})
+
+describe('IloomSettingsSchemaNoDefaults - defaultLabels', () => {
+	// The non-defaulting schema is used on individual settings files before
+	// they are merged. Crucially, it must NOT inject `defaultLabels: []` — that
+	// would pollute the merged result and clobber labels set in a
+	// lower-priority settings file.
+
+	it('leaves github.defaultLabels undefined when omitted', () => {
+		const parsed = IloomSettingsSchemaNoDefaults.parse({
+			issueManagement: {
+				github: { remote: 'origin' },
+			},
+		})
+		expect(parsed.issueManagement?.github?.defaultLabels).toBeUndefined()
+	})
+
+	it('leaves jira.defaultLabels undefined when omitted', () => {
+		const parsed = IloomSettingsSchemaNoDefaults.parse({
+			issueManagement: {
+				jira: {
+					host: 'https://example.atlassian.net',
+					username: 'u',
+					projectKey: 'PROJ',
+				},
+			},
+		})
+		expect(parsed.issueManagement?.jira?.defaultLabels).toBeUndefined()
+	})
+
+	it('still validates non-empty label entries when provided', () => {
+		expect(() =>
+			IloomSettingsSchemaNoDefaults.parse({
+				issueManagement: {
+					github: {
+						remote: 'origin',
+						defaultLabels: ['ok', ''],
+					},
+				},
+			})
+		).toThrow()
+	})
+
+	it('accepts arrays when provided', () => {
+		const parsed = IloomSettingsSchemaNoDefaults.parse({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: ['bug'],
+				},
+			},
+		})
+		expect(parsed.issueManagement?.github?.defaultLabels).toEqual(['bug'])
+	})
+})

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -579,6 +579,14 @@ export const IloomSettingsSchema = z.object({
 						.string()
 						.min(1, 'Remote name cannot be empty')
 						.describe('Git remote name to use for GitHub operations'),
+					defaultLabels: z
+						.array(z.string().min(1, 'Label cannot be empty'))
+						.optional()
+						.default([])
+						.describe(
+							'Labels to automatically apply to issues created by iloom agents. ' +
+								'Labels must already exist on the target GitHub repository; `gh` errors if an unknown label is supplied.'
+						),
 				})
 				.optional(),
 			linear: z
@@ -640,6 +648,14 @@ export const IloomSettingsSchema = z.object({
 						.optional()
 						.default(['Done'])
 						.describe('Status names to exclude from issue lists (e.g., ["Done", "Closed", "Verify"])'),
+					defaultLabels: z
+						.array(z.string().min(1, 'Label cannot be empty'))
+						.optional()
+						.default([])
+						.describe(
+							'Labels to automatically apply to issues created by iloom agents. ' +
+								'Jira labels must not contain whitespace — Jira rejects them with a 400 error.'
+						),
 				})
 				.optional(),
 		})
@@ -873,6 +889,13 @@ export const IloomSettingsSchemaNoDefaults = z.object({
 						.string()
 						.min(1, 'Remote name cannot be empty')
 						.describe('Git remote name to use for GitHub operations'),
+					defaultLabels: z
+						.array(z.string().min(1, 'Label cannot be empty'))
+						.optional()
+						.describe(
+							'Labels to automatically apply to issues created by iloom agents. ' +
+								'Labels must already exist on the target GitHub repository; `gh` errors if an unknown label is supplied.'
+						),
 				})
 				.optional(),
 			linear: z
@@ -932,6 +955,13 @@ export const IloomSettingsSchemaNoDefaults = z.object({
 						.optional()
 						.default(['Done'])
 						.describe('Status names to exclude from issue lists (e.g., ["Done", "Closed", "Verify"])'),
+					defaultLabels: z
+						.array(z.string().min(1, 'Label cannot be empty'))
+						.optional()
+						.describe(
+							'Labels to automatically apply to issues created by iloom agents. ' +
+								'Jira labels must not contain whitespace — Jira rejects them with a 400 error.'
+						),
 				})
 				.optional(),
 		})

--- a/src/lib/providers/jira/JiraApiClient.ts
+++ b/src/lib/providers/jira/JiraApiClient.ts
@@ -314,20 +314,32 @@ export class JiraApiClient {
 	/**
 	 * Create a new issue
 	 * Accepts Markdown description which is converted to ADF for Jira
+	 *
+	 * @param labels Optional array of Jira labels. Only included in the POST body
+	 *   when a non-empty array is supplied, so callers that don't use labels still
+	 *   produce the exact same request shape as before.
 	 */
-	async createIssue(projectKey: string, summary: string, description: string, issueType = 'Task'): Promise<JiraIssue> {
-		return this.post<JiraIssue>('/issue', {
-			fields: {
-				project: {
-					key: projectKey,
-				},
-				summary,
-				description: markdownToAdf(description),
-				issuetype: {
-					name: issueType,
-				},
+	async createIssue(
+		projectKey: string,
+		summary: string,
+		description: string,
+		issueType = 'Task',
+		labels?: string[]
+	): Promise<JiraIssue> {
+		const fields: Record<string, unknown> = {
+			project: {
+				key: projectKey,
 			},
-		})
+			summary,
+			description: markdownToAdf(description),
+			issuetype: {
+				name: issueType,
+			},
+		}
+		if (labels && labels.length > 0) {
+			fields.labels = labels
+		}
+		return this.post<JiraIssue>('/issue', { fields })
 	}
 
 	/**
@@ -350,29 +362,36 @@ export class JiraApiClient {
 	/**
 	 * Create an issue with a parent (subtask or child issue)
 	 * Accepts Markdown description which is converted to ADF for Jira
+	 *
+	 * @param labels Optional array of Jira labels. Only included in the POST body
+	 *   when a non-empty array is supplied, so callers that don't use labels still
+	 *   produce the exact same request shape as before.
 	 */
 	async createIssueWithParent(
 		projectKey: string,
 		summary: string,
 		description: string,
 		parentKey: string,
-		issueType = 'Subtask'
+		issueType = 'Subtask',
+		labels?: string[]
 	): Promise<JiraIssue> {
-		return this.post<JiraIssue>('/issue', {
-			fields: {
-				project: {
-					key: projectKey,
-				},
-				summary,
-				description: markdownToAdf(description),
-				issuetype: {
-					name: issueType,
-				},
-				parent: {
-					key: parentKey,
-				},
+		const fields: Record<string, unknown> = {
+			project: {
+				key: projectKey,
 			},
-		})
+			summary,
+			description: markdownToAdf(description),
+			issuetype: {
+				name: issueType,
+			},
+			parent: {
+				key: parentKey,
+			},
+		}
+		if (labels && labels.length > 0) {
+			fields.labels = labels
+		}
+		return this.post<JiraIssue>('/issue', { fields })
 	}
 
 	/**

--- a/src/lib/providers/jira/JiraIssueTracker.ts
+++ b/src/lib/providers/jira/JiraIssueTracker.ts
@@ -17,6 +17,7 @@ export interface JiraTrackerConfig extends JiraConfig {
 	transitionMappings?: Record<string, string> // Map iloom states to Jira transition names
 	defaultIssueType?: string // Default issue type for creating issues (e.g., "Task", "Story")
 	defaultSubtaskType?: string // Default issue type for creating subtasks (e.g., "Subtask", "Sub-task")
+	defaultLabels?: string[] // Labels to automatically apply when iloom agents create issues
 }
 
 /**
@@ -168,18 +169,20 @@ export class JiraIssueTracker implements IssueTracker {
 		title: string,
 		body: string,
 		_repository?: string,
-		_labels?: string[]
+		labels?: string[]
 	): Promise<{ number: string | number; url: string }> {
-		getLogger().debug('Creating Jira issue', { title, projectKey: this.config.projectKey })
+		getLogger().debug('Creating Jira issue', {
+			title,
+			projectKey: this.config.projectKey,
+			labelCount: labels?.length ?? 0,
+		})
 
-		// Convert markdown body to plain text for Jira description
-		// Note: Jira API expects Atlassian Document Format (ADF)
-		// We use a simplified plain text approach here
 		const jiraIssue = await this.client.createIssue(
 			this.config.projectKey,
 			title,
 			body,
-			this.config.defaultIssueType
+			this.config.defaultIssueType,
+			labels
 		)
 
 		return {

--- a/src/mcp/GitHubIssueManagementProvider.test.ts
+++ b/src/mcp/GitHubIssueManagementProvider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { GitHubIssueManagementProvider, extractNumericIdFromUrl } from './GitHubIssueManagementProvider.js'
 
 // Mock the github utils
@@ -1262,6 +1262,154 @@ describe('GitHubIssueManagementProvider', () => {
 			).rejects.toThrow('Invalid GitHub issue number: invalid. GitHub issue IDs must be numeric.')
 
 			expect(editGhIssue).not.toHaveBeenCalled()
+		})
+	})
+})
+
+describe('GitHubIssueManagementProvider - defaultLabels merging', () => {
+	// Ensure env-var source is clean between tests so we can test both paths
+	// (settings-based and env-var-based) deterministically.
+	const originalEnv = process.env.GITHUB_DEFAULT_LABELS
+
+	beforeEach(() => {
+		delete process.env.GITHUB_DEFAULT_LABELS
+	})
+
+	afterAll(() => {
+		if (originalEnv === undefined) {
+			delete process.env.GITHUB_DEFAULT_LABELS
+		} else {
+			process.env.GITHUB_DEFAULT_LABELS = originalEnv
+		}
+	})
+
+	it('merges configured defaultLabels from settings with agent-supplied labels (createIssue)', async () => {
+		vi.mocked(createIssue).mockResolvedValueOnce({
+			number: 1,
+			url: 'https://github.com/owner/repo/issues/1',
+		})
+
+		const provider = new GitHubIssueManagementProvider({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: ['ai-generated', 'needs-triage'],
+				},
+			},
+		} as unknown as Parameters<typeof GitHubIssueManagementProvider>[0])
+
+		await provider.createIssue({ title: 'T', body: 'B', labels: ['bug'] })
+
+		expect(createIssue).toHaveBeenCalledWith('T', 'B', {
+			labels: ['ai-generated', 'needs-triage', 'bug'],
+			repo: undefined,
+		})
+	})
+
+	it('dedupes overlapping configured and supplied labels (createIssue)', async () => {
+		vi.mocked(createIssue).mockResolvedValueOnce({
+			number: 1,
+			url: 'https://github.com/owner/repo/issues/1',
+		})
+
+		const provider = new GitHubIssueManagementProvider({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: ['bug', 'needs-triage'],
+				},
+			},
+		} as unknown as Parameters<typeof GitHubIssueManagementProvider>[0])
+
+		await provider.createIssue({ title: 'T', body: 'B', labels: ['bug', 'feature'] })
+
+		expect(createIssue).toHaveBeenCalledWith('T', 'B', {
+			labels: ['bug', 'needs-triage', 'feature'],
+			repo: undefined,
+		})
+	})
+
+	it('reads defaultLabels from GITHUB_DEFAULT_LABELS env var when settings are absent', async () => {
+		process.env.GITHUB_DEFAULT_LABELS = JSON.stringify(['from-env'])
+
+		vi.mocked(createIssue).mockResolvedValueOnce({
+			number: 1,
+			url: 'https://github.com/owner/repo/issues/1',
+		})
+
+		const provider = new GitHubIssueManagementProvider()
+
+		await provider.createIssue({ title: 'T', body: 'B', labels: ['bug'] })
+
+		expect(createIssue).toHaveBeenCalledWith('T', 'B', {
+			labels: ['from-env', 'bug'],
+			repo: undefined,
+		})
+	})
+
+	it('does not pass any labels when defaults are unset and agent supplies none (regression)', async () => {
+		vi.mocked(createIssue).mockResolvedValueOnce({
+			number: 1,
+			url: 'https://github.com/owner/repo/issues/1',
+		})
+
+		const provider = new GitHubIssueManagementProvider()
+
+		await provider.createIssue({ title: 'T', body: 'B' })
+
+		expect(createIssue).toHaveBeenCalledWith('T', 'B', {
+			labels: undefined,
+			repo: undefined,
+		})
+	})
+
+	it('merges labels for createChildIssue too', async () => {
+		vi.mocked(getIssueNodeId).mockResolvedValueOnce('I_PARENT')
+		vi.mocked(createIssue).mockResolvedValueOnce({
+			number: 2,
+			url: 'https://github.com/owner/repo/issues/2',
+		})
+		vi.mocked(getIssueNodeId).mockResolvedValueOnce('I_CHILD')
+		vi.mocked(addSubIssue).mockResolvedValueOnce(undefined)
+
+		const provider = new GitHubIssueManagementProvider({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: ['ai-generated'],
+				},
+			},
+		} as unknown as Parameters<typeof GitHubIssueManagementProvider>[0])
+
+		await provider.createChildIssue({
+			parentId: '1',
+			title: 'Child',
+			body: 'B',
+			labels: ['bug'],
+		})
+
+		expect(createIssue).toHaveBeenCalledWith('Child', 'B', {
+			labels: ['ai-generated', 'bug'],
+			repo: undefined,
+		})
+	})
+
+	it('createChildIssue regression: no labels forwarded when none configured or supplied', async () => {
+		vi.mocked(getIssueNodeId).mockResolvedValueOnce('I_PARENT')
+		vi.mocked(createIssue).mockResolvedValueOnce({
+			number: 2,
+			url: 'https://github.com/owner/repo/issues/2',
+		})
+		vi.mocked(getIssueNodeId).mockResolvedValueOnce('I_CHILD')
+		vi.mocked(addSubIssue).mockResolvedValueOnce(undefined)
+
+		const provider = new GitHubIssueManagementProvider()
+
+		await provider.createChildIssue({ parentId: '1', title: 'Child', body: 'B' })
+
+		expect(createIssue).toHaveBeenCalledWith('Child', 'B', {
+			labels: undefined,
+			repo: undefined,
 		})
 	})
 })

--- a/src/mcp/GitHubIssueManagementProvider.ts
+++ b/src/mcp/GitHubIssueManagementProvider.ts
@@ -49,6 +49,21 @@ import {
 	editGhIssue,
 } from '../utils/github.js'
 import { processMarkdownImages } from '../utils/image-processor.js'
+import { mergeLabels, parseLabelsFromEnv } from '../utils/labels.js'
+import type { IloomSettings } from '../lib/SettingsManager.js'
+
+/**
+ * Resolve the configured GitHub default labels from pre-loaded settings or the
+ * GITHUB_DEFAULT_LABELS environment variable (JSON-encoded array).
+ * Settings take precedence when both are present.
+ */
+function resolveGithubDefaultLabels(settings?: IloomSettings): string[] {
+	const fromSettings = settings?.issueManagement?.github?.defaultLabels
+	if (fromSettings && fromSettings.length > 0) {
+		return fromSettings
+	}
+	return parseLabelsFromEnv(process.env.GITHUB_DEFAULT_LABELS, 'GITHUB_DEFAULT_LABELS')
+}
 
 /**
  * GitHub-specific author structure from API
@@ -99,6 +114,19 @@ export function extractNumericIdFromUrl(url: string | null | undefined): string 
 export class GitHubIssueManagementProvider implements IssueManagementProvider {
 	readonly providerName = 'github'
 	readonly issuePrefix = '#'
+
+	private readonly defaultLabels: string[]
+
+	/**
+	 * @param settings Optional pre-loaded iloom settings. When provided,
+	 *   `issueManagement.github.defaultLabels` is used as the source of
+	 *   configured labels. Falls back to the GITHUB_DEFAULT_LABELS env var
+	 *   (JSON-encoded array) so the provider works both in CLI contexts (with
+	 *   settings) and in the MCP server subprocess (env-var bridge).
+	 */
+	constructor(settings?: IloomSettings) {
+		this.defaultLabels = resolveGithubDefaultLabels(settings)
+	}
 
 	/**
 	 * Fetch issue details using gh CLI
@@ -518,12 +546,21 @@ export class GitHubIssueManagementProvider implements IssueManagementProvider {
 
 	/**
 	 * Create a new issue
+	 *
+	 * Merges configured default labels with any agent-supplied labels via the
+	 * shared mergeLabels helper (configured labels come first, case-sensitive
+	 * dedupe). Passes `undefined` to the underlying `gh` helper when the
+	 * merged result is empty so we don't change the `gh` invocation for users
+	 * who haven't configured defaults.
 	 */
 	async createIssue(input: CreateIssueInput): Promise<CreateIssueResult> {
 		const { title, body, labels, repo } = input
 		// teamKey is ignored for GitHub
 
-		const result = await createIssue(title, body, { labels, repo })
+		const merged = mergeLabels(this.defaultLabels, labels ?? [])
+		const mergedLabels = merged.length > 0 ? merged : undefined
+
+		const result = await createIssue(title, body, { labels: mergedLabels, repo })
 
 		// Ensure number is numeric
 		const issueNumber = typeof result.number === 'number'
@@ -539,7 +576,11 @@ export class GitHubIssueManagementProvider implements IssueManagementProvider {
 
 	/**
 	 * Create a child issue linked to a parent issue
-	 * GitHub requires two-step process: create issue, then link via GraphQL
+	 * GitHub requires two-step process: create issue, then link via GraphQL.
+	 *
+	 * Merges configured default labels with any agent-supplied labels via the
+	 * shared mergeLabels helper so child issues get the same default-label
+	 * treatment as standalone issues.
 	 */
 	async createChildIssue(input: CreateChildIssueInput): Promise<CreateIssueResult> {
 		const { parentId, title, body, labels, repo } = input
@@ -554,8 +595,10 @@ export class GitHubIssueManagementProvider implements IssueManagementProvider {
 		// Step 1: Get parent issue's GraphQL node ID
 		const parentNodeId = await getIssueNodeId(parentNumber, repo)
 
-		// Step 2: Create the child issue
-		const childResult = await createIssue(title, body, { labels, repo })
+		// Step 2: Create the child issue (with merged default + supplied labels)
+		const merged = mergeLabels(this.defaultLabels, labels ?? [])
+		const mergedLabels = merged.length > 0 ? merged : undefined
+		const childResult = await createIssue(title, body, { labels: mergedLabels, repo })
 		const childNumber = typeof childResult.number === 'number'
 			? childResult.number
 			: parseInt(String(childResult.number), 10)

--- a/src/mcp/IssueManagementProviderFactory.ts
+++ b/src/mcp/IssueManagementProviderFactory.ts
@@ -20,7 +20,10 @@ export class IssueManagementProviderFactory {
 	static create(provider: IssueProvider, settings?: IloomSettings): IssueManagementProvider {
 		switch (provider) {
 			case 'github':
-				return new GitHubIssueManagementProvider()
+				// Pass settings through so GitHub provider can honor
+				// issueManagement.github.defaultLabels. Env-var fallback
+				// (GITHUB_DEFAULT_LABELS) kicks in when settings is undefined.
+				return new GitHubIssueManagementProvider(settings)
 			case 'linear':
 				return new LinearIssueManagementProvider()
 			case 'jira':

--- a/src/mcp/JiraIssueManagementProvider.test.ts
+++ b/src/mcp/JiraIssueManagementProvider.test.ts
@@ -286,3 +286,183 @@ describe('JiraIssueManagementProvider - dependencies', () => {
 		})
 	})
 })
+
+describe('JiraIssueManagementProvider - createIssue / createChildIssue label merging', () => {
+	let provider: JiraIssueManagementProvider
+	let mockCreateIssue: ReturnType<typeof vi.fn>
+	let mockCreateIssueWithParent: ReturnType<typeof vi.fn>
+	let configuredDefaultLabels: string[] | undefined
+
+	function buildProvider(opts: { defaultLabels?: string[] } = {}) {
+		configuredDefaultLabels = opts.defaultLabels
+		mockCreateIssue = vi.fn().mockResolvedValue({ key: 'PROJ-42' })
+		mockCreateIssueWithParent = vi.fn().mockResolvedValue({ key: 'PROJ-43' })
+
+		const mockApiClient = {
+			createIssue: mockCreateIssue,
+			createIssueWithParent: mockCreateIssueWithParent,
+		}
+
+		const mockTracker = {
+			normalizeIdentifier: (id: string) => id.toUpperCase(),
+			getApiClient: () => mockApiClient,
+			getConfig: () => ({
+				host: 'https://jira.example.com',
+				defaultSubtaskType: 'Subtask',
+				...(configuredDefaultLabels !== undefined && {
+					defaultLabels: configuredDefaultLabels,
+				}),
+			}),
+			// createIssue on the tracker calls the api client.createIssue; emulate that
+			createIssue: (title: string, body: string, _repo?: string, labels?: string[]) => {
+				return mockCreateIssue('PROJ', title, body, undefined, labels).then(
+					(issue: { key: string }) => ({
+						number: issue.key,
+						url: `https://jira.example.com/browse/${issue.key}`,
+					})
+				)
+			},
+		}
+
+		const settings = {
+			issueManagement: {
+				jira: {
+					host: 'https://jira.example.com',
+					username: 'user',
+					apiToken: 'token',
+					projectKey: 'PROJ',
+				},
+			},
+		}
+
+		provider = new JiraIssueManagementProvider(settings as IloomSettings)
+		;(provider as unknown as { tracker: typeof mockTracker }).tracker = mockTracker
+		// projectKey is captured in the constructor from the real config; we need
+		// to update it so createChildIssue uses the expected project key
+		;(provider as unknown as { projectKey: string }).projectKey = 'PROJ'
+	}
+
+	describe('createIssue', () => {
+		it('merges configured defaultLabels with agent-supplied labels (configured first)', async () => {
+			buildProvider({ defaultLabels: ['ai-generated', 'needs-triage'] })
+
+			await provider.createIssue({ title: 'T', body: 'B', labels: ['bug'] })
+
+			// Extract the labels arg (5th positional argument)
+			const labelsArg = mockCreateIssue.mock.calls[0][4]
+			expect(labelsArg).toEqual(['ai-generated', 'needs-triage', 'bug'])
+		})
+
+		it('dedupes overlap between configured and supplied labels', async () => {
+			buildProvider({ defaultLabels: ['bug', 'needs-triage'] })
+
+			await provider.createIssue({ title: 'T', body: 'B', labels: ['bug', 'feature'] })
+
+			const labelsArg = mockCreateIssue.mock.calls[0][4]
+			expect(labelsArg).toEqual(['bug', 'needs-triage', 'feature'])
+		})
+
+		it('rejects labels containing whitespace with a clear error naming the label', async () => {
+			buildProvider({ defaultLabels: ['needs triage'] })
+
+			await expect(
+				provider.createIssue({ title: 'T', body: 'B' })
+			).rejects.toThrow(/"needs triage"/)
+			expect(mockCreateIssue).not.toHaveBeenCalled()
+		})
+
+		it('rejects agent-supplied labels containing whitespace', async () => {
+			buildProvider({ defaultLabels: [] })
+
+			await expect(
+				provider.createIssue({ title: 'T', body: 'B', labels: ['has space'] })
+			).rejects.toThrow(/"has space"/)
+			expect(mockCreateIssue).not.toHaveBeenCalled()
+		})
+
+		it('rejects labels containing commas with a clear error naming the label', async () => {
+			buildProvider({ defaultLabels: ['needs,triage'] })
+
+			await expect(
+				provider.createIssue({ title: 'T', body: 'B' })
+			).rejects.toThrow(/whitespace or commas: "needs,triage"/)
+			expect(mockCreateIssue).not.toHaveBeenCalled()
+		})
+
+		it('passes undefined labels to the API when no labels are configured or supplied (regression)', async () => {
+			buildProvider({ defaultLabels: [] })
+
+			await provider.createIssue({ title: 'T', body: 'B' })
+
+			const labelsArg = mockCreateIssue.mock.calls[0][4]
+			expect(labelsArg).toBeUndefined()
+		})
+
+		it('uses configured labels alone when agent supplies none', async () => {
+			buildProvider({ defaultLabels: ['ai-generated'] })
+
+			await provider.createIssue({ title: 'T', body: 'B' })
+
+			const labelsArg = mockCreateIssue.mock.calls[0][4]
+			expect(labelsArg).toEqual(['ai-generated'])
+		})
+	})
+
+	describe('createChildIssue', () => {
+		it('merges configured defaultLabels with agent-supplied labels (configured first)', async () => {
+			buildProvider({ defaultLabels: ['ai-generated', 'needs-triage'] })
+
+			await provider.createChildIssue({
+				parentId: 'PROJ-1',
+				title: 'T',
+				body: 'B',
+				labels: ['bug'],
+			})
+
+			// createIssueWithParent(projectKey, title, body, parentKey, issueType, labels)
+			const labelsArg = mockCreateIssueWithParent.mock.calls[0][5]
+			expect(labelsArg).toEqual(['ai-generated', 'needs-triage', 'bug'])
+		})
+
+		it('dedupes overlapping labels', async () => {
+			buildProvider({ defaultLabels: ['bug'] })
+
+			await provider.createChildIssue({
+				parentId: 'PROJ-1',
+				title: 'T',
+				body: 'B',
+				labels: ['bug', 'feature'],
+			})
+
+			const labelsArg = mockCreateIssueWithParent.mock.calls[0][5]
+			expect(labelsArg).toEqual(['bug', 'feature'])
+		})
+
+		it('omits labels from the API call when neither configured nor supplied (regression)', async () => {
+			buildProvider({ defaultLabels: [] })
+
+			await provider.createChildIssue({ parentId: 'PROJ-1', title: 'T', body: 'B' })
+
+			const labelsArg = mockCreateIssueWithParent.mock.calls[0][5]
+			expect(labelsArg).toBeUndefined()
+		})
+
+		it('validates whitespace for child issues too', async () => {
+			buildProvider({ defaultLabels: ['has space'] })
+
+			await expect(
+				provider.createChildIssue({ parentId: 'PROJ-1', title: 'T', body: 'B' })
+			).rejects.toThrow(/"has space"/)
+			expect(mockCreateIssueWithParent).not.toHaveBeenCalled()
+		})
+
+		it('validates commas for child issues too', async () => {
+			buildProvider({ defaultLabels: ['has,comma'] })
+
+			await expect(
+				provider.createChildIssue({ parentId: 'PROJ-1', title: 'T', body: 'B' })
+			).rejects.toThrow(/"has,comma"/)
+			expect(mockCreateIssueWithParent).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/mcp/JiraIssueManagementProvider.ts
+++ b/src/mcp/JiraIssueManagementProvider.ts
@@ -35,6 +35,22 @@ import type { JiraTrackerConfig } from '../lib/providers/jira/JiraIssueTracker.j
 import type { Issue } from '../types/index.js'
 import { SettingsManager } from '../lib/SettingsManager.js'
 import type { IloomSettings } from '../lib/SettingsManager.js'
+import { mergeLabels, parseLabelsFromEnv } from '../utils/labels.js'
+
+/**
+ * Validate that labels don't contain whitespace or commas. Jira rejects these
+ * with a 400 error; surfacing a clear error here lets agents see which label
+ * is the problem instead of getting a generic API error.
+ */
+function validateJiraLabels(labels: string[]): void {
+	for (const label of labels) {
+		if (/[\s,]/.test(label)) {
+			throw new Error(
+				`Jira labels cannot contain whitespace or commas: "${label}". Remove spaces/tabs/newlines/commas before creating the issue.`
+			)
+		}
+	}
+}
 
 /**
  * Normalize Jira author to FlexibleAuthor format
@@ -72,6 +88,9 @@ const getJiraTrackerConfig = (settings: IloomSettings): JiraTrackerConfig => {
 		if (jiraSettings.defaultSubtaskType) {
 			config.defaultSubtaskType = jiraSettings.defaultSubtaskType
 		}
+		if (jiraSettings.defaultLabels && jiraSettings.defaultLabels.length > 0) {
+			config.defaultLabels = jiraSettings.defaultLabels
+		}
 
 		return config;
 	}
@@ -96,6 +115,10 @@ const getJiraTrackerConfig = (settings: IloomSettings): JiraTrackerConfig => {
 		}
 		if (process.env.JIRA_DEFAULT_SUBTASK_TYPE) {
 			config.defaultSubtaskType = process.env.JIRA_DEFAULT_SUBTASK_TYPE
+		}
+		const envLabels = parseLabelsFromEnv(process.env.JIRA_DEFAULT_LABELS, 'JIRA_DEFAULT_LABELS')
+		if (envLabels.length > 0) {
+			config.defaultLabels = envLabels
 		}
 
 		return config
@@ -262,12 +285,25 @@ export class JiraIssueManagementProvider implements IssueManagementProvider {
 
 	/**
 	 * Create a new issue
+	 *
+	 * Merges configured default labels with any agent-supplied labels via the
+	 * shared mergeLabels helper (configured labels come first, case-sensitive
+	 * dedupe). Jira rejects labels containing whitespace, so we validate
+	 * up-front with a clear error identifying the offending label.
 	 */
 	async createIssue(input: CreateIssueInput): Promise<CreateIssueResult> {
-		const { title, body } = input
+		const { title, body, labels } = input
 
-		// Create issue via tracker (labels not supported in current implementation)
-		const issue = await this.tracker.createIssue(title, body)
+		const configured = this.tracker.getConfig().defaultLabels ?? []
+		const merged = mergeLabels(configured, labels ?? [])
+		validateJiraLabels(merged)
+
+		const issue = await this.tracker.createIssue(
+			title,
+			body,
+			undefined,
+			merged.length > 0 ? merged : undefined
+		)
 
 		const result: CreateIssueResult = {
 			id: String(issue.number),
@@ -294,18 +330,28 @@ export class JiraIssueManagementProvider implements IssueManagementProvider {
 
 	/**
 	 * Create a child issue linked to a parent issue
-	 * Uses Jira's parent field to create a subtask
+	 * Uses Jira's parent field to create a subtask.
+	 *
+	 * Merges configured default labels with any agent-supplied labels via the
+	 * shared mergeLabels helper. Jira rejects labels containing whitespace,
+	 * so we validate up-front with a clear error identifying the offending
+	 * label.
 	 */
 	async createChildIssue(input: CreateChildIssueInput): Promise<CreateIssueResult> {
-		const { parentId, title, body } = input
+		const { parentId, title, body, labels } = input
 		const parentKey = this.tracker.normalizeIdentifier(parentId)
+
+		const configured = this.tracker.getConfig().defaultLabels ?? []
+		const merged = mergeLabels(configured, labels ?? [])
+		validateJiraLabels(merged)
 
 		const jiraIssue = await this.tracker.getApiClient().createIssueWithParent(
 			this.projectKey,
 			title,
 			body,
 			parentKey,
-			this.tracker.getConfig().defaultSubtaskType
+			this.tracker.getConfig().defaultSubtaskType,
+			merged.length > 0 ? merged : undefined
 		)
 
 		return {

--- a/src/utils/labels.test.ts
+++ b/src/utils/labels.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./logger.js', () => ({
+	logger: {
+		warn: vi.fn(),
+	},
+}))
+
+import { mergeLabels, parseLabelsFromEnv } from './labels.js'
+import { logger } from './logger.js'
+
+describe('mergeLabels', () => {
+	it('returns empty array when both inputs are omitted', () => {
+		expect(mergeLabels()).toEqual([])
+	})
+
+	it('returns empty array when both inputs are empty', () => {
+		expect(mergeLabels([], [])).toEqual([])
+	})
+
+	it('returns configured labels when supplied is empty', () => {
+		expect(mergeLabels(['bug', 'priority:high'], [])).toEqual(['bug', 'priority:high'])
+	})
+
+	it('returns supplied labels when configured is empty', () => {
+		expect(mergeLabels([], ['feature', 'needs-review'])).toEqual(['feature', 'needs-review'])
+	})
+
+	it('preserves configured-first order when merging both inputs', () => {
+		expect(mergeLabels(['ai-generated', 'needs-triage'], ['bug'])).toEqual([
+			'ai-generated',
+			'needs-triage',
+			'bug',
+		])
+	})
+
+	it('dedupes labels present in both inputs (configured wins)', () => {
+		expect(mergeLabels(['ai-generated', 'bug'], ['bug', 'feature'])).toEqual([
+			'ai-generated',
+			'bug',
+			'feature',
+		])
+	})
+
+	it('dedupes duplicates within the configured list', () => {
+		expect(mergeLabels(['bug', 'bug', 'feature'], [])).toEqual(['bug', 'feature'])
+	})
+
+	it('dedupes duplicates within the supplied list', () => {
+		expect(mergeLabels([], ['bug', 'bug', 'feature'])).toEqual(['bug', 'feature'])
+	})
+
+	it('is case-sensitive (Bug and bug are distinct)', () => {
+		expect(mergeLabels(['Bug'], ['bug'])).toEqual(['Bug', 'bug'])
+	})
+
+	it('handles undefined inputs as empty arrays', () => {
+		expect(mergeLabels(undefined, ['bug'])).toEqual(['bug'])
+		expect(mergeLabels(['bug'], undefined)).toEqual(['bug'])
+		expect(mergeLabels(undefined, undefined)).toEqual([])
+	})
+})
+
+describe('parseLabelsFromEnv', () => {
+	beforeEach(() => {
+		vi.mocked(logger.warn).mockReset()
+	})
+
+	it('returns [] when env value is missing', () => {
+		expect(parseLabelsFromEnv(undefined, 'TEST_LABELS')).toEqual([])
+		expect(logger.warn).not.toHaveBeenCalled()
+	})
+
+	it('parses a valid JSON array of non-empty strings', () => {
+		expect(parseLabelsFromEnv('["bug","needs-triage"]', 'TEST_LABELS')).toEqual(['bug', 'needs-triage'])
+		expect(logger.warn).not.toHaveBeenCalled()
+	})
+
+	it('returns [] and warns when parsed value is not an array', () => {
+		expect(parseLabelsFromEnv('"bug"', 'TEST_LABELS')).toEqual([])
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('TEST_LABELS must be a JSON array of strings')
+		)
+	})
+
+	it('returns [] and warns when array contains non-string or empty entries', () => {
+		expect(parseLabelsFromEnv('["bug", ""]', 'TEST_LABELS')).toEqual([])
+		expect(logger.warn).toHaveBeenCalledWith(
+			'TEST_LABELS contains a non-string or empty entry. Ignoring entire value.'
+		)
+	})
+
+	it('returns [] and warns when JSON is invalid', () => {
+		expect(parseLabelsFromEnv('{', 'TEST_LABELS')).toEqual([])
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Invalid JSON in TEST_LABELS. Ignoring.',
+			expect.objectContaining({ error: expect.any(String) })
+		)
+	})
+})

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared label utilities for issue tracker integrations.
+ *
+ * Used by GitHub and Jira issue management providers to merge configured
+ * default labels with agent-supplied labels before forwarding them to the
+ * underlying tracker API. Keeping the merge semantics in one helper ensures
+ * both providers behave consistently (configured-first, case-sensitive,
+ * deduped via Set).
+ */
+import { logger } from './logger.js'
+
+/**
+ * Merge configured default labels with agent-supplied labels.
+ *
+ * Behavior:
+ * - Configured labels come first, preserving their declared order.
+ * - Agent-supplied labels follow, preserving their order.
+ * - The result is deduped (case-sensitive) using Set semantics so the first
+ *   occurrence wins.
+ * - Empty/missing inputs are treated as `[]`.
+ *
+ * Note: labels are compared case-sensitively on purpose. GitHub treats labels
+ * case-insensitively on lookup but stores them with the casing they were
+ * created with, and Jira treats labels case-sensitively. Preserving the
+ * original casing avoids surprising the user when the rendered label differs
+ * from what they configured.
+ */
+export function mergeLabels(
+	configured: string[] = [],
+	supplied: string[] = [],
+): string[] {
+	const seen = new Set<string>()
+	const result: string[] = []
+
+	for (const label of configured) {
+		if (!seen.has(label)) {
+			seen.add(label)
+			result.push(label)
+		}
+	}
+
+	for (const label of supplied) {
+		if (!seen.has(label)) {
+			seen.add(label)
+			result.push(label)
+		}
+	}
+
+	return result
+}
+
+/**
+ * Parse a JSON-encoded label array from an environment variable.
+ * Returns an empty array for any malformed input so env-var consumers
+ * degrade gracefully instead of crashing.
+ */
+export function parseLabelsFromEnv(envValue: string | undefined, envVarName: string): string[] {
+	if (!envValue) return []
+	try {
+		const parsed = JSON.parse(envValue)
+		if (!Array.isArray(parsed)) {
+			logger.warn(`${envVarName} must be a JSON array of strings, got type "${typeof parsed}". Ignoring.`)
+			return []
+		}
+		const result: string[] = []
+		for (const item of parsed) {
+			if (typeof item !== 'string' || item.length === 0) {
+				logger.warn(`${envVarName} contains a non-string or empty entry. Ignoring entire value.`)
+				return []
+			}
+			result.push(item)
+		}
+		return result
+	} catch (error) {
+		logger.warn(`Invalid JSON in ${envVarName}. Ignoring.`, {
+			error: error instanceof Error ? error.message : 'unknown error',
+		})
+		return []
+	}
+}

--- a/src/utils/mcp.test.ts
+++ b/src/utils/mcp.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
-import { generateRecapMcpConfig, generateHarnessMcpConfig } from './mcp.js'
+import { generateRecapMcpConfig, generateHarnessMcpConfig, generateIssueManagementMcpConfig } from './mcp.js'
 import os from 'os'
 import path from 'path'
 import type { LoomMetadata } from '../lib/MetadataManager.js'
+import type { IloomSettings } from '../lib/SettingsManager.js'
 
 // Mock the github module
 vi.mock('./github.js', () => ({
@@ -245,5 +246,85 @@ describe('generateHarnessMcpConfig', () => {
 		const serverPath = (harnessConfig.args as string[])[0]
 
 		expect(path.isAbsolute(serverPath)).toBe(true)
+	})
+})
+
+describe('generateIssueManagementMcpConfig - defaultLabels env-var bridge', () => {
+	// Helpers to pull the env vars out of the generated MCP server config
+	// without re-asserting the full config shape (already covered elsewhere).
+	async function envForGithub(settings?: IloomSettings): Promise<Record<string, string>> {
+		const cfg = await generateIssueManagementMcpConfig('issue', 'owner/repo', 'github', settings)
+		const server = (cfg[0].mcpServers as Record<string, unknown>).issue_management as Record<string, unknown>
+		return server.env as Record<string, string>
+	}
+	async function envForJira(settings: IloomSettings): Promise<Record<string, string>> {
+		const cfg = await generateIssueManagementMcpConfig('issue', undefined, 'jira', settings)
+		const server = (cfg[0].mcpServers as Record<string, unknown>).issue_management as Record<string, unknown>
+		return server.env as Record<string, string>
+	}
+
+	it('serializes GitHub defaultLabels as a JSON array in GITHUB_DEFAULT_LABELS', async () => {
+		const env = await envForGithub({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: ['ai-generated', 'needs-triage'],
+				},
+			},
+		} as IloomSettings)
+
+		expect(env.GITHUB_DEFAULT_LABELS).toBeDefined()
+		expect(JSON.parse(env.GITHUB_DEFAULT_LABELS)).toEqual(['ai-generated', 'needs-triage'])
+	})
+
+	it('omits GITHUB_DEFAULT_LABELS when defaultLabels is empty', async () => {
+		const env = await envForGithub({
+			issueManagement: {
+				github: {
+					remote: 'origin',
+					defaultLabels: [],
+				},
+			},
+		} as IloomSettings)
+
+		expect(env.GITHUB_DEFAULT_LABELS).toBeUndefined()
+	})
+
+	it('omits GITHUB_DEFAULT_LABELS when defaultLabels is not configured', async () => {
+		const env = await envForGithub(undefined)
+		expect(env.GITHUB_DEFAULT_LABELS).toBeUndefined()
+	})
+
+	it('serializes Jira defaultLabels as a JSON array in JIRA_DEFAULT_LABELS', async () => {
+		const env = await envForJira({
+			issueManagement: {
+				jira: {
+					host: 'https://example.atlassian.net',
+					username: 'u',
+					apiToken: 't',
+					projectKey: 'PROJ',
+					defaultLabels: ['ai-generated', 'from-iloom'],
+				},
+			},
+		} as IloomSettings)
+
+		expect(env.JIRA_DEFAULT_LABELS).toBeDefined()
+		expect(JSON.parse(env.JIRA_DEFAULT_LABELS)).toEqual(['ai-generated', 'from-iloom'])
+	})
+
+	it('omits JIRA_DEFAULT_LABELS when defaultLabels is empty', async () => {
+		const env = await envForJira({
+			issueManagement: {
+				jira: {
+					host: 'https://example.atlassian.net',
+					username: 'u',
+					apiToken: 't',
+					projectKey: 'PROJ',
+					defaultLabels: [],
+				},
+			},
+		} as IloomSettings)
+
+		expect(env.JIRA_DEFAULT_LABELS).toBeUndefined()
 	})
 })

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -67,6 +67,13 @@ export async function generateIssueManagementMcpConfig(
 			...(githubEventName && { GITHUB_EVENT_NAME: githubEventName }),
 		}
 
+		// Pass configured default labels through so the MCP provider can merge them
+		// with agent-supplied labels when creating issues.
+		const githubDefaultLabels = settings?.issueManagement?.github?.defaultLabels
+		if (githubDefaultLabels && githubDefaultLabels.length > 0) {
+			envVars.GITHUB_DEFAULT_LABELS = JSON.stringify(githubDefaultLabels)
+		}
+
 		logger.debug('Generated MCP config for GitHub issue management', {
 			provider,
 			repoOwner: owner,
@@ -120,6 +127,9 @@ export async function generateIssueManagementMcpConfig(
 		}
 		if (jiraSettings?.defaultSubtaskType) {
 			envVars.JIRA_DEFAULT_SUBTASK_TYPE = jiraSettings.defaultSubtaskType
+		}
+		if (jiraSettings?.defaultLabels && jiraSettings.defaultLabels.length > 0) {
+			envVars.JIRA_DEFAULT_LABELS = JSON.stringify(jiraSettings.defaultLabels)
 		}
 
 		logger.debug('Generated MCP config for Jira issue management', {


### PR DESCRIPTION
Fixes #985

## Plan: Configurable default labels for issue tracker integrations

<details>
<summary>Issue details</summary>

## Problem statement

Teams adopting iloom-cli have no reliable, org-wide way to distinguish AI-assisted tickets from human-authored ones in their issue tracker. Agents can technically supply labels via the MCP `create_issue` tool, but relying on agent behavior is non-deterministic — labels get missed, inconsistent, or dropped silently (Jira drops them entirely today).

A settings-driven default would make every iloom-created ticket identifiable without relying on agent instructions.

## Goals

- Configure a list of labels in `settings.json` that get applied automatically to every issue created through iloom-cli
- Merge configured defaults with any agent-supplied labels (union, dedup) so configured identifiers are always present
- Propagate the config through the MCP env-var bridge so the issue-management MCP server picks it up
- Deliver for GitHub and Jira in this epic

## Scope

**In scope:**
- GitHub and Jira tracker providers
- New `settings.issueManagement.{github,jira}.defaultLabels: string[]` config (defaults to `[]`)
- Configured defaults merged (case-sensitive union with dedup, configured-first order) with agent-supplied labels
- MCP env-var bridge propagates config to the subprocess
- Documentation in `docs/iloom-commands.md`

**Out of scope:**
- **Linear**: Labels are currently unimplemented in iloom-cli's Linear integration (`createLinearIssue` and `createLinearChildIssue` in `src/utils/linear.ts` silently drop the `_labels` parameter), and Linear's SDK requires resolving label names to label UUIDs via a lookup helper that does not yet exist. Deferred to a follow-up epic focused on Linear label support.
- Legacy `JiraIssueTracker.createIssue` CLI path (unused by the MCP-driven issue creation flow)
- First-run-setup prompting
- Telemetry (no workflow change)

## Summary of approach

One config-surface change (schema + env bridge + docs) establishes the contract. Two parallel per-tracker wiring changes (GitHub and Jira) consume the contract and merge the configured defaults with agent-supplied labels before the label list reaches each tracker's API. A final integration verification confirms the wires are connected end-to-end.

## Task overview

| # | Title | Description | Dependencies | Complexity |
|---|-------|-------------|--------------|------------|
| 1 | Add `defaultLabels` to settings schema + env-var bridge + docs | Extend settings schema and MCP env-var bridge with `defaultLabels` for GitHub and Jira; document in settings reference. | None | Simple |
| 2 | Apply `defaultLabels` in Jira provider + API client | Merge configured + agent labels in Jira MCP provider; forward as `fields.labels` in REST API POST body. | Task 1 | Simple |
| 3 | Apply `defaultLabels` in GitHub provider | Merge configured + agent labels in GitHub MCP provider; forward to existing `gh` CLI label pipeline. | Task 1 | Simple |
| 4 | Verify default-label integration | Integration tests confirming merged-label flow end-to-end for both providers with no regression when unset. | Tasks 2, 3 | Simple |

## Detailed breakdown

The full implementation breakdown — per-task acceptance criteria, shared contracts, scope boundaries, must-haves, and the architectural decision record — is posted as a comment on this issue.

## Note

An earlier version of this plan was incorrectly created as four separate issues (#986, #987, #988, #989). Those have been closed; this issue is the single source of truth for the plan.

</details>

---
*This PR was created automatically by iloom.*