### PR TITLE
fix(plan): write architect prompt to file to avoid E2BIG on spawn

### DIFF
--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -6,6 +6,7 @@ import type { AgentManager } from '../lib/AgentManager.js'
 import * as claudeUtils from '../utils/claude.js'
 import * as claudeTrust from '../utils/claude-trust.js'
 import * as mcpUtils from '../utils/mcp.js'
+import * as systemPromptWriter from '../utils/system-prompt-writer.js'
 import * as firstRunSetup from '../utils/first-run-setup.js'
 import { IssueManagementProviderFactory } from '../mcp/IssueManagementProviderFactory.js'
 import { TelemetryService } from '../lib/TelemetryService.js'
@@ -18,6 +19,7 @@ import type { HarnessHandler } from '../lib/HarnessServer.js'
 vi.mock('../utils/claude.js')
 vi.mock('../utils/claude-trust.js')
 vi.mock('../utils/mcp.js')
+vi.mock('../utils/system-prompt-writer.js')
 vi.mock('../utils/first-run-setup.js')
 vi.mock('../utils/IdentifierParser.js')
 vi.mock('../mcp/IssueManagementProviderFactory.js')
@@ -105,6 +107,9 @@ describe('PlanCommand', () => {
 		vi.mocked(mcpUtils.generateIssueManagementMcpConfig).mockResolvedValue([
 			{ mcpServers: { issue_management: {} } },
 		])
+		vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mockResolvedValue({
+			appendSystemPromptFile: '/tmp/iloom-system-prompt-test.md',
+		})
 		// Default: project is already configured (no first-run setup needed)
 		vi.mocked(firstRunSetup.needsFirstRunSetup).mockResolvedValue(false)
 		vi.mocked(firstRunSetup.launchFirstRunSetup).mockResolvedValue(undefined)
@@ -337,16 +342,24 @@ describe('PlanCommand', () => {
 	})
 
 	describe('Claude launch options', () => {
-		it('should pass appendSystemPrompt with template content', async () => {
+		it('should write the architect prompt to a file and pass appendSystemPromptFile', async () => {
 			const mockPromptContent = 'Test architect prompt content'
+			const mockPromptFile = '/tmp/iloom-system-prompt-test.md'
 			vi.mocked(mockTemplateManager.getPrompt).mockResolvedValue(mockPromptContent)
+			vi.mocked(systemPromptWriter.prepareSystemPromptForPlatform).mockResolvedValue({
+				appendSystemPromptFile: mockPromptFile,
+			})
 
 			await command.execute()
 
+			expect(systemPromptWriter.prepareSystemPromptForPlatform).toHaveBeenCalledWith(
+				mockPromptContent,
+				expect.any(String),
+			)
 			expect(claudeUtils.launchClaude).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.objectContaining({
-					appendSystemPrompt: mockPromptContent,
+					appendSystemPromptFile: mockPromptFile,
 				})
 			)
 		})

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -4,6 +4,7 @@ import { withLogger } from '../utils/logger-context.js'
 import chalk from 'chalk'
 import { detectClaudeCli, launchClaude } from '../utils/claude.js'
 import { preAcceptClaudeTrust } from '../utils/claude-trust.js'
+import { prepareSystemPromptForPlatform } from '../utils/system-prompt-writer.js'
 import { PromptTemplateManager, type TemplateVariables } from '../lib/PromptTemplateManager.js'
 import { AgentManager } from '../lib/AgentManager.js'
 import { generateIssueManagementMcpConfig, generateHarnessMcpConfig } from '../utils/mcp.js'
@@ -523,11 +524,19 @@ export class PlanCommand {
 			...(autoSwarm ? ['mcp__harness__signal'] : []),
 		]
 
+		// Write the architect prompt to a file to keep the claude argv under the
+		// OS arg-list limit — inlining via --append-system-prompt can push large
+		// prompts past ARG_MAX and fail with E2BIG (spawn error -8) on macOS.
+		const systemPromptConfig = await prepareSystemPromptForPlatform(
+			architectPrompt,
+			process.cwd(),
+		)
+
 		// Build Claude options
 		const claudeOptions: Parameters<typeof launchClaude>[1] = {
 			model: effectiveModel,
 			headless: isHeadless,
-			appendSystemPrompt: architectPrompt,
+			appendSystemPromptFile: systemPromptConfig.appendSystemPromptFile,
 			mcpConfig,
 			addDir: process.cwd(),
 			allowedTools,
@@ -575,7 +584,7 @@ export class PlanCommand {
 		logger.debug('Launching Claude with options', {
 			optionKeys: Object.keys(claudeOptions),
 			headless: claudeOptions.headless,
-			hasSystemPrompt: !!claudeOptions.appendSystemPrompt,
+			hasSystemPrompt: !!claudeOptions.appendSystemPromptFile,
 			addDir: claudeOptions.addDir,
 			effectiveAutonomous,
 			effectiveOneShot,


### PR DESCRIPTION
## Summary

- `il plan` was inlining the architect prompt (~42 KB) via `--append-system-prompt` and the iloom-issue-analyzer agent (~35 KB) via `--agents`. Combined with the two `--mcp-config` blobs and env, the claude argv was tipping past macOS `ARG_MAX` (~1 MB) and failing with `Unknown system error -8` (E2BIG) at `posix_spawn`.
- Switch `plan.ts` to use `prepareSystemPromptForPlatform()` so the prompt is written to a temp file and passed via `--append-system-prompt-file` — same approach `ignite.ts` already uses. Drops ~42 KB out of the argv.
- Update the corresponding `plan.test.ts` assertion to reflect the new contract (`appendSystemPromptFile` instead of `appendSystemPrompt`).

Note: the `--agents` JSON is still inline. If a project ships several large agent definitions to plan mode, that path could still trip the limit — worth a follow-up if it surfaces in practice.

## Test plan

- [x] `pnpm vitest run src/commands/plan.test.ts` — 66/66 pass
- [x] Pre-commit hook passes (lint, compile, full test suite, build)
- [ ] Manual verification: `il plan --auto-swarm <topic> --dangerously-skip-permissions --autonomous` on a repo where the previous invocation reproduced the failure