### PR TITLE
fix(start): skip IDE validation when --create-only flag is used

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -285,6 +285,18 @@ describe('IDE validation', () => {
       })
     })
 
+    describe('--create-only flag handling', () => {
+      it('should skip validation when --create-only flag is used', async () => {
+        commandName = 'start'
+        commandOpts = { createOnly: true }
+
+        await validateIdeForStartCommand(createMockCommand())
+
+        expect(mockExit).not.toHaveBeenCalled()
+        expect(mockIsIdeAvailable).not.toHaveBeenCalled()
+      })
+    })
+
     describe('startIde setting handling', () => {
       it('should skip validation when startIde is false in settings', async () => {
         commandName = 'start'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -325,10 +325,10 @@ export async function validateIdeForStartCommand(command: Command): Promise<void
     return
   }
 
-  // Check if --no-code flag was passed (Commander stores negated option as 'code' = false)
-  const codeOption = command.opts()['code']
-  if (codeOption === false) {
-    return // User explicitly disabled IDE launch
+  // Check if --no-code or --create-only flag was passed
+  const opts = command.opts()
+  if (opts['code'] === false || opts['createOnly'] === true) {
+    return // IDE launch will be skipped
   }
 
   // Load settings to check IDE configuration and startIde default
@@ -343,7 +343,7 @@ export async function validateIdeForStartCommand(command: Command): Promise<void
 
   // If startIde is explicitly false in workflow config and --code flag wasn't used, skip validation
   const workflowConfig = settings.workflows?.issue
-  if (workflowConfig?.startIde === false && codeOption !== true) {
+  if (workflowConfig?.startIde === false && opts['code'] !== true) {
     return
   }
 


### PR DESCRIPTION
## Summary
- `--create-only` disables all launch components (Claude, IDE, terminal, dev server), but the preAction IDE validation hook in `cli.ts` didn't check for it — causing `process.exit(1)` when the configured IDE command wasn't found, even though it would never be launched
- Added `createOnly` check alongside the existing `--no-code` check in `validateIdeForStartCommand`
- Added test coverage for the new behavior

## Test plan
- [x] Existing `validateIdeForStartCommand` tests pass (34/34)
- [x] New test verifies `--create-only` skips IDE validation
- [x] Pre-commit hooks pass (lint, compile, build, tests)