### PR TITLE
chore(plan): default plan.model to opus[1m]

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -1408,7 +1408,7 @@ il plan <issue-number> [options]
 
 | Flag | Values | Description |
 |------|--------|-------------|
-| `--model <model>` | `opus`, `sonnet`, `haiku`, `opus[1m]`, `sonnet[1m]` | Model to use (default: from settings `plan.model`, falls back to 'opus'). The `[1m]` variants use the 1M context window. `opus[1m]` requires a Max or Team plan. |
+| `--model <model>` | `opus`, `sonnet`, `haiku`, `opus[1m]`, `sonnet[1m]` | Model to use (default: from settings `plan.model`, falls back to 'opus[1m]'). The `[1m]` variants use the 1M context window. `opus[1m]` requires a Max or Team plan. |
 | `--one-shot <mode>` | `default`, `noReview`, `bypassPermissions` | One-shot automation mode (`noReview` skips confirmation gates; `bypassPermissions` skips both gates and permission prompts) |
 | `--dangerously-skip-permissions` | - | Skip Claude permission prompts without skipping confirmation gates (composable with `--one-shot`) |
 | `--autonomous` | - | Alias for `--one-shot=bypassPermissions` (backwards compat) |
@@ -1557,7 +1557,7 @@ Settings file (`.iloom/settings.json`):
 
 | Setting | Values | Default | Description |
 |---------|--------|---------|-------------|
-| `plan.model` | `opus`, `sonnet`, `haiku`, `opus[1m]`, `sonnet[1m]` | `opus` | Claude model for the planning session. The `[1m]` variants use the 1M context window. `opus[1m]` requires a Max or Team plan. |
+| `plan.model` | `opus`, `sonnet`, `haiku`, `opus[1m]`, `sonnet[1m]` | `opus[1m]` | Claude model for the planning session. The `[1m]` variants use the 1M context window. `opus[1m]` requires a Max or Team plan. |
 | `plan.planner` | `claude`, `gemini`, `codex` | `claude` | AI provider for generating plans |
 | `plan.reviewer` | `claude`, `gemini`, `codex`, `none` | `none` | AI provider for reviewing plans |
 | `plan.waveVerification` | `true`, `false` | `true` | Generate verification child issues between dependency waves |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1622,7 +1622,7 @@ program
   .command('plan')
   .description('Launch interactive planning session with Architect persona')
   .argument('[prompt]', 'Initial planning prompt or topic')
-  .option('--model <model>', 'Model to use: opus, sonnet, haiku, opus[1m], sonnet[1m] (default: opus)')
+  .option('--model <model>', 'Model to use: opus, sonnet, haiku, opus[1m], sonnet[1m] (default: opus[1m])')
   .addOption(
     new Option('--one-shot <mode>', 'One-shot automation mode')
       .choices(['default', 'noReview', 'bypassPermissions'])

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -82,7 +82,7 @@ export class PlanCommand {
 	/**
 	 * Main entry point for the plan command
 	 * @param prompt - Optional initial planning prompt or topic
-	 * @param model - Optional model to use (defaults to 'opus')
+	 * @param model - Optional model to use (defaults to 'opus[1m]')
 	 * @param flags - Optional flags object controlling permissions and auto-swarm
 	 * @param planner - Optional planner provider (defaults to 'claude')
 	 * @param reviewer - Optional reviewer provider (defaults to 'none')
@@ -272,7 +272,7 @@ export class PlanCommand {
 			}
 		}
 
-		// Use CLI model if provided, otherwise use settings (plan.model), defaults to opus
+		// Use CLI model if provided, otherwise use settings (plan.model), defaults to opus[1m]
 		const effectiveModel = model ?? settingsManager.getPlanModel(settings ?? undefined)
 
 		// Get effective effort level (CLI > settings > undefined/defer to Claude Code)

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -101,7 +101,7 @@ export const SpinAgentSettingsSchema = z.object({
 export const PlanCommandSettingsSchema = z.object({
 	model: z
 		.enum(VALID_CLAUDE_MODELS)
-		.default('opus')
+		.default('opus[1m]')
 		.describe('Claude model shorthand for plan command'),
 	effort: z
 		.enum(VALID_EFFORT_LEVELS)
@@ -561,7 +561,7 @@ export const IloomSettingsSchema = z.object({
 		'Spin orchestrator configuration. Model defaults to opus when not configured.',
 	),
 	plan: PlanCommandSettingsSchema.optional().describe(
-		'Plan command configuration. Model defaults to opus, planner to claude, reviewer to none when not configured.',
+		'Plan command configuration. Model defaults to opus[1m], planner to claude, reviewer to none when not configured.',
 	),
 	summary: SummarySettingsSchema.optional().describe(
 		'Session summary generation configuration. Model defaults to sonnet when not configured.',


### PR DESCRIPTION
## Summary
- Change `PlanCommandSettingsSchema.model` default from `opus` to `opus[1m]` so the `il plan` command uses the 1M context window by default
- Update `--model` CLI help text and `docs/iloom-commands.md` to reflect the new default
- Refresh JSDoc/inline comments in `src/commands/plan.ts`

## Test plan
- [x] `pnpm lint` / `pnpm compile` pass via pre-commit
- [ ] `il plan` without `--model` runs with opus[1m]