### PR TITLE
fix(settings): defer global settings validation until after merge

### DIFF
--- a/src/lib/SettingsManager.test.ts
+++ b/src/lib/SettingsManager.test.ts
@@ -2574,14 +2574,24 @@ const error: { code?: string; message: string } = {
 				expect(result).toEqual({})
 			})
 
-			it('should warn but return empty object on validation error', async () => {
-				const invalidSettings = {
-					mainBranch: 123, // Invalid: should be string
-				}
-				vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify(invalidSettings))
+			it('should warn but return empty object when content is not a JSON object', async () => {
+				vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify(['not', 'an', 'object']))
 
 				const result = await settingsManager['loadGlobalSettingsFile']()
 				expect(result).toEqual({})
+			})
+
+			it('should pass schema-invalid global settings through for post-merge validation', async () => {
+				// Schema validation no longer runs per-file — it happens after merge in
+				// loadSettings() so partial configs (e.g. shared apiToken in global with
+				// teamId set per-project) are not rejected before the merge completes.
+				const partiallyInvalidSettings = {
+					mainBranch: 123, // Bad type — caught later by loadSettings()
+				}
+				vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify(partiallyInvalidSettings))
+
+				const result = await settingsManager['loadGlobalSettingsFile']()
+				expect(result).toEqual(partiallyInvalidSettings)
 			})
 		})
 

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -1369,19 +1369,18 @@ export class SettingsManager {
 				return {}
 			}
 
-			// Validate with non-defaulting schema
-			try {
-				const validated = IloomSettingsSchemaNoDefaults.strict().parse(parsed)
-				return validated
-			} catch (error) {
-				if (error instanceof z.ZodError) {
-					const errorMsg = this.formatAllZodErrors(error, 'global settings')
-					logger.warn(`${errorMsg.message}. Ignoring global settings.`)
-				} else {
-					logger.warn(`Validation error in global settings: ${error instanceof Error ? error.message : 'Unknown error'}. Ignoring global settings.`)
-				}
+			// Only enforce that the file is a JSON object here. Full schema validation
+			// happens post-merge in loadSettings() so that partial configs (e.g. a
+			// shared apiToken in global with teamId set per-project) are not rejected
+			// before the merge has a chance to complete them.
+			if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+				logger.warn(
+					`Global settings at ${settingsPath} is not a JSON object (received ${Array.isArray(parsed) ? 'array' : typeof parsed}). Ignoring global settings.`,
+				)
 				return {}
 			}
+
+			return parsed as z.infer<typeof IloomSettingsSchemaNoDefaults>
 		} catch (error) {
 			// File not found is not an error - return empty settings
 			if ((error as { code?: string }).code === 'ENOENT') {


### PR DESCRIPTION
## Summary
- Global settings were validated standalone with the strict no-defaults schema, while project/local files deliberately defer to post-merge validation. Valid configs were getting dropped with `Settings validation failed at global settings ... Ignoring global settings.`
- Align `loadGlobalSettingsFile` with `loadSettingsFile`: only enforce that the file is a JSON object, and let `loadSettings()` be the single source of truth for schema validation after merging.
- Updates one unit test that asserted the old per-file Zod validation; adds a test that confirms partial/incomplete global settings now pass through.

## Test plan
- [x] `pnpm vitest run src/lib/SettingsManager.test.ts` (261 passing)
- [x] `pnpm build`
- [ ] Verify a global `~/.config/iloom-ai/settings.json` containing only a Linear `apiToken` (with `teamId` set per-project) loads without the warning