### PR TITLE
fix(update): support Volta-managed installs

### DIFF
--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { UpdateCommand } from './update.js'
-import { detectInstallationMethod } from '../utils/installation-detector.js'
+import { detectInstallationMethod, isVoltaInstall } from '../utils/installation-detector.js'
 import { logger } from '../utils/logger.js'
 import { UpdateNotifier } from '../utils/update-notifier.js'
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import { default as fs } from 'fs-extra'
 
 // Mock dependencies
@@ -18,7 +18,8 @@ vi.mock('../utils/logger.js', () => ({
 }))
 
 vi.mock('../utils/installation-detector.js', () => ({
-  detectInstallationMethod: vi.fn()
+  detectInstallationMethod: vi.fn(),
+  isVoltaInstall: vi.fn()
 }))
 
 vi.mock('../utils/update-notifier.js', () => ({
@@ -32,7 +33,8 @@ vi.mock('fs-extra', () => ({
 }))
 
 vi.mock('child_process', () => ({
-  spawn: vi.fn()
+  spawn: vi.fn(),
+  spawnSync: vi.fn()
 }))
 
 describe('UpdateCommand', () => {
@@ -53,6 +55,11 @@ describe('UpdateCommand', () => {
       name: '@iloom/cli',
       version: '1.0.0'
     }))
+
+    // Default: not a Volta install
+    vi.mocked(isVoltaInstall).mockReturnValue(false)
+    // Default: any command is available
+    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as never)
   })
 
   it('exits with error for non-global installations', async () => {
@@ -151,6 +158,79 @@ describe('UpdateCommand', () => {
     expect(logger.info).toHaveBeenCalledWith('   Would run: npm install -g @iloom/cli@latest')
     expect(logger.info).toHaveBeenCalledWith('   Current version: 1.0.0')
     expect(logger.info).toHaveBeenCalledWith('   Target version: 1.1.0')
+  })
+
+  it('uses volta install when running under a Volta-managed install', async () => {
+    vi.mocked(detectInstallationMethod).mockReturnValue('global')
+    vi.mocked(isVoltaInstall).mockReturnValue(true)
+
+    const mockCheckForUpdates = vi.fn().mockResolvedValue({
+      updateAvailable: true,
+      currentVersion: '1.0.0',
+      latestVersion: '1.1.0'
+    })
+    vi.mocked(UpdateNotifier).mockImplementation(() => ({
+      checkForUpdates: mockCheckForUpdates
+    }) as never)
+
+    let closeCallback: ((code: number) => void) | undefined
+    const mockOn = vi.fn((event: string, callback: (code: number) => void) => {
+      if (event === 'close') closeCallback = callback
+    })
+    vi.mocked(spawn).mockReturnValue({ on: mockOn } as never)
+    mockExit.mockImplementation((() => {}) as never)
+
+    await updateCommand.execute()
+
+    expect(spawn).toHaveBeenCalledWith('volta', ['install', '@iloom/cli@latest'], {
+      stdio: 'inherit'
+    })
+    closeCallback!(0)
+    expect(mockExit).toHaveBeenCalledWith(0)
+  })
+
+  it('shows a helpful error when Volta-managed but volta is not on PATH', async () => {
+    vi.mocked(detectInstallationMethod).mockReturnValue('global')
+    vi.mocked(isVoltaInstall).mockReturnValue(true)
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as never)
+
+    const mockCheckForUpdates = vi.fn().mockResolvedValue({
+      updateAvailable: true,
+      currentVersion: '1.0.0',
+      latestVersion: '1.1.0'
+    })
+    vi.mocked(UpdateNotifier).mockImplementation(() => ({
+      checkForUpdates: mockCheckForUpdates
+    }) as never)
+
+    await expect(updateCommand.execute()).rejects.toThrow('process.exit(1)')
+
+    expect(spawn).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Volta')
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('~/.volta/bin')
+    )
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it('shows volta command in dry run when Volta-managed', async () => {
+    vi.mocked(detectInstallationMethod).mockReturnValue('global')
+    vi.mocked(isVoltaInstall).mockReturnValue(true)
+
+    const mockCheckForUpdates = vi.fn().mockResolvedValue({
+      updateAvailable: true,
+      currentVersion: '1.0.0',
+      latestVersion: '1.1.0'
+    })
+    vi.mocked(UpdateNotifier).mockImplementation(() => ({
+      checkForUpdates: mockCheckForUpdates
+    }) as never)
+
+    await updateCommand.execute({ dryRun: true })
+
+    expect(logger.info).toHaveBeenCalledWith('   Would run: volta install @iloom/cli@latest')
   })
 
   it('exits with error when update check fails', async () => {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,9 +1,9 @@
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import fs from 'fs-extra'
 import { logger } from '../utils/logger.js'
-import { detectInstallationMethod } from '../utils/installation-detector.js'
+import { detectInstallationMethod, isVoltaInstall } from '../utils/installation-detector.js'
 import { UpdateNotifier } from '../utils/update-notifier.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -30,11 +30,15 @@ export class UpdateCommand {
         default:
           logger.info('Unable to determine installation method.')
           logger.info('If globally installed, try: npm install -g @iloom/cli@latest')
+          logger.info('If installed via Volta, try: volta install @iloom/cli@latest')
           break
       }
 
       process.exit(1)
     }
+
+    const voltaManaged = isVoltaInstall(__filename)
+    logger.debug(`[update] Volta-managed install: ${voltaManaged}`)
 
     // Get current version from package.json
     const packageJsonPath = join(__dirname, '..', 'package.json')
@@ -63,18 +67,36 @@ export class UpdateCommand {
     // Show update info and proceed
     logger.info(`Update available: ${updateResult.currentVersion} → ${updateResult.latestVersion}`)
 
+    const updateCommand = voltaManaged ? 'volta' : 'npm'
+    const updateArgs = voltaManaged
+      ? ['install', `${packageName}@latest`]
+      : ['install', '-g', `${packageName}@latest`]
+
     if (options.dryRun) {
       logger.info('🔍 DRY RUN - showing what would be done:')
-      logger.info(`   Would run: npm install -g ${packageName}@latest`)
+      logger.info(`   Would run: ${updateCommand} ${updateArgs.join(' ')}`)
       logger.info(`   Current version: ${currentVersion}`)
       logger.info(`   Target version: ${updateResult.latestVersion}`)
       logger.debug(`[update] Dry run complete, skipping actual update`)
       return
     }
 
+    if (voltaManaged && !isCommandAvailable('volta')) {
+      logger.error('iloom appears to be installed under Volta (~/.volta/), but the `volta` command is not available on your PATH.')
+      logger.info('')
+      logger.info('Volta needs its shim directory on PATH to update packages. To fix:')
+      logger.info('  1. Ensure ~/.volta/bin is on your PATH (Volta usually adds this during install).')
+      logger.info('  2. Reload your shell: exec $SHELL -l')
+      logger.info('  3. Verify with: which volta')
+      logger.info('  4. If Volta was uninstalled, reinstall from https://volta.sh, or remove ~/.volta and reinstall iloom with: npm install -g @iloom/cli@latest')
+      logger.info('')
+      logger.info(`Once \`volta\` is available, re-run: il update  (or manually: volta install ${packageName}@latest)`)
+      process.exit(1)
+    }
+
     logger.info('🔄 Starting update...')
 
-    const child = spawn('npm', ['install', '-g', `${packageName}@latest`], {
+    const child = spawn(updateCommand, updateArgs, {
       stdio: 'inherit'
     })
 
@@ -87,4 +109,10 @@ export class UpdateCommand {
       process.exit(code ?? 0)
     })
   }
+}
+
+function isCommandAvailable(cmd: string): boolean {
+  const which = process.platform === 'win32' ? 'where' : 'which'
+  const result = spawnSync(which, [cmd], { stdio: 'ignore' })
+  return result.status === 0
 }

--- a/src/utils/installation-detector.test.ts
+++ b/src/utils/installation-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { detectInstallationMethod, shouldShowUpdateNotification } from './installation-detector.js'
+import { detectInstallationMethod, isVoltaInstall, shouldShowUpdateNotification } from './installation-detector.js'
 import fs from 'fs'
 import type { Stats } from 'fs'
 
@@ -135,6 +135,38 @@ describe('detectInstallationMethod', () => {
 
     const result = detectInstallationMethod('/path/to/script')
     expect(result).toBe('unknown')
+  })
+})
+
+describe('isVoltaInstall', () => {
+  beforeEach(() => {
+    vi.mocked(fs.realpathSync).mockImplementation((path: string | Buffer) => path as string)
+  })
+
+  it('returns true for paths under ~/.volta/', () => {
+    expect(
+      isVoltaInstall('/Users/user/.volta/tools/image/packages/@iloom/cli/lib/node_modules/@iloom/cli/dist/cli.js')
+    ).toBe(true)
+  })
+
+  it('returns true when a symlink resolves into ~/.volta/', () => {
+    vi.mocked(fs.realpathSync).mockReturnValue(
+      '/Users/user/.volta/tools/image/packages/@iloom/cli/lib/node_modules/@iloom/cli/dist/cli.js'
+    )
+    expect(isVoltaInstall('/Users/user/.volta/bin/il')).toBe(true)
+  })
+
+  it('returns false for non-Volta global installs', () => {
+    expect(
+      isVoltaInstall('/Users/user/.nvm/versions/node/v22.17.0/lib/node_modules/@iloom/cli/dist/cli.js')
+    ).toBe(false)
+  })
+
+  it('returns false when realpathSync throws and the original path is not Volta', () => {
+    vi.mocked(fs.realpathSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    expect(isVoltaInstall('/usr/local/lib/node_modules/@iloom/cli/dist/cli.js')).toBe(false)
   })
 })
 

--- a/src/utils/installation-detector.ts
+++ b/src/utils/installation-detector.ts
@@ -99,3 +99,19 @@ export function detectInstallationMethod(scriptPath: string): InstallationMethod
 export function shouldShowUpdateNotification(method: InstallationMethod): boolean {
   return method === 'global'
 }
+
+/**
+ * Detect whether the script is installed under Volta's tools directory.
+ * Volta installs packages at ~/.volta/tools/image/packages/<pkg>/lib/node_modules/<pkg>/...
+ * so a `/.volta/` segment in the resolved script path is a reliable signal.
+ */
+export function isVoltaInstall(scriptPath: string): boolean {
+  let resolved = scriptPath
+  try {
+    resolved = realpathSync(scriptPath)
+  } catch {
+    // fall through with the original path
+  }
+  const normalized = resolved.replace(/\\/g, '/')
+  return normalized.includes('/.volta/')
+}


### PR DESCRIPTION
## Summary
- `il update` now detects installs under `~/.volta/` and runs `volta install @iloom/cli@latest` instead of `npm install -g`, which doesn't reliably upgrade Volta-managed packages.
- If the install is Volta-managed but `volta` isn't on PATH, surface a focused error explaining how to fix it (PATH check, shell reload, `which volta`, reinstall path) instead of silently failing.
- Mention Volta in the unknown-install hint and dry-run output.

## Test plan
- [x] `pnpm vitest run src/commands/update.test.ts src/utils/installation-detector.test.ts` — 21 tests pass (3 new Volta-path tests in update + 4 in detector)
- [x] `pnpm build` clean
- [ ] Manual smoke test once published: Volta user runs `il update` and gets upgraded to latest