### PR TITLE
Add support for downloading/using images added/inlined to Linear issues

### DIFF
--- a/src/commands/enhance.test.ts
+++ b/src/commands/enhance.test.ts
@@ -6,9 +6,13 @@ import type { SettingsManager, IloomSettings } from '../lib/SettingsManager.js'
 import type { Issue } from '../types/index.js'
 import { openBrowser } from '../utils/browser.js'
 import { waitForKeypress } from '../utils/prompt.js'
+import { processMarkdownImages } from '../utils/image-processor.js'
 
 // Mock dependencies
 vi.mock('../utils/browser.js')
+vi.mock('../utils/image-processor.js', () => ({
+	processMarkdownImages: vi.fn(),
+}))
 vi.mock('../utils/prompt.js', () => ({
 	waitForKeypress: vi.fn(),
 	promptConfirmation: vi.fn(),
@@ -659,6 +663,151 @@ describe('EnhanceCommand', () => {
 			await expect(
 				command.execute({ issueNumber: 42, options: {} })
 			).resolves.not.toThrow()
+		})
+	})
+
+	describe('image processing', () => {
+		beforeEach(() => {
+			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValue({} as IloomSettings)
+			vi.mocked(mockEnhancementService.enhanceExistingIssue).mockResolvedValue({ enhanced: false })
+		})
+
+		it('should rewrite image URLs for Linear-provider issue bodies', async () => {
+			const linearService = {
+				fetchIssue: vi.fn(),
+				providerName: 'linear',
+			} as unknown as GitHubService
+			const linearCommand = new EnhanceCommand(linearService, mockEnhancementService, mockSettingsManager)
+
+			const originalBody = 'See ![mockup](https://uploads.linear.app/abc/foo.png)'
+			const rewrittenBody = 'See ![mockup](/tmp/iloom-images/abc.png)'
+
+			vi.mocked(linearService.fetchIssue).mockResolvedValue({
+				number: 42,
+				title: 'Test Issue',
+				body: originalBody,
+				state: 'open',
+				labels: [],
+				assignees: [],
+				url: 'https://linear.app/team/issue/TEAM-42',
+			} as Issue)
+
+			vi.mocked(processMarkdownImages).mockResolvedValue(rewrittenBody)
+
+			await linearCommand.execute({ issueNumber: 42, options: {} })
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(originalBody, 'linear')
+		})
+
+		it('should rewrite image URLs for GitHub-provider issue bodies', async () => {
+			const originalBody = 'Screenshot ![](https://private-user-images.githubusercontent.com/x/y.png)'
+			const rewrittenBody = 'Screenshot ![](/tmp/iloom-images/y.png)'
+
+			vi.mocked(mockGitHubService.fetchIssue).mockResolvedValue({
+				number: 42,
+				title: 'Test Issue',
+				body: originalBody,
+				state: 'open',
+				labels: [],
+				assignees: [],
+				url: 'https://github.com/owner/repo/issues/42',
+			} as Issue)
+
+			vi.mocked(processMarkdownImages).mockResolvedValue(rewrittenBody)
+
+			await command.execute({ issueNumber: 42, options: {} })
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(originalBody, 'github')
+		})
+
+		it('should pass through bodies with no images unchanged', async () => {
+			const plainBody = 'Just some text with no images.'
+
+			vi.mocked(mockGitHubService.fetchIssue).mockResolvedValue({
+				number: 42,
+				title: 'Test Issue',
+				body: plainBody,
+				state: 'open',
+				labels: [],
+				assignees: [],
+				url: 'https://github.com/owner/repo/issues/42',
+			} as Issue)
+
+			// processMarkdownImages returns the content unchanged when no images exist
+			vi.mocked(processMarkdownImages).mockResolvedValue(plainBody)
+
+			await expect(
+				command.execute({ issueNumber: 42, options: {} })
+			).resolves.not.toThrow()
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(plainBody, 'github')
+		})
+
+		it('should fall back to the original body when image processing throws', async () => {
+			const originalBody = '![img](https://uploads.linear.app/abc/foo.png)'
+
+			const linearService = {
+				fetchIssue: vi.fn(),
+				providerName: 'linear',
+			} as unknown as GitHubService
+			const linearCommand = new EnhanceCommand(linearService, mockEnhancementService, mockSettingsManager)
+
+			vi.mocked(linearService.fetchIssue).mockResolvedValue({
+				number: 42,
+				title: 'Test Issue',
+				body: originalBody,
+				state: 'open',
+				labels: [],
+				assignees: [],
+				url: 'https://linear.app/team/issue/TEAM-42',
+			} as Issue)
+
+			vi.mocked(processMarkdownImages).mockRejectedValue(new Error('network failure'))
+
+			// Should not throw - fall back to original body
+			await expect(
+				linearCommand.execute({ issueNumber: 42, options: {} })
+			).resolves.not.toThrow()
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(originalBody, 'linear')
+		})
+
+		it('should skip image processing for unsupported providers (e.g. jira)', async () => {
+			const jiraService = {
+				fetchIssue: vi.fn(),
+				providerName: 'jira',
+			} as unknown as GitHubService
+			const jiraCommand = new EnhanceCommand(jiraService, mockEnhancementService, mockSettingsManager)
+
+			vi.mocked(jiraService.fetchIssue).mockResolvedValue({
+				number: 42,
+				title: 'Test Issue',
+				body: 'Body with image',
+				state: 'open',
+				labels: [],
+				assignees: [],
+				url: 'https://example.atlassian.net/browse/PROJ-42',
+			} as Issue)
+
+			await jiraCommand.execute({ issueNumber: 42, options: {} })
+
+			expect(processMarkdownImages).not.toHaveBeenCalled()
+		})
+
+		it('should skip image processing when issue body is empty', async () => {
+			vi.mocked(mockGitHubService.fetchIssue).mockResolvedValue({
+				number: 42,
+				title: 'Test Issue',
+				body: '',
+				state: 'open',
+				labels: [],
+				assignees: [],
+				url: 'https://github.com/owner/repo/issues/42',
+			} as Issue)
+
+			await command.execute({ issueNumber: 42, options: {} })
+
+			expect(processMarkdownImages).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/src/commands/enhance.ts
+++ b/src/commands/enhance.ts
@@ -2,12 +2,14 @@ import type { IssueTracker } from '../lib/IssueTracker.js'
 import type { SettingsManager } from '../lib/SettingsManager.js'
 import type { EnhanceResult } from '../types/index.js'
 import type { IssueEnhancementService } from '../lib/IssueEnhancementService.js'
+import type { IssueProvider } from '../mcp/types.js'
 import { openBrowser } from '../utils/browser.js'
 import { waitForKeypress } from '../utils/prompt.js'
 import { getLogger } from '../utils/logger-context.js'
 import { SettingsManager as DefaultSettingsManager } from '../lib/SettingsManager.js'
 import { getConfiguredRepoFromSettings, hasMultipleRemotes } from '../utils/remote.js'
 import { launchFirstRunSetup, needsFirstRunSetup } from '../utils/first-run-setup.js'
+import { processMarkdownImages } from '../utils/image-processor.js'
 
 export interface EnhanceCommandInput {
 	issueNumber: string | number
@@ -79,6 +81,23 @@ export class EnhanceCommand {
 		}
 		const issue = await this.issueTracker.fetchIssue(issueNumber, repo)
 		getLogger().debug('Issue fetched successfully', { number: issue.number, title: issue.title })
+
+		// Process authenticated image URLs in issue body to local cached file paths
+		// before the body is consumed downstream (e.g. by the enhancer Claude prompt).
+		// Only Linear/GitHub providers are supported by processMarkdownImages.
+		const providerName = this.issueTracker.providerName
+		if (issue.body && (providerName === 'linear' || providerName === 'github')) {
+			try {
+				issue.body = await processMarkdownImages(issue.body, providerName as IssueProvider)
+			} catch (error) {
+				if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+					throw error
+				}
+				getLogger().debug(
+					`Failed to process markdown images, falling back to original body: ${error instanceof Error ? error.message : String(error)}`
+				)
+			}
+		}
 
 		// Step 3: Invoke enhancement service
 		if (!isJsonMode) {

--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -14,6 +14,7 @@ import * as identifierParser from '../utils/IdentifierParser.js'
 import { IssueTrackerFactory } from '../lib/IssueTrackerFactory.js'
 import { HarnessServer } from '../lib/HarnessServer.js'
 import type { HarnessHandler } from '../lib/HarnessServer.js'
+import { processMarkdownImages } from '../utils/image-processor.js'
 
 // Mock dependencies
 vi.mock('../utils/claude.js')
@@ -24,6 +25,9 @@ vi.mock('../utils/first-run-setup.js')
 vi.mock('../utils/IdentifierParser.js')
 vi.mock('../mcp/IssueManagementProviderFactory.js')
 vi.mock('../lib/HarnessServer.js')
+vi.mock('../utils/image-processor.js', () => ({
+	processMarkdownImages: vi.fn(),
+}))
 vi.mock('./start.js', () => {
 	class MockStartCommand {
 		async execute() {
@@ -118,6 +122,8 @@ describe('PlanCommand', () => {
 		// Default: TelemetryService mock
 		const mockTrack = vi.fn()
 		vi.mocked(TelemetryService.getInstance).mockReturnValue({ track: mockTrack } as unknown as TelemetryService)
+		// Default: processMarkdownImages returns the input unchanged
+		vi.mocked(processMarkdownImages).mockImplementation(async (content: string) => content)
 	})
 
 	describe('VS Code mode detection', () => {
@@ -951,6 +957,8 @@ describe('PlanCommand', () => {
 			// Setup IssueManagementProviderFactory mock
 			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
 				getChildIssues: mockGetChildIssues,
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockResolvedValue({ id: '42', title: 'Test epic', body: 'Epic body', state: 'open', url: '', provider: 'github', author: null }),
 			} as never)
 
 			// Setup decomposition mode: matchIssueIdentifier returns true for "42"
@@ -1179,6 +1187,220 @@ describe('PlanCommand', () => {
 
 			// generateHarnessMcpConfig called with the harness socket path
 			expect(mcpUtils.generateHarnessMcpConfig).toHaveBeenCalledWith(mockHarnessInstance.path)
+		})
+	})
+
+	describe('image processing on fetched issue body', () => {
+		beforeEach(() => {
+			// Decomposition mode: matchIssueIdentifier returns true for "42"
+			vi.mocked(identifierParser.matchIssueIdentifier).mockReturnValue({
+				isIssueIdentifier: true,
+				type: 'numeric',
+				identifier: '42',
+			})
+
+			// IssueManagementProviderFactory mock — children/dependencies/comments path
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockResolvedValue({ id: '42', title: 'Test', body: '', state: 'open', url: '', provider: 'github', author: null }),
+			} as never)
+		})
+
+		it('invokes processMarkdownImages with provider="github" when tracker is github', async () => {
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
+			const linearImageBody = 'See screenshot ![](https://github.com/user-attachments/assets/abc.png)'
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: linearImageBody }),
+			} as never)
+			vi.mocked(processMarkdownImages).mockResolvedValue('processed-github-body')
+
+			await command.execute('42')
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(linearImageBody, 'github')
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: 'processed-github-body' })
+			)
+		})
+
+		it('invokes processMarkdownImages with provider="linear" when tracker is linear', async () => {
+			const { SettingsManager } = await import('../lib/SettingsManager.js')
+			vi.mocked(SettingsManager).mockImplementation(() => ({
+				loadSettings: vi.fn().mockResolvedValue({ issueManagement: { provider: 'linear' } }),
+				getPlanModel: vi.fn().mockReturnValue('opus'),
+				getPlanPlanner: vi.fn().mockReturnValue('claude'),
+				getPlanReviewer: vi.fn().mockReturnValue('none'),
+				getPlanWaveVerification: vi.fn().mockReturnValue(true),
+				getPlanEffort: vi.fn().mockReturnValue('high'),
+			}) as unknown as InstanceType<typeof SettingsManager>)
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('linear')
+			command = new PlanCommand(mockTemplateManager, mockAgentManager as unknown as AgentManager)
+
+			const linearImageBody = 'See screenshot ![](https://uploads.linear.app/abc.png)'
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: 'ENG-42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 'ENG-42', title: 'Test', body: linearImageBody }),
+			} as never)
+			vi.mocked(processMarkdownImages).mockResolvedValue('processed-linear-body')
+
+			await command.execute('ENG-42')
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(linearImageBody, 'linear')
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: 'processed-linear-body' })
+			)
+		})
+
+		it('returns body unchanged when there are no images', async () => {
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
+			const plainBody = 'Plain text body with no images'
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: plainBody }),
+			} as never)
+			// processMarkdownImages's own contract: no images -> returns input unchanged
+			vi.mocked(processMarkdownImages).mockImplementation(async (content: string) => content)
+
+			await command.execute('42')
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(plainBody, 'github')
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: plainBody })
+			)
+		})
+
+		it('falls back to original body when processMarkdownImages throws', async () => {
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
+			const originalBody = 'body with image ![](https://github.com/user-attachments/assets/x.png)'
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: originalBody }),
+			} as never)
+			vi.mocked(processMarkdownImages).mockRejectedValue(new Error('boom'))
+
+			await command.execute('42')
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: originalBody })
+			)
+		})
+	})
+
+	describe('comment fetching for plan decomposition', () => {
+		beforeEach(() => {
+			vi.mocked(identifierParser.matchIssueIdentifier).mockReturnValue({
+				isIssueIdentifier: true,
+				type: 'numeric',
+				identifier: '42',
+			})
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: 'Body' }),
+			} as never)
+			vi.mocked(processMarkdownImages).mockImplementation(async (content: string) => content)
+		})
+
+		it('appends a Comments section to the body when MCP returns comments', async () => {
+			const mockGetIssue = vi.fn().mockResolvedValue({
+				id: '42',
+				title: 'Test',
+				body: 'Body',
+				state: 'open',
+				url: '',
+				provider: 'github',
+				author: null,
+				comments: [
+					{ id: 'c1', body: 'First comment', author: { id: 'u1', displayName: 'Alice' }, createdAt: '' },
+					{ id: 'c2', body: 'Second comment', author: { id: 'u2', displayName: 'Bob' }, createdAt: '' },
+				],
+			})
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: mockGetIssue,
+			} as never)
+
+			await command.execute('42')
+
+			expect(mockGetIssue).toHaveBeenCalledWith({ number: '42', includeComments: true })
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({
+					PARENT_ISSUE_BODY: expect.stringContaining('## Comments'),
+				})
+			)
+			const call = vi.mocked(mockTemplateManager.getPrompt).mock.calls.find(c => c[0] === 'plan')
+			const body = (call?.[1] as { PARENT_ISSUE_BODY?: string } | undefined)?.PARENT_ISSUE_BODY ?? ''
+			expect(body).toContain('### Comment by Alice')
+			expect(body).toContain('First comment')
+			expect(body).toContain('### Comment by Bob')
+			expect(body).toContain('Second comment')
+		})
+
+		it('omits the Comments section when MCP returns no comments', async () => {
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockResolvedValue({
+					id: '42',
+					title: 'Test',
+					body: 'Body',
+					state: 'open',
+					url: '',
+					provider: 'github',
+					author: null,
+					comments: [],
+				}),
+			} as never)
+
+			await command.execute('42')
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: 'Body' })
+			)
+		})
+
+		it('continues with body-only context when MCP getIssue throws', async () => {
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockRejectedValue(new Error('MCP fetch failure')),
+			} as never)
+
+			await expect(command.execute('42')).resolves.toBeUndefined()
+
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: 'Body' })
+			)
+		})
+
+		it('passes includeComments: true to the MCP getIssue call', async () => {
+			const mockGetIssue = vi.fn().mockResolvedValue({
+				id: '42',
+				title: 'Test',
+				body: 'Body',
+				state: 'open',
+				url: '',
+				provider: 'github',
+				author: null,
+			})
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: mockGetIssue,
+			} as never)
+
+			await command.execute('42')
+
+			expect(mockGetIssue).toHaveBeenCalledWith(expect.objectContaining({ includeComments: true }))
 		})
 	})
 })

--- a/src/commands/plan.test.ts
+++ b/src/commands/plan.test.ts
@@ -1190,7 +1190,7 @@ describe('PlanCommand', () => {
 		})
 	})
 
-	describe('image processing on fetched issue body', () => {
+	describe('body source-of-truth for plan decomposition', () => {
 		beforeEach(() => {
 			// Decomposition mode: matchIssueIdentifier returns true for "42"
 			vi.mocked(identifierParser.matchIssueIdentifier).mockReturnValue({
@@ -1198,34 +1198,41 @@ describe('PlanCommand', () => {
 				type: 'numeric',
 				identifier: '42',
 			})
+		})
 
-			// IssueManagementProviderFactory mock — children/dependencies/comments path
+		it('uses mcpIssue.body as PARENT_ISSUE_BODY (already image-processed by MCP layer)', async () => {
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: 'raw-fetchIssue-body' }),
+			} as never)
+			const mockGetIssue = vi.fn().mockResolvedValue({
+				id: '42',
+				title: 'Test',
+				body: 'mcp-processed-body',
+				state: 'open',
+				url: '',
+				provider: 'github',
+				author: null,
+			})
 			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
 				getChildIssues: vi.fn().mockResolvedValue([]),
 				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
-				getIssue: vi.fn().mockResolvedValue({ id: '42', title: 'Test', body: '', state: 'open', url: '', provider: 'github', author: null }),
+				getIssue: mockGetIssue,
 			} as never)
-		})
-
-		it('invokes processMarkdownImages with provider="github" when tracker is github', async () => {
-			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
-			const linearImageBody = 'See screenshot ![](https://github.com/user-attachments/assets/abc.png)'
-			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
-				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
-				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: linearImageBody }),
-			} as never)
-			vi.mocked(processMarkdownImages).mockResolvedValue('processed-github-body')
 
 			await command.execute('42')
 
-			expect(processMarkdownImages).toHaveBeenCalledWith(linearImageBody, 'github')
+			expect(mockGetIssue).toHaveBeenCalledWith({ number: '42', includeComments: true })
 			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
 				'plan',
-				expect.objectContaining({ PARENT_ISSUE_BODY: 'processed-github-body' })
+				expect.objectContaining({ PARENT_ISSUE_BODY: 'mcp-processed-body' })
 			)
+			// Source-of-truth comes from MCP, so the explicit fallback path is not used.
+			expect(processMarkdownImages).not.toHaveBeenCalled()
 		})
 
-		it('invokes processMarkdownImages with provider="linear" when tracker is linear', async () => {
+		it('preserves Linear attachment section appended by the MCP provider', async () => {
 			const { SettingsManager } = await import('../lib/SettingsManager.js')
 			vi.mocked(SettingsManager).mockImplementation(() => ({
 				loadSettings: vi.fn().mockResolvedValue({ issueManagement: { provider: 'linear' } }),
@@ -1238,47 +1245,67 @@ describe('PlanCommand', () => {
 			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('linear')
 			command = new PlanCommand(mockTemplateManager, mockAgentManager as unknown as AgentManager)
 
-			const linearImageBody = 'See screenshot ![](https://uploads.linear.app/abc.png)'
 			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
 				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: 'ENG-42' }),
-				fetchIssue: vi.fn().mockResolvedValue({ number: 'ENG-42', title: 'Test', body: linearImageBody }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 'ENG-42', title: 'Test', body: 'Original body' }),
 			} as never)
-			vi.mocked(processMarkdownImages).mockResolvedValue('processed-linear-body')
+			const mcpBodyWithAttachments = 'Original body\n\n## Attachments\n\n![screenshot](https://uploads.linear.app/abc.png)'
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockResolvedValue({
+					id: 'ENG-42',
+					title: 'Test',
+					body: mcpBodyWithAttachments,
+					state: 'open',
+					url: '',
+					provider: 'linear',
+					author: null,
+				}),
+			} as never)
 
 			await command.execute('ENG-42')
 
-			expect(processMarkdownImages).toHaveBeenCalledWith(linearImageBody, 'linear')
-			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
-				'plan',
-				expect.objectContaining({ PARENT_ISSUE_BODY: 'processed-linear-body' })
-			)
+			const call = vi.mocked(mockTemplateManager.getPrompt).mock.calls.find(c => c[0] === 'plan')
+			const body = (call?.[1] as { PARENT_ISSUE_BODY?: string } | undefined)?.PARENT_ISSUE_BODY ?? ''
+			expect(body).toContain('## Attachments')
+			expect(body).toContain('![screenshot](https://uploads.linear.app/abc.png)')
 		})
 
-		it('returns body unchanged when there are no images', async () => {
-			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
-			const plainBody = 'Plain text body with no images'
-			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
-				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
-				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: plainBody }),
-			} as never)
-			// processMarkdownImages's own contract: no images -> returns input unchanged
-			vi.mocked(processMarkdownImages).mockImplementation(async (content: string) => content)
-
-			await command.execute('42')
-
-			expect(processMarkdownImages).toHaveBeenCalledWith(plainBody, 'github')
-			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
-				'plan',
-				expect.objectContaining({ PARENT_ISSUE_BODY: plainBody })
-			)
-		})
-
-		it('falls back to original body when processMarkdownImages throws', async () => {
+		it('falls back to processMarkdownImages on raw body when MCP getIssue throws', async () => {
 			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
 			const originalBody = 'body with image ![](https://github.com/user-attachments/assets/x.png)'
 			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
 				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
 				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: originalBody }),
+			} as never)
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockRejectedValue(new Error('MCP fetch failure')),
+			} as never)
+			vi.mocked(processMarkdownImages).mockResolvedValue('fallback-processed-body')
+
+			await command.execute('42')
+
+			expect(processMarkdownImages).toHaveBeenCalledWith(originalBody, 'github')
+			expect(mockTemplateManager.getPrompt).toHaveBeenCalledWith(
+				'plan',
+				expect.objectContaining({ PARENT_ISSUE_BODY: 'fallback-processed-body' })
+			)
+		})
+
+		it('falls back to raw body when both MCP getIssue and processMarkdownImages throw', async () => {
+			vi.mocked(IssueTrackerFactory.getProviderName).mockReturnValue('github')
+			const originalBody = 'body with image ![](https://github.com/user-attachments/assets/x.png)'
+			vi.mocked(IssueTrackerFactory.create).mockReturnValue({
+				detectInputType: vi.fn().mockResolvedValue({ type: 'issue', identifier: '42' }),
+				fetchIssue: vi.fn().mockResolvedValue({ number: 42, title: 'Test', body: originalBody }),
+			} as never)
+			vi.mocked(IssueManagementProviderFactory.create).mockReturnValue({
+				getChildIssues: vi.fn().mockResolvedValue([]),
+				getDependencies: vi.fn().mockResolvedValue({ blocking: [], blockedBy: [] }),
+				getIssue: vi.fn().mockRejectedValue(new Error('MCP fetch failure')),
 			} as never)
 			vi.mocked(processMarkdownImages).mockRejectedValue(new Error('boom'))
 

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -18,6 +18,7 @@ import { needsFirstRunSetup, launchFirstRunSetup } from '../utils/first-run-setu
 import type { IssueProvider, ChildIssueResult, DependenciesResult } from '../mcp/types.js'
 import { promptConfirmation, isInteractiveEnvironment } from '../utils/prompt.js'
 import { TelemetryService } from '../lib/TelemetryService.js'
+import { processMarkdownImages } from '../utils/image-processor.js'
 import { StartCommand } from './start.js'
 import { IgniteCommand } from './ignite.js'
 
@@ -225,44 +226,97 @@ export class PlanCommand {
 			if (detection.type === 'issue' && detection.identifier) {
 				// Valid issue found - fetch full details for decomposition context
 				const issue = await issueTracker.fetchIssue(detection.identifier)
+
+				// Process authenticated image URLs in the body (download + cache + rewrite to local paths).
+				// processMarkdownImages is already fail-open, but wrap defensively so any unexpected
+				// error here cannot break the planning session — fall back to the original body.
+				let processedBody = issue.body
+				try {
+					processedBody = await processMarkdownImages(issue.body, provider as IssueProvider)
+				} catch (error) {
+					if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+						throw error
+					}
+					logger.debug(`processMarkdownImages failed for issue body, falling back to original: ${error instanceof Error ? error.message : String(error)}`)
+					processedBody = issue.body
+				}
+
+				// Construct the MCP provider once and reuse for both comments and children/dependencies.
+				// If construction fails, both fetches are skipped — the planning session continues
+				// with body-only context.
+				let mcpProvider: ReturnType<typeof IssueManagementProviderFactory.create> | null = null
+				try {
+					mcpProvider = IssueManagementProviderFactory.create(provider as IssueProvider, settings ?? undefined)
+				} catch (error) {
+					if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+						throw error
+					}
+					logger.debug(`Failed to construct MCP provider, continuing without comments/children/dependencies: ${error instanceof Error ? error.message : String(error)}`)
+				}
+
+				// Fetch comments via MCP provider so they are image-processed by the same path
+				// as the MCP get_issue tool. We use only the comments here — body was already
+				// fetched and image-processed above via the IssueTracker path.
+				let commentsSection = ''
+				if (mcpProvider) {
+					try {
+						const mcpIssue = await mcpProvider.getIssue({ number: detection.identifier, includeComments: true })
+						if (mcpIssue.comments && mcpIssue.comments.length > 0) {
+							const commentBlocks = mcpIssue.comments.map(c => {
+								const displayName = c.author?.displayName
+								const login = c.author && typeof c.author.login === 'string' ? c.author.login : undefined
+								const author = displayName ?? login ?? 'unknown'
+								const body = c.body || ''
+								return `### Comment by ${author}\n\n${body}`
+							})
+							commentsSection = `\n\n## Comments\n\n${commentBlocks.join('\n\n---\n\n')}`
+						}
+					} catch (error) {
+						if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+							throw error
+						}
+						logger.debug(`Failed to fetch comments for plan context, continuing without comments: ${error instanceof Error ? error.message : String(error)}`)
+					}
+				}
+
 				decompositionContext = {
 					identifier: String(issue.number),
 					title: issue.title,
-					body: issue.body
+					body: processedBody + commentsSection
 				}
 				logger.info(chalk.dim(`Preparing to create a detailed plan for issue #${decompositionContext.identifier}: ${decompositionContext.title}`))
 
 				// Fetch existing children and dependencies using MCP provider
 				// This allows users to resume planning where they left off
-				try {
-					const mcpProvider = IssueManagementProviderFactory.create(provider as IssueProvider, settings ?? undefined)
+				if (mcpProvider) {
+					try {
+						// Fetch child issues
+						logger.debug('Fetching child issues for decomposition context', { identifier: decompositionContext.identifier })
+						const children = await mcpProvider.getChildIssues({ number: decompositionContext.identifier })
+						if (children.length > 0) {
+							decompositionContext.children = children
+							logger.debug('Found existing child issues', { count: children.length })
+						}
 
-					// Fetch child issues
-					logger.debug('Fetching child issues for decomposition context', { identifier: decompositionContext.identifier })
-					const children = await mcpProvider.getChildIssues({ number: decompositionContext.identifier })
-					if (children.length > 0) {
-						decompositionContext.children = children
-						logger.debug('Found existing child issues', { count: children.length })
-					}
-
-					// Fetch dependencies (both directions)
-					logger.debug('Fetching dependencies for decomposition context', { identifier: decompositionContext.identifier })
-					const dependencies = await mcpProvider.getDependencies({
-						number: decompositionContext.identifier,
-						direction: 'both'
-					})
-					if (dependencies.blocking.length > 0 || dependencies.blockedBy.length > 0) {
-						decompositionContext.dependencies = dependencies
-						logger.debug('Found existing dependencies', {
-							blocking: dependencies.blocking.length,
-							blockedBy: dependencies.blockedBy.length
+						// Fetch dependencies (both directions)
+						logger.debug('Fetching dependencies for decomposition context', { identifier: decompositionContext.identifier })
+						const dependencies = await mcpProvider.getDependencies({
+							number: decompositionContext.identifier,
+							direction: 'both'
+						})
+						if (dependencies.blocking.length > 0 || dependencies.blockedBy.length > 0) {
+							decompositionContext.dependencies = dependencies
+							logger.debug('Found existing dependencies', {
+								blocking: dependencies.blocking.length,
+								blockedBy: dependencies.blockedBy.length
+							})
+						}
+					} catch (error) {
+						// Log but don't fail - children/dependencies are optional context
+						logger.debug('Failed to fetch children/dependencies, continuing without them', {
+							error: error instanceof Error ? error.message : 'Unknown error'
 						})
 					}
-				} catch (error) {
-					// Log but don't fail - children/dependencies are optional context
-					logger.debug('Failed to fetch children/dependencies, continuing without them', {
-						error: error instanceof Error ? error.message : 'Unknown error'
-					})
 				}
 			} else {
 				// Input matched issue pattern but issue not found - treat as regular prompt

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -227,23 +227,10 @@ export class PlanCommand {
 				// Valid issue found - fetch full details for decomposition context
 				const issue = await issueTracker.fetchIssue(detection.identifier)
 
-				// Process authenticated image URLs in the body (download + cache + rewrite to local paths).
-				// processMarkdownImages is already fail-open, but wrap defensively so any unexpected
-				// error here cannot break the planning session — fall back to the original body.
-				let processedBody = issue.body
-				try {
-					processedBody = await processMarkdownImages(issue.body, provider as IssueProvider)
-				} catch (error) {
-					if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
-						throw error
-					}
-					logger.debug(`processMarkdownImages failed for issue body, falling back to original: ${error instanceof Error ? error.message : String(error)}`)
-					processedBody = issue.body
-				}
-
-				// Construct the MCP provider once and reuse for both comments and children/dependencies.
-				// If construction fails, both fetches are skipped — the planning session continues
-				// with body-only context.
+				// Construct the MCP provider once and reuse for body+comments and
+				// children/dependencies. If construction fails, all MCP fetches are
+				// skipped and the planning session falls back to issueTracker.fetchIssue's
+				// body, with image-processing run on it explicitly below.
 				let mcpProvider: ReturnType<typeof IssueManagementProviderFactory.create> | null = null
 				try {
 					mcpProvider = IssueManagementProviderFactory.create(provider as IssueProvider, settings ?? undefined)
@@ -254,13 +241,20 @@ export class PlanCommand {
 					logger.debug(`Failed to construct MCP provider, continuing without comments/children/dependencies: ${error instanceof Error ? error.message : String(error)}`)
 				}
 
-				// Fetch comments via MCP provider so they are image-processed by the same path
-				// as the MCP get_issue tool. We use only the comments here — body was already
-				// fetched and image-processed above via the IssueTracker path.
+				// The MCP provider's getIssue is the source of truth for body content:
+				// it already runs processMarkdownImages AND appends provider-specific extras
+				// (e.g. Linear paperclip attachments). Discarding its body would silently drop
+				// attachments from the planning context.
+				let bodyForPlan = issue.body
+				let bodyFromMcp = false
 				let commentsSection = ''
 				if (mcpProvider) {
 					try {
 						const mcpIssue = await mcpProvider.getIssue({ number: detection.identifier, includeComments: true })
+						if (mcpIssue.body) {
+							bodyForPlan = mcpIssue.body
+							bodyFromMcp = true
+						}
 						if (mcpIssue.comments && mcpIssue.comments.length > 0) {
 							const commentBlocks = mcpIssue.comments.map(c => {
 								const displayName = c.author?.displayName
@@ -275,14 +269,29 @@ export class PlanCommand {
 						if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
 							throw error
 						}
-						logger.debug(`Failed to fetch comments for plan context, continuing without comments: ${error instanceof Error ? error.message : String(error)}`)
+						logger.debug(`MCP getIssue failed for plan context, falling back to issueTracker body: ${error instanceof Error ? error.message : String(error)}`)
+					}
+				}
+
+				// Fallback: if MCP didn't supply a body (provider construction failed or
+				// getIssue threw), run image processing directly on the raw fetchIssue body
+				// so authenticated image URLs are still rewritten to local paths.
+				if (!bodyFromMcp) {
+					try {
+						bodyForPlan = await processMarkdownImages(issue.body, provider as IssueProvider)
+					} catch (error) {
+						if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+							throw error
+						}
+						logger.debug(`processMarkdownImages fallback failed, using raw body: ${error instanceof Error ? error.message : String(error)}`)
+						bodyForPlan = issue.body
 					}
 				}
 
 				decompositionContext = {
 					identifier: String(issue.number),
 					title: issue.title,
-					body: processedBody + commentsSection
+					body: bodyForPlan + commentsSection
 				}
 				logger.info(chalk.dim(`Preparing to create a detailed plan for issue #${decompositionContext.identifier}: ${decompositionContext.title}`))
 

--- a/src/mcp/LinearIssueManagementProvider.test.ts
+++ b/src/mcp/LinearIssueManagementProvider.test.ts
@@ -22,6 +22,16 @@ vi.mock('../utils/linear.js', async (importOriginal) => {
 	}
 })
 
+// Mock image-processor so we can assert what body it sees, but preserve the
+// rest of the module (extractMarkdownImageUrls, etc.) for tests that need it.
+vi.mock('../utils/image-processor.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../utils/image-processor.js')>()
+	return {
+		...actual,
+		processMarkdownImages: vi.fn(async (content: string) => content),
+	}
+})
+
 // Import mocked functions for assertions
 import {
 	fetchLinearIssue,
@@ -38,6 +48,7 @@ import {
 	updateLinearIssueState,
 	editLinearIssue,
 } from '../utils/linear.js'
+import { processMarkdownImages, extractMarkdownImageUrls } from '../utils/image-processor.js'
 
 describe('LinearIssueManagementProvider', () => {
 	let provider: LinearIssueManagementProvider
@@ -143,6 +154,173 @@ describe('LinearIssueManagementProvider', () => {
 
 			expect(fetchLinearIssueComments).not.toHaveBeenCalled()
 			expect(result.comments).toBeUndefined()
+		})
+
+		it('should append image attachments to body before image processing', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue with attachments',
+				description: 'Original body content',
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+				attachments: [
+					{
+						id: 'att-1',
+						url: 'https://uploads.linear.app/abc/screenshot.png',
+						title: 'Screenshot',
+					},
+					{
+						id: 'att-2',
+						url: 'https://example.com/image.jpg',
+						title: 'External image',
+					},
+				],
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			expect(result.body).toContain('Original body content')
+			expect(result.body).toContain('## Attachments')
+			expect(result.body).toContain('![Screenshot](https://uploads.linear.app/abc/screenshot.png)')
+			expect(result.body).toContain('![External image](https://example.com/image.jpg)')
+
+			// Verify processMarkdownImages was invoked with the FINAL body (including attachments)
+			expect(processMarkdownImages).toHaveBeenCalledWith(
+				expect.stringContaining('## Attachments'),
+				'linear',
+			)
+		})
+
+		it('should not add Attachments section when attachments are non-image', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue with non-image attachments',
+				description: 'Body content',
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+				attachments: [
+					{
+						id: 'att-1',
+						url: 'https://slack.com/archives/C123/p456',
+						title: 'Slack message',
+					},
+					{
+						id: 'att-2',
+						url: 'https://github.com/foo/bar/pull/123',
+						title: 'GitHub PR',
+					},
+				],
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			expect(result.body).toBe('Body content')
+			expect(result.body).not.toContain('## Attachments')
+		})
+
+		it('should not add Attachments section when no attachments are present', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue without attachments',
+				description: 'Body content',
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			expect(result.body).toBe('Body content')
+			expect(result.body).not.toContain('## Attachments')
+		})
+
+		it('should produce body starting with Attachments section when description is empty', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue with no description',
+				// no description field
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+				attachments: [
+					{
+						id: 'att-1',
+						url: 'https://uploads.linear.app/abc/image.png',
+						title: 'Image',
+					},
+				],
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			expect(result.body.startsWith('## Attachments')).toBe(true)
+		})
+
+		it('should sanitize attachment titles containing markdown-breaking characters', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue with hostile titles',
+				description: 'Body',
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+				attachments: [
+					{
+						id: 'att-1',
+						url: 'https://uploads.linear.app/abc/img1.png',
+						title: 'Has [brackets] and \\backslash',
+					},
+					{
+						id: 'att-2',
+						url: 'https://uploads.linear.app/abc/img2.png',
+						title: 'Has\nnewlines\rcarriage',
+					},
+				],
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			// None of the markdown-breaking characters should remain in the alt-text portion.
+			// Confirm by re-extracting image URLs from the resulting body — both should round-trip.
+			const extracted = extractMarkdownImageUrls(result.body)
+			const urls = extracted.map((m) => m.url)
+			expect(urls).toContain('https://uploads.linear.app/abc/img1.png')
+			expect(urls).toContain('https://uploads.linear.app/abc/img2.png')
+
+			// The body must not contain raw `[`/`]`/`\\`/newline characters between the `![` opener
+			// and the closing `]` of the alt text — otherwise extractMarkdownImageUrls's regex would
+			// have failed and the URLs above would not have been recovered. The assertion above is
+			// the strongest check; additionally verify the literal hostile substrings are gone.
+			expect(result.body).not.toContain('[brackets]')
+			expect(result.body).not.toContain('\\backslash')
+			expect(result.body).not.toMatch(/!\[[^\]]*\n[^\]]*\]/)
 		})
 
 		it('should include comments when requested', async () => {

--- a/src/mcp/LinearIssueManagementProvider.test.ts
+++ b/src/mcp/LinearIssueManagementProvider.test.ts
@@ -323,6 +323,66 @@ describe('LinearIssueManagementProvider', () => {
 			expect(result.body).not.toMatch(/!\[[^\]]*\n[^\]]*\]/)
 		})
 
+		it('should not classify a docs URL with image-extension fragment as an image', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue with docs link attachment',
+				description: 'Body',
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+				attachments: [
+					{
+						id: 'att-1',
+						url: 'https://docs.example.com/guide#section-image.png',
+						title: 'Section guide',
+					},
+				],
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			// The fragment-only "image" must not trigger an Attachments section.
+			expect(result.body).not.toContain('## Attachments')
+			expect(result.body).not.toContain('docs.example.com/guide')
+		})
+
+		it('should URL-encode attachment URLs containing spaces so they remain markdown-extractable', async () => {
+			const mockLinearIssue = {
+				id: 'uuid-123',
+				identifier: 'ENG-123',
+				title: 'Issue with spaced URL',
+				description: 'Body',
+				state: 'Todo',
+				url: 'https://linear.app/issue/ENG-123',
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-02T00:00:00Z',
+				attachments: [
+					{
+						id: 'att-1',
+						url: 'https://uploads.linear.app/abc/file with space.png',
+						title: 'spaced',
+					},
+				],
+			}
+
+			vi.mocked(fetchLinearIssue).mockResolvedValue(mockLinearIssue)
+			vi.mocked(fetchLinearIssueComments).mockResolvedValue([])
+
+			const result = await provider.getIssue({ number: 'ENG-123' })
+
+			expect(result.body).toContain('![spaced](https://uploads.linear.app/abc/file%20with%20space.png)')
+			// The encoded URL must round-trip through extractMarkdownImageUrls
+			const extracted = extractMarkdownImageUrls(result.body)
+			const urls = extracted.map((m) => m.url)
+			expect(urls).toContain('https://uploads.linear.app/abc/file%20with%20space.png')
+		})
+
 		it('should include comments when requested', async () => {
 			const mockLinearIssue = {
 				id: 'uuid-123',

--- a/src/mcp/LinearIssueManagementProvider.ts
+++ b/src/mcp/LinearIssueManagementProvider.ts
@@ -46,6 +46,20 @@ import {
 import { LinearMarkupConverter } from '../utils/linear-markup-converter.js'
 import { processMarkdownImages } from '../utils/image-processor.js'
 
+// Heuristic: file extension indicates an image. Used to filter Linear's mixed attachment list
+// (which may contain non-image files like PDFs, Slack message links, GitHub PR links, etc.).
+const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|svg|bmp|avif|heic|heif)(\?|#|$)/i
+
+function isImageAttachment(att: { url: string; title?: string }): boolean {
+	try {
+		const parsed = new URL(att.url)
+		if (parsed.hostname === 'uploads.linear.app') return true
+	} catch {
+		// invalid URL — fall through to extension check
+	}
+	return IMAGE_EXTENSIONS.test(att.url) || (att.title ? IMAGE_EXTENSIONS.test(att.title) : false)
+}
+
 /**
  * Linear-specific implementation of IssueManagementProvider
  */
@@ -94,6 +108,21 @@ export class LinearIssueManagementProvider implements IssueManagementProvider {
 			linearState: raw.state,
 			createdAt: raw.createdAt,
 			updatedAt: raw.updatedAt,
+		}
+
+		// Append image attachments as markdown image refs so processMarkdownImages picks them up.
+		// Sanitize titles to prevent brackets/newlines/backslashes from breaking the markdown
+		// image syntax (which would also cause extractMarkdownImageUrls's regex to miss them).
+		if (raw.attachments && raw.attachments.length > 0) {
+			const imageAttachments = raw.attachments.filter(isImageAttachment)
+			if (imageAttachments.length > 0) {
+				const lines = imageAttachments.map((a) => {
+					const sanitizedTitle = (a.title || 'attachment').replace(/[[\]\\\n\r]/g, ' ').trim() || 'attachment'
+					return `![${sanitizedTitle}](${a.url})`
+				})
+				const separator = result.body.length > 0 ? '\n\n' : ''
+				result.body = `${result.body}${separator}## Attachments\n\n${lines.join('\n\n')}`
+			}
 		}
 
 		// Fetch comments if requested

--- a/src/mcp/LinearIssueManagementProvider.ts
+++ b/src/mcp/LinearIssueManagementProvider.ts
@@ -54,10 +54,13 @@ function isImageAttachment(att: { url: string; title?: string }): boolean {
 	try {
 		const parsed = new URL(att.url)
 		if (parsed.hostname === 'uploads.linear.app') return true
+		// Test only the pathname so query/fragment fragments like
+		// "...#section-image.png" don't false-positive a docs URL as an image.
+		if (IMAGE_EXTENSIONS.test(parsed.pathname)) return true
 	} catch {
-		// invalid URL — fall through to extension check
+		// invalid URL — fall through to title check
 	}
-	return IMAGE_EXTENSIONS.test(att.url) || (att.title ? IMAGE_EXTENSIONS.test(att.title) : false)
+	return att.title ? IMAGE_EXTENSIONS.test(att.title) : false
 }
 
 /**
@@ -118,7 +121,10 @@ export class LinearIssueManagementProvider implements IssueManagementProvider {
 			if (imageAttachments.length > 0) {
 				const lines = imageAttachments.map((a) => {
 					const sanitizedTitle = (a.title || 'attachment').replace(/[[\]\\\n\r]/g, ' ').trim() || 'attachment'
-					return `![${sanitizedTitle}](${a.url})`
+					// encodeURI preserves existing percent-encoding while encoding spaces, parens,
+					// and other chars that would break extractMarkdownImageUrls's URL regex.
+					// encodeURIComponent would over-encode `://` and break the URL.
+					return `![${sanitizedTitle}](${encodeURI(a.url)})`
 				})
 				const separator = result.body.length > 0 ? '\n\n' : ''
 				result.body = `${result.body}${separator}## Attachments\n\n${lines.join('\n\n')}`

--- a/src/mcp/issue-management-server.ts
+++ b/src/mcp/issue-management-server.ts
@@ -110,7 +110,8 @@ server.registerTool(
 		description:
 			'Fetch issue details including body, title, comments, labels, assignees, and other metadata. ' +
 			'Author fields vary by provider: GitHub uses { login }, Linear uses { name, displayName }, Jira uses { displayName, accountId }. ' +
-			'All authors have normalized core fields: { id, displayName } plus provider-specific fields.',
+			'All authors have normalized core fields: { id, displayName } plus provider-specific fields. ' +
+			'Authenticated images embedded in the body and comments (Linear `uploads.linear.app`, GitHub user-attachments) are automatically downloaded, cached, and rewritten to local file paths so they can be viewed directly. Linear paperclip attachments are surfaced inline as a `## Attachments` section.',
 		inputSchema: {
 			number: z.string().describe('The issue identifier'),
 			includeComments: z
@@ -199,7 +200,8 @@ server.registerTool(
 		description:
 			'Fetch pull request details including title, body, comments, files, commits, and branch information. ' +
 			'Uses the configured VCS provider (GitHub or BitBucket). Falls back to GitHub when no VCS provider is configured. ' +
-			'Author fields have normalized core fields: { id, displayName } plus provider-specific fields.',
+			'Author fields have normalized core fields: { id, displayName } plus provider-specific fields. ' +
+			'Authenticated images embedded in the body and comments (Linear `uploads.linear.app`, GitHub user-attachments) are automatically downloaded, cached, and rewritten to local file paths so they can be viewed directly.',
 		inputSchema: {
 			number: z.string().describe('The PR number'),
 			includeComments: z
@@ -330,7 +332,8 @@ server.registerTool(
 		description:
 			'Fetch inline code review comments on a pull request (comments on specific files and lines). ' +
 			'Returns comments with file path, line number, diff side, author, and reply threading. ' +
-			'Uses the configured VCS provider when available, falls back to GitHub.',
+			'Uses the configured VCS provider when available, falls back to GitHub. ' +
+			'Authenticated images embedded in comment bodies (Linear `uploads.linear.app`, GitHub user-attachments) are automatically downloaded, cached, and rewritten to local file paths so they can be viewed directly.',
 		inputSchema: {
 			number: z.string().describe('The PR number'),
 			reviewId: z
@@ -430,7 +433,8 @@ server.registerTool(
 	{
 		title: 'Get Comment',
 		description:
-			'Fetch a specific comment by ID. Author has normalized core fields { id, displayName } plus provider-specific fields.',
+			'Fetch a specific comment by ID. Author has normalized core fields { id, displayName } plus provider-specific fields. ' +
+			'Authenticated images embedded in the comment body (Linear `uploads.linear.app`, GitHub user-attachments) are automatically downloaded, cached, and rewritten to local file paths so they can be viewed directly.',
 		inputSchema: {
 			commentId: z.string().describe('The comment identifier to fetch'),
 			number: z.string().describe('The issue or PR identifier (context for providers that need it)'),

--- a/src/types/linear.ts
+++ b/src/types/linear.ts
@@ -3,6 +3,20 @@
  */
 
 /**
+ * Linear issue attachment (paperclip-uploaded files separate from description body)
+ */
+export interface LinearIssueAttachment {
+  /** Attachment UUID */
+  id: string
+  /** Attachment URL (may be on uploads.linear.app or external) */
+  url: string
+  /** Title shown in Linear's attachment widget */
+  title: string
+  /** Optional subtitle */
+  subtitle?: string
+}
+
+/**
  * Linear issue response from SDK
  */
 export interface LinearIssue {
@@ -22,6 +36,8 @@ export interface LinearIssue {
   createdAt: string
   /** Last update timestamp (ISO string) */
   updatedAt: string
+  /** Issue attachments (paperclip-uploaded files) */
+  attachments?: LinearIssueAttachment[]
 }
 
 /**

--- a/src/utils/image-processor.test.ts
+++ b/src/utils/image-processor.test.ts
@@ -704,6 +704,70 @@ Some text
       }
     })
 
+    test('sends raw Linear API key without Bearer prefix in Authorization header', async () => {
+      const originalToken = process.env.LINEAR_API_TOKEN
+      process.env.LINEAR_API_TOKEN = 'lin_api_test123'
+
+      // Unique URL to avoid hitting any cached file from prior runs.
+      const url = `https://uploads.linear.app/auth-header-linear-${Date.now()}/image.png`
+
+      try {
+        const content = `![diagram](${url})`
+
+        const imageData = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+        const mockStream = createMockReadableStream([imageData])
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          headers: new Map([['Content-Length', String(imageData.length)]]),
+          body: mockStream
+        })
+
+        await processMarkdownImages(content, 'linear')
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          url,
+          expect.objectContaining({
+            headers: { Authorization: 'lin_api_test123' }
+          })
+        )
+      } finally {
+        if (originalToken) {
+          process.env.LINEAR_API_TOKEN = originalToken
+        } else {
+          delete process.env.LINEAR_API_TOKEN
+        }
+      }
+    })
+
+    test('sends Bearer-prefixed token in Authorization header for GitHub', async () => {
+      // Unique URL to avoid hitting any cached file from prior runs.
+      const url = `https://private-user-images.githubusercontent.com/auth-header-github-${Date.now()}/image.png?jwt=token`
+      const content = `![screenshot](${url})`
+
+      vi.mocked(execa).mockResolvedValueOnce({
+        stdout: 'ghp_testtoken',
+        stderr: '',
+        exitCode: 0
+      } as never)
+
+      const imageData = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+      const mockStream = createMockReadableStream([imageData])
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['Content-Length', String(imageData.length)]]),
+        body: mockStream
+      })
+
+      await processMarkdownImages(content, 'github')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer ghp_testtoken' }
+        })
+      )
+    })
+
     test('uses cached image path when file exists', async () => {
       // Create a cached file
       mkdirSync(CACHE_DIR, { recursive: true })

--- a/src/utils/image-processor.test.ts
+++ b/src/utils/image-processor.test.ts
@@ -1,8 +1,7 @@
 /* global ReadableStream */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, rmSync, utimesSync, readdirSync } from 'node:fs'
 
 // Mock execa before importing the module
 vi.mock('execa', () => ({
@@ -24,6 +23,7 @@ import {
   rewriteMarkdownUrls,
   processMarkdownImages,
   clearCachedGitHubToken,
+  resetPruneFlagForTesting,
   CACHE_DIR
 } from './image-processor.js'
 import { execa } from 'execa'
@@ -32,6 +32,7 @@ describe('ImageProcessor', () => {
   // Clear cached GitHub token before each test to ensure test isolation
   beforeEach(() => {
     clearCachedGitHubToken()
+    resetPruneFlagForTesting()
   })
   describe('extractMarkdownImageUrls', () => {
     test('extracts standard markdown image syntax: ![alt](url)', () => {
@@ -243,15 +244,6 @@ End of content
   })
 
   describe('getCachedImagePath', () => {
-    const testCacheDir = join(tmpdir(), 'iloom-images-test-cache')
-
-    beforeEach(() => {
-      // Clean up test cache directory
-      if (existsSync(testCacheDir)) {
-        rmSync(testCacheDir, { recursive: true })
-      }
-    })
-
     test('returns path when cached file exists', () => {
       // Create the cache directory and a fake cached file
       mkdirSync(CACHE_DIR, { recursive: true })
@@ -419,7 +411,7 @@ End of content
       const url = 'https://uploads.linear.app/test/image.png'
       const destPath = getCacheDestPath(url)
 
-      expect(destPath).toContain('iloom-images')
+      expect(destPath).toContain(CACHE_DIR)
       expect(destPath).toMatch(/\.png$/)
     })
 
@@ -559,7 +551,7 @@ Some text
 
       // Should contain local file path instead of remote URL
       expect(result).not.toContain('private-user-images.githubusercontent.com')
-      expect(result).toContain('iloom-images')
+      expect(result).toContain(CACHE_DIR)
     })
 
     test('downloads and rewrites Linear images', async () => {
@@ -582,7 +574,7 @@ Some text
 
         // Should contain local file path instead of remote URL
         expect(result).not.toContain('uploads.linear.app')
-        expect(result).toContain('iloom-images')
+        expect(result).toContain(CACHE_DIR)
       } finally {
         if (originalToken) {
           process.env.LINEAR_API_TOKEN = originalToken
@@ -707,7 +699,7 @@ Some text
         const result = await processMarkdownImages(content, 'linear')
 
         // First should be replaced (local path)
-        expect(result).toContain('iloom-images')
+        expect(result).toContain(CACHE_DIR)
         // Second should preserve original URL
         expect(result).toContain(secondUrl)
       } finally {
@@ -717,6 +709,146 @@ Some text
           delete process.env.LINEAR_API_TOKEN
         }
       }
+    })
+  })
+
+  describe('stale cache pruning', () => {
+    const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+    // Helper: write a file with a specific mtime
+    function writeFileWithAge(filePath: string, ageMs: number): void {
+      writeFileSync(filePath, 'cached data')
+      const mtime = new Date(Date.now() - ageMs)
+      utimesSync(filePath, mtime, mtime)
+    }
+
+    test('processMarkdownImages triggers pruneStaleCache exactly once per process', async () => {
+      mkdirSync(CACHE_DIR, { recursive: true })
+
+      // Seed: one stale file (older than TTL) and one fresh file
+      const staleName = `prune-test-stale-${Date.now()}.png`
+      const freshName = `prune-test-fresh-${Date.now()}.png`
+      const stalePath = join(CACHE_DIR, staleName)
+      const freshPath = join(CACHE_DIR, freshName)
+
+      writeFileWithAge(stalePath, CACHE_TTL_MS + 60_000) // 1 min past TTL
+      writeFileWithAge(freshPath, 60_000) // 1 min old
+
+      try {
+        // First call: should prune stale, keep fresh
+        await processMarkdownImages('no images here', 'github')
+        expect(existsSync(stalePath)).toBe(false)
+        expect(existsSync(freshPath)).toBe(true)
+
+        // Re-add the stale file: a second call must NOT prune it again (flag is set)
+        writeFileWithAge(stalePath, CACHE_TTL_MS + 60_000)
+        await processMarkdownImages('still no images', 'github')
+        expect(existsSync(stalePath)).toBe(true)
+      } finally {
+        if (existsSync(stalePath)) rmSync(stalePath)
+        if (existsSync(freshPath)) rmSync(freshPath)
+      }
+    })
+
+    test('pruning re-runs after PRUNE_INTERVAL_MS has elapsed', async () => {
+      const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000
+      mkdirSync(CACHE_DIR, { recursive: true })
+
+      const staleName = `prune-test-interval-${Date.now()}.png`
+      const stalePath = join(CACHE_DIR, staleName)
+      writeFileWithAge(stalePath, CACHE_TTL_MS + 60_000)
+
+      try {
+        // First call (lastPruneAt=0) should prune
+        await processMarkdownImages('', 'github')
+        expect(existsSync(stalePath)).toBe(false)
+
+        // Recreate stale file; immediate second call should NOT prune (within interval)
+        writeFileWithAge(stalePath, CACHE_TTL_MS + 60_000)
+        await processMarkdownImages('', 'github')
+        expect(existsSync(stalePath)).toBe(true)
+
+        // Advance Date.now beyond PRUNE_INTERVAL_MS so the next call re-prunes
+        const realNow = Date.now.bind(Date)
+        const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + PRUNE_INTERVAL_MS + 1000)
+        try {
+          await processMarkdownImages('', 'github')
+          expect(existsSync(stalePath)).toBe(false)
+        } finally {
+          dateNowSpy.mockRestore()
+        }
+      } finally {
+        if (existsSync(stalePath)) rmSync(stalePath)
+      }
+    })
+
+    test('after resetPruneFlagForTesting, pruning runs again on next call', async () => {
+      mkdirSync(CACHE_DIR, { recursive: true })
+
+      const staleName = `prune-test-reset-${Date.now()}.png`
+      const stalePath = join(CACHE_DIR, staleName)
+      writeFileWithAge(stalePath, CACHE_TTL_MS + 60_000)
+
+      try {
+        // First call prunes
+        await processMarkdownImages('', 'github')
+        expect(existsSync(stalePath)).toBe(false)
+
+        // Recreate stale file; without reset, second call should NOT prune
+        writeFileWithAge(stalePath, CACHE_TTL_MS + 60_000)
+        await processMarkdownImages('', 'github')
+        expect(existsSync(stalePath)).toBe(true)
+
+        // After reset, next call prunes again
+        resetPruneFlagForTesting()
+        await processMarkdownImages('', 'github')
+        expect(existsSync(stalePath)).toBe(false)
+      } finally {
+        if (existsSync(stalePath)) rmSync(stalePath)
+      }
+    })
+
+    test('keeps files whose mtime is within TTL', async () => {
+      mkdirSync(CACHE_DIR, { recursive: true })
+
+      const freshName = `prune-fresh-only-${Date.now()}.png`
+      const freshPath = join(CACHE_DIR, freshName)
+      // Just under TTL
+      writeFileWithAge(freshPath, CACHE_TTL_MS - 60_000)
+
+      try {
+        await processMarkdownImages('', 'github')
+        expect(existsSync(freshPath)).toBe(true)
+      } finally {
+        if (existsSync(freshPath)) rmSync(freshPath)
+      }
+    })
+
+    test('pruning failure does not throw out of processMarkdownImages', async () => {
+      // Make readdir fail by pointing CACHE_DIR-readdir at... we cannot easily
+      // mutate the dir constant. Instead, simulate failure by ensuring the call
+      // succeeds gracefully even when the cache dir has unreadable contents.
+      // The simplest fail-open assertion: processMarkdownImages completes
+      // normally even if the cache dir doesn't exist.
+      if (existsSync(CACHE_DIR)) {
+        // Remove only if we can; ignore on failure
+        try {
+          // Remove all entries we created in prior tests
+          for (const entry of readdirSync(CACHE_DIR)) {
+            try {
+              rmSync(join(CACHE_DIR, entry))
+            } catch {
+              // ignore
+            }
+          }
+          rmSync(CACHE_DIR, { recursive: true })
+        } catch {
+          // ignore
+        }
+      }
+
+      // Should not throw even though cache dir is missing
+      await expect(processMarkdownImages('', 'github')).resolves.toBe('')
     })
   })
 })

--- a/src/utils/image-processor.test.ts
+++ b/src/utils/image-processor.test.ts
@@ -1,6 +1,7 @@
-/* global ReadableStream */
+/* global ReadableStream, setTimeout */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { existsSync, mkdirSync, writeFileSync, rmSync, utimesSync, readdirSync } from 'node:fs'
 
 // Mock execa before importing the module
@@ -24,6 +25,7 @@ import {
   processMarkdownImages,
   clearCachedGitHubToken,
   resetPruneFlagForTesting,
+  resetLegacyCleanupFlagForTesting,
   CACHE_DIR
 } from './image-processor.js'
 import { execa } from 'execa'
@@ -33,6 +35,7 @@ describe('ImageProcessor', () => {
   beforeEach(() => {
     clearCachedGitHubToken()
     resetPruneFlagForTesting()
+    resetLegacyCleanupFlagForTesting()
   })
   describe('extractMarkdownImageUrls', () => {
     test('extracts standard markdown image syntax: ![alt](url)', () => {
@@ -404,6 +407,84 @@ End of content
       await expect(downloadAndSaveImage('https://example.com/image.png', destPath))
         .rejects.toThrow('Response body is null')
     })
+
+    test('strips auth header on cross-origin redirect (case-insensitive match)', async () => {
+      const imageData = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+
+      // First response: 302 redirect to a different origin
+      mockFetch.mockResolvedValueOnce({
+        status: 302,
+        headers: new Map([['Location', 'https://s3.amazonaws.com/bucket/image.png']])
+      })
+      // Second response: success at new origin (must not include Authorization)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Map([['Content-Length', String(imageData.length)]]),
+        body: createMockReadableStream([imageData])
+      })
+
+      const destPath = join(CACHE_DIR, 'test-redirect-strip-lower.png')
+      await downloadAndSaveImage('https://github.com/img.png', destPath, 'Bearer secret')
+
+      // Verify the second call (after redirect) does NOT include any auth header,
+      // regardless of case. The strip iterates all keys with lowercased comparison
+      // so any future variant ('authorization', 'AUTHORIZATION', etc.) is also dropped.
+      const secondCall = mockFetch.mock.calls[1]
+      const sentHeaders = (secondCall?.[1] as { headers?: Record<string, string> } | undefined)?.headers ?? {}
+      const headerKeys = Object.keys(sentHeaders).map(k => k.toLowerCase())
+      expect(headerKeys).not.toContain('authorization')
+
+      if (existsSync(destPath)) rmSync(destPath)
+    })
+
+    test('preserves Authorization header on same-origin redirect', async () => {
+      const imageData = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+
+      mockFetch.mockResolvedValueOnce({
+        status: 302,
+        headers: new Map([['Location', 'https://github.com/different-path.png']])
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Map([['Content-Length', String(imageData.length)]]),
+        body: createMockReadableStream([imageData])
+      })
+
+      const destPath = join(CACHE_DIR, 'test-redirect-same-origin.png')
+      await downloadAndSaveImage('https://github.com/img.png', destPath, 'Bearer secret')
+
+      const secondCall = mockFetch.mock.calls[1]
+      const sentHeaders = (secondCall?.[1] as { headers?: Record<string, string> } | undefined)?.headers ?? {}
+      expect(sentHeaders['Authorization']).toBe('Bearer secret')
+
+      if (existsSync(destPath)) rmSync(destPath)
+    })
+
+    test('preserves Authorization on same-host http -> https upgrade', async () => {
+      const imageData = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+
+      mockFetch.mockResolvedValueOnce({
+        status: 301,
+        headers: new Map([['Location', 'https://api.example.com/asset.png']])
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Map([['Content-Length', String(imageData.length)]]),
+        body: createMockReadableStream([imageData])
+      })
+
+      const destPath = join(CACHE_DIR, 'test-https-upgrade.png')
+      await downloadAndSaveImage('http://api.example.com/asset.png', destPath, 'Bearer secret')
+
+      const secondCall = mockFetch.mock.calls[1]
+      const sentHeaders = (secondCall?.[1] as { headers?: Record<string, string> } | undefined)?.headers ?? {}
+      expect(sentHeaders['Authorization']).toBe('Bearer secret')
+
+      if (existsSync(destPath)) rmSync(destPath)
+    })
   })
 
   describe('getCacheDestPath', () => {
@@ -421,6 +502,45 @@ End of content
 
       expect(existsSync(CACHE_DIR)).toBe(true)
       expect(destPath.startsWith(CACHE_DIR)).toBe(true)
+    })
+  })
+
+  describe('legacy cache cleanup', () => {
+    test('removes legacy /tmp/iloom-images dir on first ensureCacheDir call', async () => {
+      const legacyDir = join(tmpdir(), 'iloom-images')
+      mkdirSync(legacyDir, { recursive: true })
+      writeFileSync(join(legacyDir, 'stale.png'), 'stale')
+      expect(existsSync(legacyDir)).toBe(true)
+
+      // Trigger ensureCacheDir via the public API
+      getCacheDestPath('https://uploads.linear.app/x/image.png')
+
+      // rm is async fire-and-forget; wait for the microtask/IO to settle
+      for (let i = 0; i < 20 && existsSync(legacyDir); i++) {
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+      expect(existsSync(legacyDir)).toBe(false)
+    })
+
+    test('legacy cleanup runs only once per process (idempotent)', async () => {
+      const legacyDir = join(tmpdir(), 'iloom-images')
+
+      // First call: cleanup runs (flag flips). Reset flag to simulate fresh process.
+      resetLegacyCleanupFlagForTesting()
+      getCacheDestPath('https://uploads.linear.app/x/first.png')
+
+      // Now without resetting, recreate the legacy dir and call again — should NOT be removed.
+      mkdirSync(legacyDir, { recursive: true })
+      writeFileSync(join(legacyDir, 'stale-second.png'), 'stale')
+
+      getCacheDestPath('https://uploads.linear.app/x/second.png')
+
+      // Wait briefly to give any cleanup a chance to run (it shouldn't).
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(existsSync(legacyDir)).toBe(true)
+
+      // Cleanup
+      rmSync(legacyDir, { recursive: true, force: true })
     })
   })
 

--- a/src/utils/image-processor.ts
+++ b/src/utils/image-processor.ts
@@ -1,10 +1,11 @@
-/* global fetch, AbortController, setTimeout, clearTimeout */
-import { tmpdir } from 'node:os'
+/* global fetch, AbortController, AbortSignal, Response, setTimeout, clearTimeout */
+import { homedir } from 'node:os'
 import { join, extname } from 'node:path'
-import { existsSync, mkdirSync, createWriteStream, unlinkSync } from 'node:fs'
+import { existsSync, mkdirSync, createWriteStream } from 'node:fs'
+import { readdir, stat, unlink, rename, chmod } from 'node:fs/promises'
 import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { execa } from 'execa'
 import { logger } from './logger.js'
 import type { IssueProvider } from '../mcp/types.js'
@@ -34,14 +35,51 @@ const MAX_IMAGE_SIZE = 10 * 1024 * 1024
 const REQUEST_TIMEOUT_MS = 30000
 
 /**
- * Cache directory path for downloaded images
+ * Cache directory path for downloaded images.
+ * Lives under the per-user iloom-ai config dir (not /tmp) so it isn't world-readable
+ * and isn't subject to pre-creation/cache-poisoning by other users on shared hosts.
  */
-export const CACHE_DIR = join(tmpdir(), 'iloom-images')
+export const CACHE_DIR = join(homedir(), '.config', 'iloom-ai', 'cache', 'images')
+
+/**
+ * Cache TTL: files older than this are pruned during periodic prune sweeps
+ */
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * How often to run the stale-cache prune sweep within a single process.
+ * Long-running processes (orchestrator, watch mode) need to prune more than once.
+ */
+const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Timestamp of the most recent prune within this process. Zero means "never pruned yet".
+ */
+let lastPruneAt = 0
 
 /**
  * Cached GitHub auth token (module-level to avoid repeated `gh auth token` calls)
  */
 let cachedGitHubToken: string | undefined
+
+/**
+ * Ensure CACHE_DIR exists with restrictive (0o700) permissions.
+ * mkdir's mode is only honored on creation, so chmod defensively to fix
+ * pre-existing dirs that may have been created with broader permissions.
+ */
+function ensureCacheDir(): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 })
+  }
+  // Best-effort defensive chmod; tighten perms if dir already existed with broader mode.
+  // chmod is a no-op on Windows but harmless. Failures are non-fatal.
+  chmod(CACHE_DIR, 0o700).catch((error: unknown) => {
+    if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+      throw error
+    }
+    logger.debug(`chmod on cache dir failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`)
+  })
+}
 
 /**
  * Extract all image URLs from markdown content
@@ -236,7 +274,102 @@ export function clearCachedGitHubToken(): void {
 }
 
 /**
- * Download image from URL and stream it directly to a file
+ * Reset the periodic prune timestamp (for testing purposes)
+ */
+export function resetPruneFlagForTesting(): void {
+  lastPruneAt = 0
+}
+
+/**
+ * Delete cached image files older than CACHE_TTL_MS.
+ * Fail-open: pruning errors must NEVER break the actual image-fetch flow.
+ */
+async function pruneStaleCache(cacheDir: string): Promise<void> {
+  try {
+    if (!existsSync(cacheDir)) {
+      return
+    }
+    const entries = await readdir(cacheDir)
+    const now = Date.now()
+    await Promise.all(entries.map(async (entry) => {
+      const entryPath = join(cacheDir, entry)
+      try {
+        const stats = await stat(entryPath)
+        if (stats.isFile() && now - stats.mtimeMs > CACHE_TTL_MS) {
+          await unlink(entryPath)
+        }
+      } catch (err) {
+        // Per-entry failure is non-fatal; continue pruning others
+        logger.debug(`pruneStaleCache: failed for ${entryPath}: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }))
+  } catch (err) {
+    // Top-level failure is non-fatal; image fetch must proceed
+    logger.debug(`pruneStaleCache: failed to read ${cacheDir}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+/**
+ * Maximum number of redirects to follow before giving up.
+ */
+const MAX_REDIRECTS = 5
+
+/**
+ * Fetch the URL while following redirects manually so we can drop the
+ * Authorization header on cross-origin redirects (e.g., GitHub
+ * /user-attachments/assets/* 302s to S3 / objects.githubusercontent.com,
+ * and we must not leak `Bearer <gh-token>` to AWS).
+ */
+async function fetchFollowingRedirects(
+  initialUrl: string,
+  initialHeaders: Record<string, string>,
+  signal: AbortSignal
+): Promise<Response> {
+  let currentUrl = initialUrl
+  let currentHeaders = { ...initialHeaders }
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const response = await fetch(currentUrl, {
+      headers: currentHeaders,
+      signal,
+      redirect: 'manual',
+    })
+
+    const status = response.status
+    const isRedirect = status === 301 || status === 302 || status === 303 || status === 307 || status === 308
+    if (!isRedirect) {
+      return response
+    }
+
+    const location = response.headers.get('Location') ?? response.headers.get('location')
+    if (!location) {
+      return response
+    }
+
+    const nextUrl = new URL(location, currentUrl).toString()
+    const fromOrigin = new URL(currentUrl).origin
+    const toOrigin = new URL(nextUrl).origin
+
+    if (fromOrigin !== toOrigin && currentHeaders['Authorization']) {
+      // Drop auth header on cross-origin redirect to avoid leaking tokens to third parties.
+      const next = { ...currentHeaders }
+      delete next['Authorization']
+      currentHeaders = next
+    }
+
+    currentUrl = nextUrl
+  }
+
+  throw new Error(`Too many redirects (>${MAX_REDIRECTS}) while downloading image`)
+}
+
+/**
+ * Download image from URL and stream it directly to a file.
+ *
+ * Writes to a per-call temp file (`${destPath}.<uuid>.tmp`) and atomically
+ * renames into place on success. This prevents torn writes when multiple
+ * parallel callers race the same destPath (children processed in Promise.all,
+ * plan + orchestrator in same process, etc.).
  *
  * @param url - Image URL to download
  * @param destPath - Destination file path
@@ -257,8 +390,10 @@ export async function downloadAndSaveImage(
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
 
+  const tmpPath = `${destPath}.${randomUUID()}.tmp`
+
   try {
-    const response = await fetch(url, { headers, signal: controller.signal })
+    const response = await fetchFollowingRedirects(url, headers, controller.signal)
 
     if (!response.ok) {
       throw new Error(`Failed to download image: ${response.status} ${response.statusText}`)
@@ -301,24 +436,27 @@ export async function downloadAndSaveImage(
       }
     })
 
-    // Ensure cache directory exists
-    if (!existsSync(CACHE_DIR)) {
-      mkdirSync(CACHE_DIR, { recursive: true })
-    }
+    ensureCacheDir()
 
-    // Stream to file
-    const writeStream = createWriteStream(destPath)
+    // Stream to per-call temp file, then atomically rename into place on success.
+    const writeStream = createWriteStream(tmpPath)
 
     try {
       await pipeline(nodeReadable, writeStream)
+      await rename(tmpPath, destPath)
     } catch (pipelineError) {
-      // Clean up partial file on error
+      // Clean up temp file on error (best-effort; ignore ENOENT).
       try {
-        if (existsSync(destPath)) {
-          unlinkSync(destPath)
+        await unlink(tmpPath)
+      } catch (unlinkError) {
+        if (
+          unlinkError instanceof TypeError ||
+          unlinkError instanceof ReferenceError ||
+          unlinkError instanceof SyntaxError
+        ) {
+          throw unlinkError
         }
-      } catch {
-        // Ignore cleanup errors
+        // ENOENT and similar fs errors are expected; nothing to clean up.
       }
       throw pipelineError
     }
@@ -339,10 +477,7 @@ export async function downloadAndSaveImage(
  * @returns Local file path where image should be saved
  */
 export function getCacheDestPath(url: string): string {
-  // Ensure cache directory exists
-  if (!existsSync(CACHE_DIR)) {
-    mkdirSync(CACHE_DIR, { recursive: true })
-  }
+  ensureCacheDir()
 
   // Generate cache key from URL
   const cacheKey = getCacheKey(url)
@@ -360,13 +495,16 @@ export function rewriteMarkdownUrls(
   content: string,
   urlMap: Map<string, string>
 ): string {
-  let result = content
+  // Sort by descending key length so that when one URL is a prefix of another
+  // (e.g., same image with and without `?query`), the longer one is replaced
+  // first and isn't corrupted by an earlier replacement of the shorter one.
+  const sorted = [...urlMap.entries()].sort(([a], [b]) => b.length - a.length)
 
-  for (const [originalUrl, localPath] of urlMap) {
-    // Escape special regex characters in the URL
-    const escapedUrl = originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const urlRegex = new RegExp(escapedUrl, 'g')
-    result = result.replace(urlRegex, localPath)
+  let result = content
+  for (const [originalUrl, localPath] of sorted) {
+    // split/join is literal — neither side interprets regex metacharacters
+    // nor `String.prototype.replace`'s special replacement tokens ($&, $1, etc.).
+    result = result.split(originalUrl).join(localPath)
   }
 
   return result
@@ -384,6 +522,18 @@ export async function processMarkdownImages(
   content: string,
   provider: IssueProvider
 ): Promise<string> {
+  // Periodic stale-cache prune (fail-open). Long-running processes (orchestrator,
+  // watch mode) need this to fire on a schedule, not just once per process.
+  if (Date.now() - lastPruneAt > PRUNE_INTERVAL_MS) {
+    lastPruneAt = Date.now()
+    await pruneStaleCache(CACHE_DIR).catch((error: unknown) => {
+      if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+        throw error
+      }
+      logger.debug(`Cache prune failed: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  }
+
   // Early return if empty
   if (!content) {
     return ''

--- a/src/utils/image-processor.ts
+++ b/src/utils/image-processor.ts
@@ -1,8 +1,8 @@
 /* global fetch, AbortController, AbortSignal, Response, setTimeout, clearTimeout */
-import { homedir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join, extname } from 'node:path'
-import { existsSync, mkdirSync, createWriteStream } from 'node:fs'
-import { readdir, stat, unlink, rename, chmod } from 'node:fs/promises'
+import { existsSync, mkdirSync, createWriteStream, chmodSync } from 'node:fs'
+import { readdir, stat, unlink, rename, rm } from 'node:fs/promises'
 import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
 import { createHash, randomUUID } from 'node:crypto'
@@ -63,22 +63,54 @@ let lastPruneAt = 0
 let cachedGitHubToken: string | undefined
 
 /**
+ * One-shot flag for legacy cache cleanup. Reset via resetLegacyCleanupFlagForTesting()
+ * in tests so each test can re-trigger the cleanup path.
+ */
+let legacyCleanedThisRun = false
+
+/**
+ * Best-effort recursive cleanup of the legacy /tmp/iloom-images cache dir from
+ * earlier builds. macOS doesn't reliably purge /tmp on reboot, so users who
+ * upgrade leave a world-readable image cache behind. Runs once per process.
+ */
+function cleanupLegacyCache(): void {
+  if (legacyCleanedThisRun) return
+  legacyCleanedThisRun = true
+
+  const legacyDir = join(tmpdir(), 'iloom-images')
+  if (!existsSync(legacyDir)) return
+
+  rm(legacyDir, { recursive: true, force: true }).catch((error: unknown) => {
+    if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+      throw error
+    }
+    logger.debug(`Failed to remove legacy cache at ${legacyDir}: ${error instanceof Error ? error.message : String(error)}`)
+  })
+}
+
+/**
  * Ensure CACHE_DIR exists with restrictive (0o700) permissions.
  * mkdir's mode is only honored on creation, so chmod defensively to fix
  * pre-existing dirs that may have been created with broader permissions.
+ *
+ * Uses sync chmod so the tightened perms are guaranteed in place before
+ * any caller writes to the dir (the next line in downloadAndSaveImage is
+ * createWriteStream — async chmod could race with the write).
  */
 function ensureCacheDir(): void {
   if (!existsSync(CACHE_DIR)) {
     mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 })
   }
-  // Best-effort defensive chmod; tighten perms if dir already existed with broader mode.
-  // chmod is a no-op on Windows but harmless. Failures are non-fatal.
-  chmod(CACHE_DIR, 0o700).catch((error: unknown) => {
+  try {
+    chmodSync(CACHE_DIR, 0o700)
+  } catch (error) {
     if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
       throw error
     }
     logger.debug(`chmod on cache dir failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`)
-  })
+  }
+
+  cleanupLegacyCache()
 }
 
 /**
@@ -281,6 +313,13 @@ export function resetPruneFlagForTesting(): void {
 }
 
 /**
+ * Reset the legacy-cleanup one-shot flag (for testing purposes)
+ */
+export function resetLegacyCleanupFlagForTesting(): void {
+  legacyCleanedThisRun = false
+}
+
+/**
  * Delete cached image files older than CACHE_TTL_MS.
  * Fail-open: pruning errors must NEVER break the actual image-fetch flow.
  */
@@ -347,13 +386,26 @@ async function fetchFollowingRedirects(
     }
 
     const nextUrl = new URL(location, currentUrl).toString()
-    const fromOrigin = new URL(currentUrl).origin
-    const toOrigin = new URL(nextUrl).origin
+    const fromUrl = new URL(currentUrl)
+    const toUrl = new URL(nextUrl)
 
-    if (fromOrigin !== toOrigin && currentHeaders['Authorization']) {
-      // Drop auth header on cross-origin redirect to avoid leaking tokens to third parties.
-      const next = { ...currentHeaders }
-      delete next['Authorization']
+    // Treat http→https on the same hostname as same-origin for auth purposes.
+    // URL.origin includes the protocol, so a same-host upgrade would otherwise
+    // strip auth and break the follow-up GET with 401.
+    const isHttpsUpgrade =
+      fromUrl.hostname === toUrl.hostname &&
+      fromUrl.protocol === 'http:' &&
+      toUrl.protocol === 'https:'
+    const sameOrigin = fromUrl.origin === toUrl.origin || isHttpsUpgrade
+
+    if (!sameOrigin) {
+      // Drop auth header(s) case-insensitively on cross-origin redirect to avoid
+      // leaking tokens to third parties. HTTP header names are case-insensitive
+      // per spec — strip any key whose lowercased name is 'authorization'.
+      const next: Record<string, string> = {}
+      for (const [k, v] of Object.entries(currentHeaders)) {
+        if (k.toLowerCase() !== 'authorization') next[k] = v
+      }
       currentHeaders = next
     }
 

--- a/src/utils/image-processor.ts
+++ b/src/utils/image-processor.ts
@@ -625,11 +625,16 @@ export async function processMarkdownImages(
       // Cache miss - download and stream directly to file
       logger.debug(`Downloading image: ${url}`)
       const destPath = getCacheDestPath(url)
-      await downloadAndSaveImage(
-        url,
-        destPath,
-        authToken ? `Bearer ${authToken}` : undefined
-      )
+      // Linear personal API keys (lin_api_*) require the raw token in the
+      // Authorization header — Linear's docs reject `Bearer <key>` for personal
+      // keys (only OAuth access tokens use the Bearer scheme). GitHub tokens
+      // continue to use the standard `Bearer <token>` form.
+      const authHeader = authToken
+        ? provider === 'linear'
+          ? authToken
+          : `Bearer ${authToken}`
+        : undefined
+      await downloadAndSaveImage(url, destPath, authHeader)
       return { url, localPath: destPath }
     } catch (error) {
       // Graceful degradation - log warning, return null to keep original URL

--- a/src/utils/linear.test.ts
+++ b/src/utils/linear.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Hoisted shared mock — accessible from both vi.mock factory and test bodies
+const { mockIssueFn } = vi.hoisted(() => ({ mockIssueFn: vi.fn() }))
+
+// Mock @linear/sdk LinearClient before importing the module under test
+vi.mock('@linear/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@linear/sdk')>()
+	return {
+		...actual,
+		LinearClient: vi.fn(),
+	}
+})
+
+import { LinearClient } from '@linear/sdk'
+import { fetchLinearIssue } from './linear.js'
+
+describe('fetchLinearIssue', () => {
+	const baseIssue = {
+		id: 'uuid-123',
+		identifier: 'ENG-123',
+		title: 'Test Issue',
+		description: 'Body text',
+		url: 'https://linear.app/issue/ENG-123',
+		createdAt: new Date('2024-01-01T00:00:00Z'),
+		updatedAt: new Date('2024-01-02T00:00:00Z'),
+		state: Promise.resolve({ name: 'Todo' }),
+	}
+
+	beforeEach(() => {
+		process.env.LINEAR_API_TOKEN = 'test-token'
+		// Re-establish LinearClient impl after global mockReset wipes it between tests
+		vi.mocked(LinearClient).mockImplementation(
+			() => ({ issue: mockIssueFn }) as unknown as LinearClient,
+		)
+	})
+
+	it('returns issue with attachments when SDK returns attachment nodes', async () => {
+		const attachmentsFn = vi.fn().mockResolvedValue({
+			nodes: [
+				{
+					id: 'att-1',
+					url: 'https://uploads.linear.app/abc/image.png',
+					title: 'Screenshot',
+					subtitle: 'A screenshot',
+				},
+				{
+					id: 'att-2',
+					url: 'https://example.com/file.pdf',
+					title: 'Document',
+					subtitle: undefined,
+				},
+			],
+		})
+
+		mockIssueFn.mockResolvedValue({
+			...baseIssue,
+			attachments: attachmentsFn,
+		})
+
+		const result = await fetchLinearIssue('ENG-123')
+
+		expect(result.attachments).toHaveLength(2)
+		expect(result.attachments?.[0]).toEqual({
+			id: 'att-1',
+			url: 'https://uploads.linear.app/abc/image.png',
+			title: 'Screenshot',
+			subtitle: 'A screenshot',
+		})
+		expect(result.attachments?.[1]).toEqual({
+			id: 'att-2',
+			url: 'https://example.com/file.pdf',
+			title: 'Document',
+		})
+	})
+
+	it('returns issue without attachments when SDK returns empty connection', async () => {
+		const attachmentsFn = vi.fn().mockResolvedValue({ nodes: [] })
+
+		mockIssueFn.mockResolvedValue({
+			...baseIssue,
+			attachments: attachmentsFn,
+		})
+
+		const result = await fetchLinearIssue('ENG-123')
+
+		expect(result.attachments).toBeUndefined()
+		expect(result.identifier).toBe('ENG-123')
+	})
+
+	it('returns issue without attachments (and does not throw) when issue.attachments() rejects', async () => {
+		const attachmentsFn = vi.fn().mockRejectedValue(new Error('API failure'))
+
+		mockIssueFn.mockResolvedValue({
+			...baseIssue,
+			attachments: attachmentsFn,
+		})
+
+		const result = await fetchLinearIssue('ENG-123')
+
+		expect(result.attachments).toBeUndefined()
+		expect(result.identifier).toBe('ENG-123')
+		expect(result.title).toBe('Test Issue')
+	})
+})

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -157,6 +157,26 @@ export async function fetchLinearIssue(identifier: string): Promise<LinearIssue>
       }
     }
 
+    // Fetch attachments fail-open: an attachment-fetch failure must not break issue retrieval
+    try {
+      const attachmentConnection = await issue.attachments()
+      if (attachmentConnection?.nodes && attachmentConnection.nodes.length > 0) {
+        result.attachments = attachmentConnection.nodes.map((a) => ({
+          id: a.id,
+          url: a.url,
+          title: a.title,
+          ...(a.subtitle !== undefined && { subtitle: a.subtitle }),
+        }))
+      }
+    } catch (error) {
+      if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+        throw error
+      }
+      logger.debug(
+        `Failed to fetch Linear attachments for ${identifier}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+
     return result
   } catch (error) {
     if (error instanceof LinearServiceError) {

--- a/src/utils/list-children.test.ts
+++ b/src/utils/list-children.test.ts
@@ -6,6 +6,7 @@ import {
   assembleChildrenData,
   fetchChildIssueDetails,
 } from './list-children.js'
+import { processMarkdownImages } from './image-processor.js'
 import type { IssueTracker } from '../lib/IssueTracker.js'
 import type { LoomMetadata, MetadataManager } from '../lib/MetadataManager.js'
 
@@ -16,6 +17,10 @@ vi.mock('./logger.js', () => ({
     info: vi.fn(),
     error: vi.fn(),
   },
+}))
+
+vi.mock('./image-processor.js', () => ({
+  processMarkdownImages: vi.fn(async (content: string) => content),
 }))
 
 // Helper factories
@@ -666,6 +671,91 @@ describe('list-children', () => {
       await fetchChildIssueDetails('100', mockTracker, 'owner/repo')
 
       expect(mockTracker.getChildIssues).toHaveBeenCalledWith('100', 'owner/repo')
+    })
+
+    it('should rewrite images via processMarkdownImages for GitHub provider', async () => {
+      const originalBody = 'See ![img](https://github.com/user-attachments/assets/abc)'
+      const rewrittenBody = 'See ![img](/tmp/iloom-images/cached.png)'
+
+      vi.mocked(processMarkdownImages).mockResolvedValueOnce(rewrittenBody)
+
+      const mockTracker = createMockIssueTracker({
+        providerName: 'github',
+        getChildIssues: vi.fn().mockResolvedValue([
+          { id: '101', title: 'Task 1', url: 'https://github.com/o/r/issues/101', state: 'open' },
+        ]),
+        fetchIssue: vi.fn().mockResolvedValue({
+          number: 101, title: 'Task 1', body: originalBody, state: 'open', labels: [], assignees: [], url: 'url1',
+        }),
+      })
+
+      const result = await fetchChildIssueDetails('100', mockTracker)
+
+      expect(processMarkdownImages).toHaveBeenCalledWith(originalBody, 'github')
+      expect(result[0].body).toBe(rewrittenBody)
+    })
+
+    it('should rewrite images via processMarkdownImages for Linear provider', async () => {
+      const originalBody = 'See ![img](https://uploads.linear.app/abc)'
+      const rewrittenBody = 'See ![img](/tmp/iloom-images/cached.png)'
+
+      vi.mocked(processMarkdownImages).mockResolvedValueOnce(rewrittenBody)
+
+      const mockTracker = createMockIssueTracker({
+        providerName: 'linear',
+        getChildIssues: vi.fn().mockResolvedValue([
+          { id: 'ENG-101', title: 'Linear Task', url: 'https://linear.app/i/ENG-101', state: 'In Progress' },
+        ]),
+        fetchIssue: vi.fn().mockResolvedValue({
+          number: 'ENG-101', title: 'Linear Task', body: originalBody, state: 'open', labels: [], assignees: [], url: 'url',
+        }),
+      })
+
+      const result = await fetchChildIssueDetails('ENG-100', mockTracker)
+
+      expect(processMarkdownImages).toHaveBeenCalledWith(originalBody, 'linear')
+      expect(result[0].body).toBe(rewrittenBody)
+    })
+
+    it('should pass through Jira bodies without invoking processMarkdownImages', async () => {
+      const originalBody = 'Jira body with ![img](https://example.com/img.png)'
+
+      vi.mocked(processMarkdownImages).mockClear()
+
+      const mockTracker = createMockIssueTracker({
+        providerName: 'jira',
+        getChildIssues: vi.fn().mockResolvedValue([
+          { id: 'PROJ-101', title: 'Jira Task', url: 'https://example.atlassian.net/browse/PROJ-101', state: 'Open' },
+        ]),
+        fetchIssue: vi.fn().mockResolvedValue({
+          number: 'PROJ-101', title: 'Jira Task', body: originalBody, state: 'open', labels: [], assignees: [], url: 'url',
+        }),
+      })
+
+      const result = await fetchChildIssueDetails('PROJ-100', mockTracker)
+
+      expect(processMarkdownImages).not.toHaveBeenCalled()
+      expect(result[0].body).toBe(originalBody)
+    })
+
+    it('should fall back to original body when processMarkdownImages throws', async () => {
+      const originalBody = 'See ![img](https://uploads.linear.app/abc)'
+
+      vi.mocked(processMarkdownImages).mockRejectedValueOnce(new Error('download failed'))
+
+      const mockTracker = createMockIssueTracker({
+        providerName: 'linear',
+        getChildIssues: vi.fn().mockResolvedValue([
+          { id: 'ENG-101', title: 'Linear Task', url: 'https://linear.app/i/ENG-101', state: 'In Progress' },
+        ]),
+        fetchIssue: vi.fn().mockResolvedValue({
+          number: 'ENG-101', title: 'Linear Task', body: originalBody, state: 'open', labels: [], assignees: [], url: 'url',
+        }),
+      })
+
+      const result = await fetchChildIssueDetails('ENG-100', mockTracker)
+
+      expect(result[0].body).toBe(originalBody)
     })
   })
 })

--- a/src/utils/list-children.ts
+++ b/src/utils/list-children.ts
@@ -11,6 +11,8 @@
 import { MetadataManager, type LoomMetadata } from '../lib/MetadataManager.js'
 import type { IssueTracker } from '../lib/IssueTracker.js'
 import { logger } from './logger.js'
+import { processMarkdownImages } from './image-processor.js'
+import type { IssueProvider } from '../mcp/types.js'
 
 // ============================================================================
 // Type Definitions
@@ -315,10 +317,11 @@ export async function fetchChildIssueDetails(
     childIssues.map(async (child): Promise<ChildIssueDetail> => {
       try {
         const fullIssue = await issueTracker.fetchIssue(child.id, repo)
+        const processedBody = await processChildIssueBody(fullIssue.body, providerName)
         return {
           number: formatIssueNumber(child.id, providerName),
           title: fullIssue.title,
-          body: fullIssue.body,
+          body: processedBody,
           url: child.url,
         }
       } catch {
@@ -344,6 +347,32 @@ export async function fetchChildIssueDetails(
   }
 
   return details
+}
+
+/**
+ * Process a child issue body to download authenticated images and rewrite URLs to local cache paths.
+ *
+ * Only runs for providers supported by image-processor ('github' | 'linear'). Other providers
+ * (e.g., 'jira') pass through unchanged. Errors are logged at debug level and the original
+ * body is returned, so image processing failures never block CHILD_ISSUES JSON construction.
+ */
+async function processChildIssueBody(body: string, providerName: string): Promise<string> {
+  if (providerName !== 'github' && providerName !== 'linear') {
+    return body
+  }
+
+  try {
+    return await processMarkdownImages(body, providerName as IssueProvider)
+  } catch (error) {
+    if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError) {
+      throw error
+    }
+    logger.debug('Failed to process images in child issue body', {
+      error: error instanceof Error ? error.message : String(error),
+      providerName,
+    })
+    return body
+  }
 }
 
 /**

--- a/templates/prompts/issue-prompt.txt
+++ b/templates/prompts/issue-prompt.txt
@@ -54,6 +54,19 @@ If you need to access the web server for testing purposes, use localhost:{{PORT}
 {{/if}}
 {{/unless}}
 
+## Issue Tracker Tools — Use iloom's `mcp__issue_management__*` Tools
+
+Always use the bundled `mcp__issue_management__*` MCP tools (e.g. `mcp__issue_management__get_issue`, `mcp__issue_management__get_pr`, `mcp__issue_management__get_child_issues`, `mcp__issue_management__create_comment`) for ALL issue-tracker reads and writes.
+
+DO NOT use provider-specific MCP servers the user may have installed globally (e.g. `mcp__claude_ai_Linear__*`, `mcp__claude_ai_Github__*`, `mcp__github__*`). Those return raw image URLs that you cannot view without manual auth handling.
+
+iloom's `mcp__issue_management__*` tools automatically:
+- Download authenticated images (Linear `uploads.linear.app`, GitHub user-attachments) and rewrite the URLs in issue/comment bodies to local cached file paths, so embedded screenshots and attachment images are immediately viewable.
+- Surface Linear paperclip attachments inline in the body as a `## Attachments` section.
+- Route correctly across GitHub, Linear, and Jira based on project configuration.
+
+If you see a raw `https://uploads.linear.app/...` or `https://github.com/user-attachments/assets/...` URL in tool output, that means you used the wrong tool — fall back to `mcp__issue_management__get_issue` instead.
+
 ## Loom Recap
 
 **IMPORTANT: The recap is NOT a work log. It's a knowledge capture system for the USER.**

--- a/templates/prompts/plan-prompt.txt
+++ b/templates/prompts/plan-prompt.txt
@@ -458,6 +458,19 @@ Place integration must-haves on the wave's verification issue, NOT on the indivi
 3. Create issues only after user approval
 {{/unless}}
 
+## Issue Tracker Tools — Use iloom's `mcp__issue_management__*` Tools
+
+Always use the bundled `mcp__issue_management__*` MCP tools (e.g. `mcp__issue_management__get_issue`, `mcp__issue_management__get_pr`, `mcp__issue_management__get_child_issues`, `mcp__issue_management__create_comment`) for ALL issue-tracker reads and writes.
+
+DO NOT use provider-specific MCP servers the user may have installed globally (e.g. `mcp__claude_ai_Linear__*`, `mcp__claude_ai_Github__*`, `mcp__github__*`). Those return raw image URLs that you cannot view without manual auth handling.
+
+iloom's `mcp__issue_management__*` tools automatically:
+- Download authenticated images (Linear `uploads.linear.app`, GitHub user-attachments) and rewrite the URLs in issue/comment bodies to local cached file paths, so embedded screenshots and attachment images are immediately viewable.
+- Surface Linear paperclip attachments inline in the body as a `## Attachments` section.
+- Route correctly across GitHub, Linear, and Jira based on project configuration.
+
+If you see a raw `https://uploads.linear.app/...` or `https://github.com/user-attachments/assets/...` URL in tool output, that means you used the wrong tool — fall back to `mcp__issue_management__get_issue` instead.
+
 {{#if EXISTING_ISSUE_MODE}}
 **Issue Decomposition Mode:**
 

--- a/templates/prompts/swarm-orchestrator-prompt.txt
+++ b/templates/prompts/swarm-orchestrator-prompt.txt
@@ -19,6 +19,21 @@ You are a **coordinator**, not an executor. Your job is to schedule work, track 
 
 ---
 
+## Issue Tracker Tools — Use iloom's `mcp__issue_management__*` Tools
+
+Always use the bundled `mcp__issue_management__*` MCP tools (e.g. `mcp__issue_management__get_issue`, `mcp__issue_management__get_pr`, `mcp__issue_management__get_child_issues`, `mcp__issue_management__create_comment`) for ALL issue-tracker reads and writes.
+
+DO NOT use provider-specific MCP servers the user may have installed globally (e.g. `mcp__claude_ai_Linear__*`, `mcp__claude_ai_Github__*`, `mcp__github__*`). Those return raw image URLs that you cannot view without manual auth handling.
+
+iloom's `mcp__issue_management__*` tools automatically:
+- Download authenticated images (Linear `uploads.linear.app`, GitHub user-attachments) and rewrite the URLs in issue/comment bodies to local cached file paths, so embedded screenshots and attachment images are immediately viewable.
+- Surface Linear paperclip attachments inline in the body as a `## Attachments` section.
+- Route correctly across GitHub, Linear, and Jira based on project configuration.
+
+If you see a raw `https://uploads.linear.app/...` or `https://github.com/user-attachments/assets/...` URL in tool output, that means you used the wrong tool — fall back to `mcp__issue_management__get_issue` instead.
+
+---
+
 ## Loom Recap
 
 The recap panel is visible to the user in VS Code. Use these Recap MCP tools to capture knowledge:


### PR DESCRIPTION
Fixes #1004

## Add support for downloading/using images added/inlined to Linear issues

<details>
<summary>Issue details</summary>

Currently it seems they are not used at all by epic planning or issue workflow

</details>

---
*This PR was created automatically by iloom.*