### PR TITLE
Epic: Per-repository customization via ILOOM.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ tmp/
 
 # Added by iloom CLI
 .iloom/settings.local.json
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ This example shows how to configure a project-wide default (e.g., GitHub remote)
 }
 ```
 
+### Repository Guidance (ILOOM.md)
+
+Drop an optional `ILOOM.md` at your repository root to inject project-specific guidance (review priorities, conventions, feature-flag guardrails) into every iloom agent prompt — see [ILOOM.md — Repository Guidance](docs/iloom-commands.md#iloommd--repository-guidance) for details.
+
 ### Multi-Language/Framework Project Support
 
 iloom supports projects in any programming language through `.iloom/package.iloom.json`. This file defines scripts using raw shell commands instead of npm scripts.

--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -35,6 +35,7 @@ Complete documentation for all iloom CLI commands, options, and flags.
   - [il feedback](#il-feedback)
   - [il contribute](#il-contribute)
   - [il telemetry](#il-telemetry)
+- [ILOOM.md — Repository Guidance](#iloommd--repository-guidance)
 
 ---
 
@@ -2093,6 +2094,81 @@ On first run, iloom displays a disclosure message informing you that anonymous t
 **Privacy:**
 
 For details on what data is and is not collected, see the [Telemetry section in the README](../README.md#telemetry).
+
+---
+
+## ILOOM.md — Repository Guidance
+
+`ILOOM.md` is an optional per-repository file you can drop at the root of your project to steer iloom's behavior without forking the CLI or its prompt templates. Its contents are injected into every agent prompt iloom renders — so you can tune review priorities, enforce conventions, or hand AI agents project-specific guardrails that live alongside your code and evolve with it.
+
+**Purpose:**
+
+- Steer iloom behavior (analyzers, planners, implementers, reviewers) without forking the CLI or its prompt templates
+- Keep project conventions version-controlled alongside the code that needs them
+- Let different repos use the same iloom binary with different guidance
+
+**File location:**
+
+- `./ILOOM.md` at the repository root (same directory as `.iloom/`, `package.json`, etc.)
+- Tracked in git like any other source file
+
+**When iloom reads it:**
+
+Every command that renders a prompt template loads `ILOOM.md` at invocation time and injects its contents into the rendered prompt. This applies to `il start`, `il spin`, `il plan`, `il enhance`, `il init`, `il summary`, and all swarm-mode and agent-driven flows.
+
+**Silent no-op when absent:**
+
+If `ILOOM.md` does not exist, iloom silently omits the Repository Guidance section from all prompts. There is no warning, no error, and no configuration required — it is purely opt-in. Existing projects are unaffected.
+
+**Example `ILOOM.md`:**
+
+```markdown
+# Repository Guidance for iloom Agents
+
+## Review Priorities
+
+When reviewing code, apply these priorities in order:
+
+1. **Accessibility first** — all UI changes must preserve ARIA labels and keyboard navigation. Flag any missing `aria-*` attributes as blocking.
+2. **No direct DOM mutation** outside `src/dom/` — we use the abstraction layer everywhere else.
+3. **Error handling** — never swallow errors. Always rethrow with context or log at `error` level.
+
+## Theming Conventions
+
+- Use design tokens from `src/theme/tokens.ts`. Never hardcode hex colors in components.
+- Dark mode is the default; light mode tokens live in `src/theme/light.ts`.
+- Component variants go through `variants()` — do not branch on `theme.mode` inside components.
+
+## Feature Flag Guardrails
+
+All new features must be gated behind a flag in `src/flags/registry.ts`:
+
+- Flags default to `false` until explicitly launched
+- Never remove a flag in the same PR that adds the feature
+- Flag removal requires a separate PR after at least one release cycle
+
+## Testing
+
+- Prefer integration tests in `tests/integration/` over mock-heavy unit tests
+- Do not mock our own modules — only mock external HTTP / filesystem / shell boundaries
+- Snapshot tests are allowed only for stable, rarely-changing output (CLI help text, etc.)
+```
+
+**How it appears in prompts:**
+
+When `ILOOM.md` is present, agents see a clearly labeled section near the top of their prompt:
+
+```
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+<contents of ILOOM.md>
+```
+
+**Telemetry:**
+
+iloom emits a single `iloom_md.loaded` telemetry event per process, indicating whether `ILOOM.md` was present and a coarse size bucket (`empty` / `small` / `medium` / `large`). The file's contents are never transmitted.
 
 ---
 

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -5,6 +5,7 @@ import { AgentManager } from '../lib/AgentManager.js'
 import { SettingsManager } from '../lib/SettingsManager.js'
 import { gatherDiagnosticInfo, formatDiagnosticsAsMarkdown } from '../utils/diagnostics.js'
 import { capitalizeFirstLetter } from '../utils/text.js'
+import { loadPromptExtensions } from '../lib/PromptExtensions.js'
 
 // Hardcoded target repository for feedback
 const FEEDBACK_REPOSITORY = 'iloom-ai/iloom-cli'
@@ -59,6 +60,11 @@ export class FeedbackCommand {
 		// Step 2: Gather diagnostic information
 		const diagnostics = await gatherDiagnosticInfo()
 		const diagnosticsMarkdown = formatDiagnosticsAsMarkdown(diagnostics)
+
+		// Preload repository-local prompt extensions (ILOOM.md) so ILOOM_MD_CONTENT
+		// propagates into any templates rendered downstream by IssueEnhancementService.
+		// Use process.cwd() so linked-worktree users see their branch-local ILOOM.md.
+		await loadPromptExtensions(process.cwd())
 
 		// Step 3: Create enhanced issue body with marker and diagnostics
 		const userBody = body ?? description

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -24,6 +24,7 @@ import { SwarmSetupService } from '../lib/SwarmSetupService.js'
 import type { LoomMetadata } from '../lib/MetadataManager.js'
 import { TelemetryService } from '../lib/TelemetryService.js'
 import { detectProjectLanguage } from '../utils/language-detector.js'
+import { loadPromptExtensions } from '../lib/PromptExtensions.js'
 
 /**
  * Error thrown when the spin command is run from an invalid location
@@ -278,7 +279,9 @@ export class IgniteCommand {
 			}
 
 			// Step 2.2: Get prompt template with variable substitution
+			const promptExtensions = await loadPromptExtensions(context.workspacePath)
 			const variables = this.buildTemplateVariables(context, effectiveOneShot, draftPrNumber, draftPrUrl)
+			variables.ILOOM_MD_CONTENT = promptExtensions.iloomMd
 
 			// Step 2.5: Add first-time user context if needed
 			if (isFirstRun) {
@@ -953,6 +956,8 @@ export class IgniteCommand {
 		// Determine issue prefix for commit message trailers
 		const issuePrefix = providerName === 'github' ? '#' : ''
 
+		const promptExtensions = await loadPromptExtensions(epicWorktreePath)
+
 		const variables: TemplateVariables = {
 			EPIC_ISSUE_NUMBER: epicIssueNumber,
 			EPIC_WORKTREE_PATH: epicWorktreePath,
@@ -960,6 +965,7 @@ export class IgniteCommand {
 			CHILD_ISSUES: JSON.stringify(childIssuesData, null, 2),
 			DEPENDENCY_MAP: JSON.stringify(metadata.dependencyMap, null, 2),
 			ISSUE_PREFIX: issuePrefix,
+			ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 			...(skipCleanup && { NO_CLEANUP: true }),
 		}
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,7 @@ import { SettingsMigrationManager } from '../lib/SettingsMigrationManager.js'
 import { getRepoRoot, isFileGitignored } from '../utils/git.js'
 import { FirstRunManager } from '../utils/FirstRunManager.js'
 import { TelemetryService } from '../lib/TelemetryService.js'
+import { loadPromptExtensions } from '../lib/PromptExtensions.js'
 
 /**
  * Initialize iloom configuration
@@ -368,6 +369,11 @@ export class InitCommand {
       const hasPackageJson = existsSync(packageJsonPath)
       logger.debug('Package.json detection', { packageJsonPath, hasPackageJson })
 
+      // Load repository-local prompt extensions (ILOOM.md).
+      // Use process.cwd() rather than getRepoRoot() so linked-worktree users
+      // see their branch-local ILOOM.md instead of the main checkout's.
+      const promptExtensions = await loadPromptExtensions(process.cwd())
+
       // Build template variables
       const variables = {
         SETTINGS_SCHEMA: schemaContent,
@@ -388,6 +394,7 @@ export class InitCommand {
         // Multi-language support - mutually exclusive booleans
         HAS_PACKAGE_JSON: hasPackageJson,
         NO_PACKAGE_JSON: !hasPackageJson,
+        ILOOM_MD_CONTENT: promptExtensions.iloomMd,
       }
 
       logger.debug('Building template variables', {

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -16,6 +16,7 @@ import { promptConfirmation, isInteractiveEnvironment } from '../utils/prompt.js
 import { TelemetryService } from '../lib/TelemetryService.js'
 import { StartCommand } from './start.js'
 import { IgniteCommand } from './ignite.js'
+import { loadPromptExtensions } from '../lib/PromptExtensions.js'
 
 // Define provider arrays for validation and dynamic flag generation
 const PLANNER_PROVIDERS = ['claude', 'gemini', 'codex'] as const
@@ -435,6 +436,9 @@ export class PlanCommand {
 
 		// Load plan prompt template with mode-specific variables
 		logger.debug('Loading plan prompt template')
+		// Use process.cwd() rather than getRepoRoot() so linked-worktree users
+		// see their branch-local ILOOM.md instead of the main checkout's.
+		const planPromptExtensions = await loadPromptExtensions(process.cwd())
 		const templateVariables: TemplateVariables = {
 			IS_VSCODE_MODE: isVscodeMode,
 			EXISTING_ISSUE_MODE: !!decompositionContext,
@@ -452,6 +456,7 @@ export class PlanCommand {
 			REVIEWER: effectiveReviewer,
 			HAS_REVIEWER: effectiveReviewer !== 'none',
 			AUTO_SWARM_MODE: autoSwarm ?? false,
+			ILOOM_MD_CONTENT: planPromptExtensions.iloomMd,
 			...providerFlags,
 		}
 		const architectPrompt = await this.templateManager.getPrompt('plan', templateVariables)

--- a/src/lib/ClaudeService.test.ts
+++ b/src/lib/ClaudeService.test.ts
@@ -105,6 +105,7 @@ describe('ClaudeService', () => {
 					WORKSPACE_PATH: '/workspace/issue-123',
 					PORT: 3123,
 					IS_VSCODE_MODE: false,
+					ILOOM_MD_CONTENT: '',
 				})
 
 				expect(claudeUtils.launchClaudeInNewTerminalWindow).toHaveBeenCalledWith(prompt, {
@@ -136,6 +137,7 @@ describe('ClaudeService', () => {
 					WORKSPACE_PATH: '/workspace',
 					PORT: 3123,
 					IS_VSCODE_MODE: false,
+					ILOOM_MD_CONTENT: '',
 				})
 			})
 
@@ -156,6 +158,7 @@ describe('ClaudeService', () => {
 					ISSUE_NUMBER: 123,
 					WORKSPACE_PATH: '/workspace',
 					IS_VSCODE_MODE: false,
+					ILOOM_MD_CONTENT: '',
 				})
 			})
 		})
@@ -183,6 +186,7 @@ describe('ClaudeService', () => {
 					WORKSPACE_PATH: '/workspace/pr-456',
 					PORT: 3456,
 					IS_VSCODE_MODE: false,
+					ILOOM_MD_CONTENT: '',
 				})
 
 				// PR workflow uses acceptEdits permission mode by default
@@ -214,6 +218,7 @@ describe('ClaudeService', () => {
 				expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith('regular', {
 					WORKSPACE_PATH: '/workspace/feature',
 					IS_VSCODE_MODE: false,
+					ILOOM_MD_CONTENT: '',
 				})
 
 				// Regular workflow uses acceptEdits permission mode by default

--- a/src/lib/ClaudeService.ts
+++ b/src/lib/ClaudeService.ts
@@ -2,6 +2,7 @@ import { detectClaudeCli, launchClaude, launchClaudeInNewTerminalWindow, ClaudeC
 import { PromptTemplateManager, TemplateVariables } from './PromptTemplateManager.js'
 import { SettingsManager, IloomSettings } from './SettingsManager.js'
 import { logger } from '../utils/logger.js'
+import { loadPromptExtensions } from './PromptExtensions.js'
 
 export interface ClaudeWorkflowOptions {
 	type: 'issue' | 'pr' | 'regular'
@@ -69,9 +70,13 @@ export class ClaudeService {
 			// Settings are pre-validated at CLI startup, so no error handling needed here
 			this.settings ??= await this.settingsManager.loadSettings()
 
+			// Load repository-local prompt extensions (ILOOM.md)
+			const promptExtensions = await loadPromptExtensions(workspacePath)
+
 			// Build template variables
 			const variables: TemplateVariables = {
 				WORKSPACE_PATH: workspacePath,
+				ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 			}
 
 			if (issueNumber !== undefined) {

--- a/src/lib/IssueEnhancementService.ts
+++ b/src/lib/IssueEnhancementService.ts
@@ -7,6 +7,7 @@ import { openBrowser } from '../utils/browser.js'
 import { waitForKeypress } from '../utils/prompt.js'
 import { getLogger } from '../utils/logger-context.js'
 import { generateIssueManagementMcpConfig } from '../utils/mcp.js'
+import { loadPromptExtensions } from './PromptExtensions.js'
 
 /**
  * Options for enhancing an existing issue
@@ -80,9 +81,12 @@ export class IssueEnhancementService {
 
 			// Load only the enhancer agent with template variables so Handlebars expressions resolve
 			const settings = await this.settingsManager.loadSettings()
+			// Use process.cwd() so linked-worktree users see their branch-local ILOOM.md.
+			const promptExtensions = await loadPromptExtensions(process.cwd())
 			const templateVariables: TemplateVariables = {
 				STANDARD_ISSUE_MODE: true,
 				DIRECT_PROMPT_MODE: true,
+				ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 			}
 			const loadedAgents = await this.agentManager.loadAgents(
 				settings,
@@ -210,9 +214,12 @@ Press any key to open issue for editing...`
 
 		// Load only the enhancer agent with template variables so Handlebars expressions resolve
 		const settings = await this.settingsManager.loadSettings()
+		// Use process.cwd() so linked-worktree users see their branch-local ILOOM.md.
+		const promptExtensions = await loadPromptExtensions(process.cwd())
 		const templateVariables: TemplateVariables = {
 			ISSUE_NUMBER: issueNumber,
 			STANDARD_ISSUE_MODE: true,
+			ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 		}
 		const loadedAgents = await this.agentManager.loadAgents(
 			settings,

--- a/src/lib/PromptExtensions.integration.test.ts
+++ b/src/lib/PromptExtensions.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import path from 'path'
+import { PromptTemplateManager, TemplateVariables } from './PromptTemplateManager.js'
+
+// Do NOT mock fs/promises here — this test renders real template files.
+vi.mock('../utils/logger.js', () => ({
+	logger: {
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}))
+
+/**
+ * Integration test confirming the ILOOM.md guidance block renders correctly
+ * into a real prompt template when `ILOOM_MD_CONTENT` is populated, and is
+ * omitted when empty.
+ */
+describe('PromptTemplateManager: ILOOM.md guidance injection (integration)', () => {
+	const templatesDir = path.resolve(process.cwd(), 'templates', 'prompts')
+	const manager = new PromptTemplateManager(templatesDir)
+
+	// Minimal variables required for issue-prompt.txt to render without errors.
+	const baseVariables: TemplateVariables = {
+		WORKSPACE_PATH: '/tmp/test-workspace',
+		ISSUE_NUMBER: 42,
+		ILOOM_MD_CONTENT: '',
+	}
+
+	const SENTINEL = '# Project Conventions\n- Use tabs\n- Prefer composition'
+
+	it('includes the Repository Guidance section when ILOOM_MD_CONTENT is non-empty', async () => {
+		const result = await manager.getPrompt('issue', {
+			...baseVariables,
+			ILOOM_MD_CONTENT: SENTINEL,
+		})
+
+		expect(result).toContain('Repository Guidance (from ILOOM.md)')
+		expect(result).toContain(SENTINEL)
+	})
+
+	it('omits the Repository Guidance section when ILOOM_MD_CONTENT is empty', async () => {
+		const result = await manager.getPrompt('issue', {
+			...baseVariables,
+			ILOOM_MD_CONTENT: '',
+		})
+
+		expect(result).not.toContain('Repository Guidance (from ILOOM.md)')
+	})
+})

--- a/src/lib/PromptExtensions.test.ts
+++ b/src/lib/PromptExtensions.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { loadPromptExtensions, __resetTelemetryFiredForTests } from './PromptExtensions.js'
+import { TelemetryService } from './TelemetryService.js'
+
+vi.mock('fs/promises', () => ({
+	readFile: vi.fn(),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const mockTrack = vi.fn()
+
+vi.mock('./TelemetryService.js', () => ({
+	TelemetryService: {
+		getInstance: vi.fn(() => ({
+			track: mockTrack,
+		})),
+	},
+}))
+
+const REPO_ROOT = '/fake/repo/root'
+const ILOOM_MD_PATH = path.join(REPO_ROOT, 'ILOOM.md')
+
+function makeEnoent(): NodeJS.ErrnoException {
+	const err: NodeJS.ErrnoException = Object.assign(new Error('ENOENT: no such file'), {
+		code: 'ENOENT',
+	})
+	return err
+}
+
+function makePermissionError(): NodeJS.ErrnoException {
+	const err: NodeJS.ErrnoException = Object.assign(new Error('EACCES: permission denied'), {
+		code: 'EACCES',
+	})
+	return err
+}
+
+describe('loadPromptExtensions', () => {
+	beforeEach(() => {
+		__resetTelemetryFiredForTests()
+		mockTrack.mockReset()
+	})
+
+	it('returns trimmed content and fires telemetry (present: true) when file exists with content', async () => {
+		const raw = '# Project Conventions\n\nUse tabs.\n\n   \n'
+		vi.mocked(readFile).mockResolvedValueOnce(raw)
+
+		const result = await loadPromptExtensions(REPO_ROOT)
+
+		expect(result).toEqual({ iloomMd: '# Project Conventions\n\nUse tabs.' })
+		expect(readFile).toHaveBeenCalledWith(ILOOM_MD_PATH, 'utf-8')
+		expect(mockTrack).toHaveBeenCalledTimes(1)
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: true,
+			size_bucket: 'small',
+		})
+	})
+
+	it('bucketizes medium files correctly (1024–10239 bytes)', async () => {
+		const raw = 'a'.repeat(2048)
+		vi.mocked(readFile).mockResolvedValueOnce(raw)
+
+		await loadPromptExtensions(REPO_ROOT)
+
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: true,
+			size_bucket: 'medium',
+		})
+	})
+
+	it('bucketizes large files correctly (>=10240 bytes)', async () => {
+		const raw = 'a'.repeat(20000)
+		vi.mocked(readFile).mockResolvedValueOnce(raw)
+
+		await loadPromptExtensions(REPO_ROOT)
+
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: true,
+			size_bucket: 'large',
+		})
+	})
+
+	it('returns empty string and fires telemetry (present: false, empty) when file is absent (ENOENT)', async () => {
+		vi.mocked(readFile).mockRejectedValueOnce(makeEnoent())
+
+		const result = await loadPromptExtensions(REPO_ROOT)
+
+		expect(result).toEqual({ iloomMd: '' })
+		expect(mockTrack).toHaveBeenCalledTimes(1)
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: false,
+			size_bucket: 'empty',
+		})
+	})
+
+	it('returns empty string and reports present: true with empty bucket when file is empty', async () => {
+		vi.mocked(readFile).mockResolvedValueOnce('')
+
+		const result = await loadPromptExtensions(REPO_ROOT)
+
+		expect(result).toEqual({ iloomMd: '' })
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: true,
+			size_bucket: 'empty',
+		})
+	})
+
+	it('returns empty string gracefully on non-ENOENT read errors (e.g. permissions)', async () => {
+		vi.mocked(readFile).mockRejectedValueOnce(makePermissionError())
+
+		const result = await loadPromptExtensions(REPO_ROOT)
+
+		expect(result).toEqual({ iloomMd: '' })
+		// Treat unreadable as "not present" for telemetry purposes
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: false,
+			size_bucket: 'empty',
+		})
+	})
+
+	it('fires telemetry exactly once across multiple invocations in the same process', async () => {
+		vi.mocked(readFile)
+			.mockResolvedValueOnce('first')
+			.mockResolvedValueOnce('second')
+			.mockRejectedValueOnce(makeEnoent())
+
+		await loadPromptExtensions(REPO_ROOT)
+		await loadPromptExtensions(REPO_ROOT)
+		await loadPromptExtensions(REPO_ROOT)
+
+		expect(mockTrack).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not throw if TelemetryService throws', async () => {
+		vi.mocked(readFile).mockResolvedValueOnce('content')
+		vi.mocked(TelemetryService.getInstance).mockImplementationOnce(() => {
+			throw new Error('telemetry boom')
+		})
+
+		await expect(loadPromptExtensions(REPO_ROOT)).resolves.toEqual({
+			iloomMd: 'content',
+		})
+	})
+
+	it('computes size_bucket from raw (pre-trim) byte length', async () => {
+		// Content with large trailing whitespace — ensure bucket uses raw byte length
+		const content = 'hello' + ' '.repeat(1050)
+		vi.mocked(readFile).mockResolvedValueOnce(content)
+
+		const result = await loadPromptExtensions(REPO_ROOT)
+
+		expect(result.iloomMd).toBe('hello')
+		// Raw byte length is 1055 -> medium bucket (>=1024), even though trimmed is small
+		expect(mockTrack).toHaveBeenCalledWith('iloom_md.loaded', {
+			present: true,
+			size_bucket: 'medium',
+		})
+	})
+})

--- a/src/lib/PromptExtensions.ts
+++ b/src/lib/PromptExtensions.ts
@@ -1,0 +1,109 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { logger } from '../utils/logger.js'
+import { TelemetryService } from './TelemetryService.js'
+
+/**
+ * Result of loading repository-local prompt extensions.
+ *
+ * Shared contract consumed by commands/services that inject per-repo
+ * customization (e.g. ILOOM.md) into agent prompt templates.
+ */
+export interface PromptExtensions {
+	/**
+	 * Contents of the repository's `ILOOM.md` file, trimmed of trailing
+	 * whitespace. Empty string when the file is absent or unreadable.
+	 */
+	iloomMd: string
+}
+
+/**
+ * Module-level flag ensuring the `iloom_md.loaded` telemetry event fires at
+ * most once per process, regardless of how many times `loadPromptExtensions`
+ * is invoked.
+ */
+let telemetryFired = false
+
+/**
+ * Test-only hook to reset the module-level telemetry flag. Not part of the
+ * public API.
+ *
+ * @internal
+ */
+export function __resetTelemetryFiredForTests(): void {
+	telemetryFired = false
+}
+
+function computeSizeBucket(byteLength: number): 'empty' | 'small' | 'medium' | 'large' {
+	if (byteLength === 0) return 'empty'
+	if (byteLength < 1024) return 'small'
+	if (byteLength < 10240) return 'medium'
+	return 'large'
+}
+
+function fireTelemetryOnce(present: boolean, rawContent: string): void {
+	if (telemetryFired) return
+	telemetryFired = true
+	try {
+		const byteLength = Buffer.byteLength(rawContent, 'utf-8')
+		const size_bucket = computeSizeBucket(byteLength)
+		TelemetryService.getInstance().track('iloom_md.loaded', {
+			present,
+			size_bucket,
+		})
+	} catch (error) {
+		logger.debug(`PromptExtensions: telemetry error: ${String(error)}`)
+	}
+}
+
+/**
+ * Load per-repository prompt extensions from the given `repoRoot`.
+ *
+ * Currently reads `${repoRoot}/ILOOM.md`. This function follows the
+ * graceful-degradation shape of `loadReadmeContent()` in `src/commands/ignite.ts`
+ * but takes an explicit repo root rather than walking up the filesystem.
+ *
+ * Contract:
+ * - On successful read: returns `{ iloomMd: <content trimmed of trailing whitespace> }`.
+ * - On ENOENT: returns `{ iloomMd: "" }` and debug-logs.
+ * - On any other read error: returns `{ iloomMd: "" }` and debug-logs.
+ * - Never throws.
+ *
+ * Fires a single `iloom_md.loaded` telemetry event per process the first time
+ * the loader runs, regardless of outcome. Telemetry is fire-and-forget and
+ * wrapped in try/catch; it never breaks the workflow.
+ *
+ * @param repoRoot Absolute path to the repository root directory.
+ * @returns A `PromptExtensions` object; `iloomMd` is an empty string when the
+ *   file is absent or unreadable.
+ */
+export async function loadPromptExtensions(repoRoot: string): Promise<PromptExtensions> {
+	const iloomMdPath = path.join(repoRoot, 'ILOOM.md')
+	let rawContent = ''
+	let present = false
+
+	try {
+		rawContent = await readFile(iloomMdPath, 'utf-8')
+		present = true
+		logger.debug('PromptExtensions: loaded ILOOM.md', { iloomMdPath })
+	} catch (error) {
+		// Check for ENOENT explicitly so the common "missing file" case is
+		// logged as routine. Any other read error (permissions, IO, etc.) is
+		// still handled by the public contract — return empty and debug-log.
+		const code = (error as NodeJS.ErrnoException | undefined)?.code
+		if (code === 'ENOENT') {
+			logger.debug('PromptExtensions: ILOOM.md not found', { iloomMdPath })
+		} else {
+			logger.debug(`PromptExtensions: failed to read ILOOM.md: ${String(error)}`, {
+				iloomMdPath,
+				code,
+			})
+		}
+	}
+
+	fireTelemetryOnce(present, rawContent)
+
+	return {
+		iloomMd: present ? rawContent.replace(/\s+$/, '') : '',
+	}
+}

--- a/src/lib/PromptTemplateManager.ts
+++ b/src/lib/PromptTemplateManager.ts
@@ -116,6 +116,8 @@ export interface TemplateVariables {
 	SWARM_SUB_AGENT_TIMEOUT_MS?: number  // Timeout in milliseconds for sub-agent claude -p Bash tool calls (default: 600000 = 10 minutes)
 	NO_CLEANUP?: boolean  // True when child loom cleanup should be skipped (e.g., manual cleanup later)
 	ISSUE_PREFIX?: string  // "#" for GitHub, "" for Linear/Jira — used in commit message templates
+	// Per-repo prompt extensions (from ILOOM.md at the repo root)
+	ILOOM_MD_CONTENT?: string  // Optional; Handlebars treats undefined like "" via {{#if}}
 }
 
 /**

--- a/src/lib/SessionSummaryService.test.ts
+++ b/src/lib/SessionSummaryService.test.ts
@@ -159,6 +159,7 @@ describe('SessionSummaryService', () => {
 				LOOM_TYPE: 'issue',
 				COMPACT_SUMMARIES: '',
 				RECAP_DATA: '',
+				ILOOM_MD_CONTENT: '',
 			})
 
 			// Verify Claude was called
@@ -326,6 +327,7 @@ describe('SessionSummaryService', () => {
 				LOOM_TYPE: 'issue',
 				COMPACT_SUMMARIES: compactSummary,
 				RECAP_DATA: '',
+				ILOOM_MD_CONTENT: '',
 			})
 		})
 

--- a/src/lib/SessionSummaryService.ts
+++ b/src/lib/SessionSummaryService.ts
@@ -22,6 +22,7 @@ import type { IssueProvider } from '../mcp/types.js'
 import { hasMultipleRemotes } from '../utils/remote.js'
 import type { RecapFile, RecapOutput } from '../mcp/recap-types.js'
 import { formatRecapMarkdown } from '../utils/recap-formatter.js'
+import { loadPromptExtensions } from './PromptExtensions.js'
 
 const RECAPS_DIR = path.join(os.homedir(), '.config', 'iloom-ai', 'recaps')
 
@@ -162,12 +163,14 @@ export class SessionSummaryService {
 			}
 
 			// 6. Load and process the session-summary template
+			const promptExtensions = await loadPromptExtensions(input.worktreePath)
 			const prompt = await this.templateManager.getPrompt('session-summary', {
 				ISSUE_NUMBER: String(input.issueNumber),
 				BRANCH_NAME: input.branchName,
 				LOOM_TYPE: input.loomType,
 				COMPACT_SUMMARIES: compactSummaries ?? '',
 				RECAP_DATA: recapData ?? '',
+				ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 			})
 
 			logger.debug('Session summary prompt:\n' + prompt)
@@ -254,12 +257,14 @@ export class SessionSummaryService {
 		}
 
 		// 5. Load and process the session-summary template
+		const promptExtensions = await loadPromptExtensions(worktreePath)
 		const prompt = await this.templateManager.getPrompt('session-summary', {
 			ISSUE_NUMBER: issueNumber !== undefined ? String(issueNumber) : '',
 			BRANCH_NAME: branchName,
 			LOOM_TYPE: loomType,
 			COMPACT_SUMMARIES: compactSummaries ?? '',
 			RECAP_DATA: recapData ?? '',
+			ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 		})
 
 		logger.debug('Session summary prompt:\n' + prompt)

--- a/src/lib/SwarmSetupService.ts
+++ b/src/lib/SwarmSetupService.ts
@@ -11,6 +11,7 @@ import { getLogger } from '../utils/logger-context.js'
 import { installDependencies } from '../utils/package-manager.js'
 import { generateWorktreePath } from '../utils/git.js'
 import { generateAndWriteMcpConfigFile } from '../utils/mcp.js'
+import { loadPromptExtensions } from './PromptExtensions.js'
 
 /**
  * Result of the swarm setup process
@@ -234,9 +235,11 @@ export class SwarmSetupService {
 		await fs.ensureDir(claudeAgentsDir)
 
 		const settings = await this.settingsManager.loadSettings()
+		const promptExtensions = await loadPromptExtensions(epicWorktreePath)
 
 		const templateVariables: TemplateVariables = {
 			SWARM_MODE: true,
+			ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 		}
 
 		const agents = await this.agentManager.loadAgents(settings, templateVariables)
@@ -324,6 +327,9 @@ export class SwarmSetupService {
 			const subAgentTimeoutMinutes = settings?.agents?.['iloom-swarm-worker']?.subAgentTimeout ?? 10
 			const subAgentTimeoutMs = subAgentTimeoutMinutes * 60 * 1000
 
+			// Load repository-local prompt extensions (ILOOM.md)
+			const promptExtensions = await loadPromptExtensions(epicWorktreePath)
+
 			// Build template variables for swarm worker agent rendering
 			const variables: TemplateVariables = {
 				SWARM_MODE: true,
@@ -331,6 +337,7 @@ export class SwarmSetupService {
 				EPIC_WORKTREE_PATH: epicWorktreePath,
 				ISSUE_PREFIX: issuePrefix,
 				SWARM_SUB_AGENT_TIMEOUT_MS: subAgentTimeoutMs,
+				ILOOM_MD_CONTENT: promptExtensions.iloomMd,
 				...(agentMetadata && { SWARM_AGENT_METADATA: JSON.stringify(agentMetadata) }),
 				...buildReviewTemplateVariables(settings?.agents),
 			}

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -107,6 +107,11 @@ export interface AutoSwarmCompletedProperties {
   fallback_to_normal: boolean
 }
 
+export interface IlommMdLoadedProperties {
+  present: boolean
+  size_bucket: 'empty' | 'small' | 'medium' | 'large'
+}
+
 // --- Event name → properties map (for type-safe track() in downstream issues) ---
 export interface TelemetryEventMap {
   'cli.installed': CliInstalledProperties
@@ -127,6 +132,7 @@ export interface TelemetryEventMap {
   'init.completed': InitCompletedProperties
   'auto_swarm.started': AutoSwarmStartedProperties
   'auto_swarm.completed': AutoSwarmCompletedProperties
+  'iloom_md.loaded': IlommMdLoadedProperties
 }
 
 export type TelemetryEventName = keyof TelemetryEventMap

--- a/templates/agents/iloom-artifact-reviewer.md
+++ b/templates/agents/iloom-artifact-reviewer.md
@@ -5,6 +5,15 @@ model: opus
 color: yellow
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 You are a skeptical senior staff engineer reviewing work produced by AI agents before it gets posted to a GitHub issue. Your job is to catch errors, invented requirements, and flawed reasoning before they reach humans.
 
 {{#if SWARM_MODE}}

--- a/templates/agents/iloom-code-reviewer.md
+++ b/templates/agents/iloom-code-reviewer.md
@@ -5,6 +5,15 @@ model: opus
 color: cyan
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 You are an expert code reviewer. Your task is to analyze uncommitted code changes and provide actionable feedback.
 
 {{#if SWARM_MODE}}

--- a/templates/agents/iloom-framework-detector.md
+++ b/templates/agents/iloom-framework-detector.md
@@ -6,6 +6,15 @@ color: cyan
 model: opus
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 You are Claude, a framework detection specialist. Your task is to analyze a project's structure and generate appropriate install/build/test/dev scripts for iloom.
 
 **Your Core Mission**: Detect the project's programming language and framework, then create the appropriate iloom package configuration file with shell commands for install, build, test, and development workflows.

--- a/templates/agents/iloom-issue-analyze-and-plan.md
+++ b/templates/agents/iloom-issue-analyze-and-plan.md
@@ -6,6 +6,15 @@ color: teal
 model: opus
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if SWARM_MODE}}
 ## Swarm Mode
 

--- a/templates/agents/iloom-issue-analyzer.md
+++ b/templates/agents/iloom-issue-analyzer.md
@@ -6,6 +6,15 @@ color: pink
 model: opus
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if SWARM_MODE}}
 ## Swarm Mode
 

--- a/templates/agents/iloom-issue-complexity-evaluator.md
+++ b/templates/agents/iloom-issue-complexity-evaluator.md
@@ -6,6 +6,15 @@ color: orange
 model: haiku
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if SWARM_MODE}}
 ## Swarm Mode
 

--- a/templates/agents/iloom-issue-enhancer.md
+++ b/templates/agents/iloom-issue-enhancer.md
@@ -6,6 +6,15 @@ color: purple
 model: opus
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if SWARM_MODE}}
 ## Swarm Mode
 

--- a/templates/agents/iloom-issue-implementer.md
+++ b/templates/agents/iloom-issue-implementer.md
@@ -6,6 +6,15 @@ model: opus
 color: green
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if SWARM_MODE}}
 ## Swarm Mode
 

--- a/templates/agents/iloom-issue-planner.md
+++ b/templates/agents/iloom-issue-planner.md
@@ -6,6 +6,15 @@ color: blue
 model: opus
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if SWARM_MODE}}
 ## Swarm Mode
 

--- a/templates/prompts/init-prompt.txt
+++ b/templates/prompts/init-prompt.txt
@@ -85,6 +85,15 @@ ALL iloom configuration files should default to their `.local` variants:
 
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 # iloom CLI Configuration Guide
 
 You are helping the user configure iloom CLI for their project. Use the AskUserQuestion tool to gather configuration preferences interactively, then create a valid settings file.

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -26,6 +26,15 @@ Before taking ANY action after reading your task prompt, run this self-check:
 ---
 
 {{/if}}
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 # FORBIDDEN PHRASES - NEVER USE THESE
 **ABSOLUTELY CRITICAL:** Never use these phrases or variants:
 - "You're absolutely right"

--- a/templates/prompts/plan-prompt.txt
+++ b/templates/prompts/plan-prompt.txt
@@ -4,6 +4,15 @@ You are a Senior Product Architect and Engineering Lead helping to plan and deco
 
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 ## AI Provider Configuration
 
 {{#if USE_GEMINI_PLANNER}}

--- a/templates/prompts/pr-prompt.txt
+++ b/templates/prompts/pr-prompt.txt
@@ -20,6 +20,15 @@ Before sending any response, verify it doesn't contain:
 
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if PORT}}
 <additional_env>
 Dev Server Port: {{PORT}}

--- a/templates/prompts/regular-prompt.txt
+++ b/templates/prompts/regular-prompt.txt
@@ -20,6 +20,15 @@ Before sending any response, verify it doesn't contain:
 
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 {{#if PORT}}
 <additional_env>
 Dev Server Port: {{PORT}}

--- a/templates/prompts/session-summary-prompt.txt
+++ b/templates/prompts/session-summary-prompt.txt
@@ -1,5 +1,14 @@
 You are generating a summary of THIS conversation - the development session you just completed.
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 ## Context
 - Issue/PR: #{{ISSUE_NUMBER}}
 - Branch: {{BRANCH_NAME}}

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -16,6 +16,15 @@ You are a **coordinator**, not an executor. Your job is to schedule work, track 
 
 ---
 
+{{#if ILOOM_MD_CONTENT}}
+
+## Repository Guidance (from ILOOM.md)
+
+The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.
+
+{{ILOOM_MD_CONTENT}}
+
+{{/if}}
 ## Loom Recap
 
 The recap panel is visible to the user in VS Code. Use these Recap MCP tools to capture knowledge:


### PR DESCRIPTION
Fixes #734

## Epic: Per-repository customization via ILOOM.md

<details>
<summary>Issue details</summary>

## Summary

Introduce a repo-root `ILOOM.md` file that is read at command start and injected directly into the system prompt of every iloom agent and every top-level prompt template. This gives repo maintainers a freeform way to steer iloom's behavior — review priorities, coding conventions, theming/MCP preferences, LaunchDarkly/feature-flag expectations, etc. — without changing iloom itself.

Supersedes the original "custom sub-agents via settings" proposal in favor of @acreeger's simpler ILOOM.md suggestion from the comments.

## Goals

- Repo-level `ILOOM.md` at repo root, mirroring the CLAUDE.md convention
- Content flows into every iloom-authored system prompt — top-level workflow prompts AND every agent under `templates/agents/`
- Silent no-op when the file is absent. No CLI flag, no settings toggle
- Structured so per-agent extensions (e.g. the original "custom reviewer subagents" idea) are a trivial add later, without reworking the plumbing

## Non-goals

- Per-agent overrides (future work — design leaves the door open via an extensible `PromptExtensions` module)
- A CLI flag or settings toggle to disable it
- Injection into the generated workspace CLAUDE.md template (`templates/prompts/CLAUDE.md`) — that file is what iloom writes into workspaces, not a system prompt
- Reading any file other than `./ILOOM.md` at the repo root

## Approach

1. New `src/lib/PromptExtensions.ts` module exposes `loadPromptExtensions(repoRoot)` returning a structured object. Today: `{ ilommMd: string }`. Future fields (per-agent overrides, injectable tool allowlists, etc.) land here without changing callers.
2. Every command that builds `TemplateVariables` calls the loader and assigns `ILOOM_MD_CONTENT` on the variable set.
3. Every top-level prompt template and every agent template under `templates/agents/` gets a uniform `{{#if ILOOM_MD_CONTENT}}…{{/if}}` injection block, placed outside any `SWARM_MODE`/`DRAFT_PR_MODE` conditionals.
4. Fire-and-forget telemetry event `iloom_md.loaded` with `{ present, size_bucket }` so we can see adoption without leaking content.

## Shared contracts

```ts
// src/lib/PromptExtensions.ts
export interface PromptExtensions {
  ilommMd: string
  // Future: perAgentOverrides?: Record<string, string>
  // Future: injectedTools, etc.
}
export async function loadPromptExtensions(repoRoot: string): Promise<PromptExtensions>

// src/lib/PromptTemplateManager.ts — TemplateVariables interface gains:
ILOOM_MD_CONTENT: string   // always present; "" when ILOOM.md is absent
```

- Loader reads `${repoRoot}/ILOOM.md`. On ENOENT or any other read error: returns `""`, debug-log only, never throws.
- Loader fires `iloom_md.loaded` telemetry once per process (module-level flag), with `size_bucket`: `empty` (0B), `small` (<1024B), `medium` (<10240B), `large` (≥10240B).
- Template injection block, identical across every target template, placed outside all mode conditionals:

  ```handlebars
  {{#if ILOOM_MD_CONTENT}}

  ## Repository Guidance (from ILOOM.md)

  The repository maintainers have provided the following guidance via ILOOM.md. Apply it throughout your work.

  {{ILOOM_MD_CONTENT}}

  {{/if}}
  ```

  Handlebars is configured with `noEscape: true` and does not re-parse substituted values, so literal `{{…}}` inside a user's ILOOM.md renders as-is.

## Scope

- Read-path: `./ILOOM.md` at repo root (no `.iloom/ILOOM.md`, no settings-configurable path)
- Write-path: none — file is authored by humans
- Injection sites:
  - Prompt templates under `templates/prompts/`: `issue-prompt.txt`, `pr-prompt.txt`, `regular-prompt.txt`, `plan-prompt.txt`, `swarm-orchestrator-prompt.txt`, `init-prompt.txt`, `session-summary-prompt.txt`
  - Excluded: `templates/prompts/CLAUDE.md` (generated-workspace template, not a system prompt)
  - Agent templates: all 9 under `templates/agents/`
- Wire-through sites: `src/commands/ignite.ts`, `src/commands/init.ts`, `src/commands/feedback.ts`, `src/lib/SwarmSetupService.ts`, `src/lib/IssueEnhancementService.ts`

## Task overview

| # | Title | Dependencies | Complexity |
|---|-------|--------------|------------|
| 1 | Add PromptExtensions loader + ILOOM_MD_CONTENT template variable + telemetry event | None (produces shared contract) | Simple |
| 2 | Wire PromptExtensions loader through all command entry points | Shared contract from #1 | Simple |
| 3 | Inject ILOOM.md guidance block into top-level prompt templates | Shared contract from #1 | Simple |
| 4 | Inject ILOOM.md guidance block into agent templates | Shared contract from #1 | Simple |
| 5 | Document ILOOM.md | Shared contract from #1 | Simple |
| 6 | Verify ILOOM.md integration end-to-end | Hard-blocked by #1–#5 | Simple |

Only #6 has a hard blocking dependency. Wave-1 children use compile-time shared contracts (not blocking dependencies) so they can be implemented in parallel; compile errors on isolated branches are expected and resolve on merge.

</details>

---
*This PR was created automatically by iloom.*