### PR TITLE
chore(claude): disable adaptive thinking for spawned Claude processes

### DIFF
--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -3197,7 +3197,7 @@ describe('claude utils', () => {
 				expect.arrayContaining(['-p', '--output-format', 'stream-json', '--verbose', '--model', 'haiku', '--effort', 'low', '--system-prompt', expect.any(String), '--no-session-persistence']),
 				expect.objectContaining({
 					input: expect.stringContaining(issueTitle),
-					env: expect.objectContaining({ CLAUDECODE: '0' }),
+					env: expect.objectContaining({ CLAUDECODE: '0', CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: '1' }),
 				})
 			)
 		})

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -186,7 +186,7 @@ export async function launchClaude(
 	const isDebugMode = logger.isDebugEnabled()
 
 	// Set CLAUDECODE=0 to prevent Claude from detecting it's running inside Claude Code
-	const claudeEnv = { ...process.env, CLAUDECODE: '0' }
+	const claudeEnv = { ...process.env, CLAUDECODE: '0', CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: '1' }
 
 	// Helper to build common args (avoids duplication between attempts)
 	function buildBaseArgs(includeBare: boolean): string[] {


### PR DESCRIPTION
## Summary
- Sets `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` alongside `CLAUDECODE=0` in the env passed to every Claude subprocess launched via `launchClaude()` in `src/utils/claude.ts`.
- Centralizing it here covers all iloom-orchestrated Claude flows (spin, swarm, plan, rebase, commit, finish, init, PR/issue enhancement, session summaries, branch naming) so thinking behavior is predictable across orchestrated workflows.

## Test plan
- [x] Updated `src/utils/claude.test.ts` to assert the new env var is forwarded to the subprocess.
- [x] `pnpm build` succeeds.
- [x] Full test suite passes (5091 tests).