### PR TITLE
No fallback to bare mode for summary generation

### DIFF
--- a/src/lib/SessionSummaryService.test.ts
+++ b/src/lib/SessionSummaryService.test.ts
@@ -697,6 +697,7 @@ describe('SessionSummaryService', () => {
 			expect(launchClaude).toHaveBeenCalledWith('Generated prompt content', {
 				headless: true,
 				model: 'sonnet',
+				noSessionPersistence: true,
 			})
 
 			// Verify comment was posted to issue

--- a/src/lib/SessionSummaryService.ts
+++ b/src/lib/SessionSummaryService.ts
@@ -278,6 +278,7 @@ export class SessionSummaryService {
 			const reportResult = await launchClaude(prompt, {
 				headless: true,
 				model: summaryModel,
+				noSessionPersistence: true,
 			})
 
 			if (!reportResult || typeof reportResult !== 'string' || reportResult.trim() === '') {

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -2952,6 +2952,88 @@ describe('claude utils', () => {
 			// Should only have been called once (no retry)
 			expect(execa).toHaveBeenCalledTimes(1)
 		})
+
+		it('should retry without --bare when session-in-use --resume retry fails with auth error', async () => {
+			// Set up OAuth token so bare mode will be auto-applied
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
+
+			const sessionId = '01af28fe-8630-4778-ae85-39398ab84f54'
+
+			// First call: fails with session-in-use error (bare mode auto-applied)
+			mockExeca().mockRejectedValueOnce({
+				stderr: `Error: Session ID ${sessionId} is already in use.`,
+				exitCode: 1,
+			})
+
+			// Second call (--resume retry): fails with auth error
+			const authError = Object.assign(new Error('authentication_failed'), {
+				stderr: 'Invalid API key',
+				exitCode: 1,
+			})
+			mockExeca().mockRejectedValueOnce(authError)
+
+			// Third call: succeeds (retry without bare)
+			mockExeca().mockResolvedValueOnce({
+				stdout: 'success without bare',
+				exitCode: 0,
+			})
+
+			const result = await launchClaude('test prompt', {
+				headless: true,
+				noSessionPersistence: true,
+				sessionId,
+			})
+
+			expect(result).toBe('success without bare')
+			expect(execa).toHaveBeenCalledTimes(3)
+
+			// First call should have --bare and --session-id
+			const firstCallArgs = mockExeca().mock.calls[0][1] as string[]
+			expect(firstCallArgs).toContain('--bare')
+			expect(firstCallArgs).toContain('--session-id')
+
+			// Second call (--resume) should have --bare and --resume
+			const secondCallArgs = mockExeca().mock.calls[1][1] as string[]
+			expect(secondCallArgs).toContain('--bare')
+			expect(secondCallArgs).toContain('--resume')
+
+			// Third call should NOT have --bare (fallback)
+			const thirdCallArgs = mockExeca().mock.calls[2][1] as string[]
+			expect(thirdCallArgs).not.toContain('--bare')
+
+			// Verify warning was logged
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Bare mode failed during --resume retry'))
+		})
+
+		it('should throw when session-in-use --resume retry fails with non-auth error', async () => {
+			// Set up OAuth token so bare mode will be auto-applied
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
+
+			const sessionId = '01af28fe-8630-4778-ae85-39398ab84f54'
+
+			// First call: fails with session-in-use error
+			mockExeca().mockRejectedValueOnce({
+				stderr: `Error: Session ID ${sessionId} is already in use.`,
+				exitCode: 1,
+			})
+
+			// Second call (--resume retry): fails with non-auth error
+			mockExeca().mockRejectedValueOnce({
+				stderr: 'Some other error on retry',
+				exitCode: 1,
+			})
+
+			await expect(
+				launchClaude('test prompt', {
+					headless: true,
+					noSessionPersistence: true,
+					sessionId,
+				})
+			).rejects.toThrow('Claude CLI error: Some other error on retry')
+
+			// Should have been called exactly twice (initial + resume retry, no bare fallback)
+			expect(execa).toHaveBeenCalledTimes(2)
+		})
 	})
 
 	describe.runIf(process.platform === 'darwin')('launchClaudeInNewTerminalWindow', () => {

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -449,6 +449,15 @@ export async function launchClaude(
 						const retryExecaError = retryError as { stderr?: string; message?: string }
 						// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
 						const retryErrorMessage = retryExecaError.stderr || retryExecaError.message || 'Unknown Claude CLI error'
+
+						if (attempt === 1 && bareModeAutoApplied) {
+							const isAuthError = /not logged in|unauthorized|authentication|invalid api key|Could not resolve credentials/i.test(retryErrorMessage)
+							if (isAuthError) {
+								logger.warn('Bare mode failed during --resume retry (likely expired OAuth token), retrying without --bare')
+								continue
+							}
+						}
+
 						throw new Error(`Claude CLI error: ${redactSettings(retryErrorMessage)}`)
 					}
 				}


### PR DESCRIPTION
Fixes #1022

## No fallback to bare mode for summary generation

<details>
<summary>Issue details</summary>

My organization recently switched over to Enterprise Accounts and And now the session summary always fails because of the bare flag isn't compatible. In other steps, there is a fallback, but not for the session summary generation.

```
🗂️  Generating session summary...
🤖 ...⚠️  Failed to generate session summary: Claude CLI error: Command failed with exit code 1: claude --bare --settings 
---
Command:

claude --bare --settings [REDACTED] -p --output-format stream-json --verbose --model sonnet --add-dir [REDACTED] --no-session-persistence --resume [REDACTED]

Relevant output:

{"type":"assistant","content":[{"type":"text","text":"Invalid API key · Fix external API key"}],"error":"authentication_failed"}

{"type":"result","is_error":true,"api_error_status":401,"result":"Invalid API key · Fix external API key","terminal_reason":"completed"}

Environment:

Claude Code version: 2.1.159

Model: claude-sonnet-4-6
```

</details>

---
*This PR was created automatically by iloom.*