### PR TITLE
chore(hook): route complex tasks through swarm-worker in UserPromptSubmit reminder

### DIFF
--- a/templates/hooks/iloom-hook.js
+++ b/templates/hooks/iloom-hook.js
@@ -325,15 +325,16 @@ async function main() {
 
         if (swarmCompleted) {
           // Swarm finished — show full routing table with swarm-prefixed agents
-          const reminder = `**REMINDER**: You MUST USE subagents to preserve your context window for ongoing conversation.
+          const reminder = `**REMINDER**: You MUST USE subagents to preserve your context window for ongoing conversation. Do not ask analysis agent to implement fixes.
 
 | Request Type | Action |
 |--------------|--------|
-| Trivial (quick answer, single-line fix) | Handle directly |
+| Trivial (quick answer, 1 to 3 line fix in a single file) | Handle directly |
 | Bug investigation / analysis - ESPECIALLY INVOLVING 3rd PARTY APIs/LIBRARIES | \`@agent-iloom-swarm-issue-analyzer\` → present findings → offer to fix |
 | Code changes | \`@agent-iloom-swarm-issue-implementer\` - TELL THE AGENT NOT TO MAKE/UPDATE ISSUE COMMENTS TO AVOID POLLUTION |
 | On 3rd repeated attempt at fixing the same problem | \`@agent-iloom-swarm-issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm-issue-implementer\` - DO NOT PROVIDE ADDITIONAL GUIDANCE ABOUT ISSUE COMMENTS |
-| New features / complex changes | \`@agent-iloom-swarm-issue-analyze-and-plan\` → if approved, \`@agent-iloom-swarm-issue-implementer\` - IN THIS CASE IT'S OK TO CREATE/UPDATE ISSUE COMMENTS |
+| New features / complex changes | Create a child issue, then dispatch via \`@agent-iloom-swarm-worker\` |
+| Multiple issues at once | Spawn ONE agent team for the whole set with multiple \`@agent-iloom-swarm-worker\` workers running in parallel |
 | Deep questions (how/why something works) | \`@agent-iloom-swarm-issue-analyzer\` |
 | Code review request | \`@agent-iloom-swarm-code-reviewer\` |`;
           const output = {
@@ -360,7 +361,7 @@ async function main() {
         process.exit(0);
       }
 
-      const reminder = `**REMINDER**: You MUST USE subagents to preserve your context window for ongoing conversation.
+      const reminder = `**REMINDER**: You MUST USE subagents to preserve your context window for ongoing conversation. Do not ask analysis agent to implement fixes.
 
 | Request Type | Action |
 |--------------|--------|


### PR DESCRIPTION
## Summary
- Swarm-completed UserPromptSubmit reminder: kept the prose tight ("Do not ask analysis agent to implement fixes") and folded the new routing into the table — "New features / complex changes" goes through a child issue + \`@agent-iloom-swarm-worker\`, and a new "Multiple issues at once" row says spawn ONE agent team with multiple parallel \`@agent-iloom-swarm-worker\` workers.
- Non-swarm UserPromptSubmit reminder: added the same "Do not ask analysis agent to implement fixes" warning.

## Test plan
- [ ] Manual: in a swarm session post-completion, submit a prompt and verify the additionalContext shows the updated table
- [ ] Manual: in a regular session, submit a prompt and verify the analyzer warning is now in the preamble