### PR TITLE
Make bare mode strictly opt-in (remove skipBareMode)

### DIFF
--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -2392,30 +2392,6 @@ iloom supports multiple version control providers for PR operations. By default,
 
 **Note:** Draft PR mode (`mergeBehavior.mode: "draft-pr"`) is GitHub-only. BitBucket does not support draft pull requests.
 
-**Bare Mode Settings:**
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `skipBareMode` | boolean | `true` | Skip _bare mode_ for headless Claude CLI utility operations (branch-name generation, commit messages, conflict resolution, and session summaries). Bare mode launches the Claude CLI with `--bare` — a minimal mode that skips hooks, LSP, plugins, and CLAUDE.md auto-discovery, and requires `ANTHROPIC_API_KEY` (which disables OAuth/keychain auth). When `true` (the default), iloom skips bare mode entirely and uses the standard Claude launch. Set to `false` to opt into bare mode's lower-overhead launch on accounts where it is supported. **This setting has nothing to do with database or Neon branching.** |
-
-**Example:**
-
-Bare mode is off by default. To opt _into_ bare mode, set `skipBareMode` to `false`.
-
-`.iloom/settings.json` (project-level, shared with team):
-```json
-{
-  "skipBareMode": false
-}
-```
-
-Or in `~/.config/iloom-ai/settings.json` (global, all projects):
-```json
-{
-  "skipBareMode": false
-}
-```
-
 ---
 
 ### il update

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2107,7 +2107,7 @@ program
 // Test command for bare mode branch name generation
 program
   .command('test-branch-name', { hidden: true })
-  .description('Test bare mode branch name generation')
+  .description('Test branch name generation')
   .option('--title <text>', 'Issue title to use for branch name generation')
   .option('--description <text>', 'Issue description for additional context')
   .action(async (options: { title?: string; description?: string }) => {
@@ -2127,7 +2127,7 @@ program
 // Test command for bare mode commit message generation
 program
   .command('test-commit-msg', { hidden: true })
-  .description('Test bare mode commit message generation')
+  .description('Test commit message generation')
   .action(async () => {
     try {
       const { TestCommitMsgCommand } = await import('./commands/test-commit-msg.js')

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -125,7 +125,7 @@ export class CleanupCommand {
       this.loomManager = new LoomManager(
         this.gitWorktreeManager,
         IssueTrackerFactory.create(settings),
-        new DefaultBranchNamingService({ useClaude: true, skipBareMode: settings.skipBareMode }),
+        new DefaultBranchNamingService({ useClaude: true }),
         environmentManager,
         new ClaudeContextManager(),
         new ProjectCapabilityDetector(),

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -128,7 +128,6 @@ export class CommitCommand {
 			logger.info('Running pre-commit validations...')
 			const validationResult = await this.validationRunner.runValidations(worktreePath, {
 				dryRun: false,
-				skipBareMode: settings.skipBareMode,
 				...(input.jsonStream !== undefined && { jsonStream: input.jsonStream }),
 			})
 			if (!validationResult.success) {
@@ -165,7 +164,6 @@ export class CommitCommand {
 			noReview: input.noReview ?? false,
 			trailerType,
 			timeout: settings.git?.commitTimeout,
-			skipBareMode: settings.skipBareMode,
 			...(commitMessage && { message: commitMessage }),
 			...(detected.issueNumber !== undefined && { issueNumber: detected.issueNumber }),
 		}

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -143,7 +143,7 @@ export class FinishCommand {
 		this.loomManager ??= new LoomManager(
 			this.gitWorktreeManager,
 			this.issueTracker,
-			new DefaultBranchNamingService({ useClaude: true, skipBareMode: settings.skipBareMode }),
+			new DefaultBranchNamingService({ useClaude: true }),
 			environmentManager,
 			new ClaudeContextManager(),
 			new ProjectCapabilityDetector(),
@@ -697,7 +697,6 @@ export class FinishCommand {
 			dryRun: options.dryRun ?? false,
 			force: options.force ?? false,
 			jsonStream: options.jsonStream ?? false,
-			skipBareMode: earlySettings.skipBareMode,
 		}
 		const earlyMergeBehavior = earlySettings.mergeBehavior ?? { mode: 'local' }
 		const earlyRawMode = earlyMergeBehavior.mode as string
@@ -777,12 +776,10 @@ export class FinishCommand {
 			// Validates code with latest main changes integrated
 			if (!options.dryRun) {
 				getLogger().info('Running pre-merge validations...')
-				const validationSettings = await this.settingsManager.loadSettings(worktree.path)
 
 				await this.validationRunner.runValidations(worktree.path, {
 					dryRun: options.dryRun ?? false,
 					jsonStream: options.jsonStream ?? false,
-					skipBareMode: validationSettings.skipBareMode,
 				})
 				getLogger().success('All validations passed')
 				result.operations.push({

--- a/src/commands/rebase.ts
+++ b/src/commands/rebase.ts
@@ -119,12 +119,10 @@ export class RebaseCommand {
 			throw error
 		}
 
-		const settings = await this.settingsManager.loadSettings(worktreePath)
 		const mergeOptions: MergeOptions = {
 			dryRun: options.dryRun ?? false,
 			force: options.force ?? false,
 			jsonStream: options.jsonStream ?? false,
-			skipBareMode: settings.skipBareMode,
 		}
 
 		// MergeManager.rebaseOnMain() handles:

--- a/src/commands/start.test.ts
+++ b/src/commands/start.test.ts
@@ -1640,7 +1640,6 @@ describe('StartCommand', () => {
 				one_shot_mode: 'default',
 				complexity_override: false,
 				create_only: false,
-				skip_bare_mode: false,
 			})
 		})
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -106,7 +106,7 @@ export class StartCommand {
 		const databaseManager = new DatabaseManager(neonProvider, environmentManager, databaseUrlEnvVarName)
 
 		// Create BranchNamingService (defaults to Claude-based strategy)
-		const branchNaming = new DefaultBranchNamingService({ useClaude: true, skipBareMode: settings.skipBareMode })
+		const branchNaming = new DefaultBranchNamingService({ useClaude: true })
 
 		this.loomManager = new LoomManager(
 			new GitWorktreeManager(mainWorktreePath),
@@ -403,7 +403,6 @@ export class StartCommand {
 					one_shot_mode: oneShotMap[input.options.oneShot ?? ''] ?? 'default',
 					complexity_override: !!input.options.complexity,
 					create_only: !!input.options.createOnly,
-					skip_bare_mode: !!settings.skipBareMode,
 				})
 			} catch (error: unknown) {
 				getLogger().debug(`Failed to track loom.created telemetry: ${error instanceof Error ? error.message : String(error)}`)

--- a/src/commands/test-branch-name.ts
+++ b/src/commands/test-branch-name.ts
@@ -1,37 +1,23 @@
 import { logger } from '../utils/logger.js'
-import { resolveBareModeConfig, generateBranchName } from '../utils/claude.js'
+import { generateBranchName } from '../utils/claude.js'
 
 /**
- * Test command to demonstrate bare mode branch name generation.
- * Shows whether bare mode is available and generates a sample branch name.
+ * Test command to demonstrate branch name generation.
+ * Uses the default (non-bare) Claude launch path — the same path real
+ * `il start` / `il finish` use for most users.
  */
 export class TestBranchNameCommand {
   public async execute(options: { title?: string; description?: string }): Promise<void> {
     const title = options.title ?? 'Add dark mode support to settings page'
     const description = options.description ?? 'Users have requested a dark mode toggle in the settings page that persists across sessions.'
 
-    logger.info('Testing Branch Name Generation (Bare Mode)\n')
-
-    // Show bare mode resolution
-    logger.info('Resolving bare mode configuration...')
-    const config = await resolveBareModeConfig()
-
-    if (config.bare && config.oauthToken) {
-      logger.success('Using bare mode with OAuth token')
-    } else if (config.bare) {
-      logger.success('Using bare mode with API key')
-    } else {
-      logger.warn('Using standard mode (no bare)')
-    }
-
-    logger.info('')
+    logger.info('Testing Branch Name Generation\n')
     logger.info(`Title: ${title}`)
     logger.info(`Description: ${description}`)
     logger.info('Generating branch name...\n')
 
     const startTime = Date.now()
-    // bare:true — this diagnostic exists to exercise the opt-in bare-mode launch path
-    const branchName = await generateBranchName(title, '999', 'haiku', true)
+    const branchName = await generateBranchName(title, '999')
     const duration = Date.now() - startTime
 
     logger.success(`Branch name: ${branchName}`)

--- a/src/commands/test-branch-name.ts
+++ b/src/commands/test-branch-name.ts
@@ -30,7 +30,8 @@ export class TestBranchNameCommand {
     logger.info('Generating branch name...\n')
 
     const startTime = Date.now()
-    const branchName = await generateBranchName(title, '999')
+    // bare:true — this diagnostic exists to exercise the opt-in bare-mode launch path
+    const branchName = await generateBranchName(title, '999', 'haiku', true)
     const duration = Date.now() - startTime
 
     logger.success(`Branch name: ${branchName}`)

--- a/src/commands/test-commit-msg.ts
+++ b/src/commands/test-commit-msg.ts
@@ -1,28 +1,13 @@
 import { logger } from '../utils/logger.js'
-import { resolveBareModeConfig } from '../utils/claude.js'
 import { CommitManager } from '../lib/CommitManager.js'
 
 /**
- * Test command to demonstrate bare mode commit message generation.
- * Uses the real CommitManager code path to generate a commit message.
+ * Test command to demonstrate commit message generation.
+ * Uses the real CommitManager code path (default, non-bare launch).
  */
 export class TestCommitMsgCommand {
   public async execute(): Promise<void> {
-    logger.info('Testing Commit Message Generation (Bare Mode)\n')
-
-    // Show bare mode resolution
-    logger.info('Resolving bare mode configuration...')
-    const config = await resolveBareModeConfig()
-
-    if (config.bare && config.oauthToken) {
-      logger.success('Using bare mode with OAuth token')
-    } else if (config.bare) {
-      logger.success('Using bare mode with API key')
-    } else {
-      logger.warn('Using standard mode (no bare)')
-    }
-
-    logger.info('')
+    logger.info('Testing Commit Message Generation\n')
     logger.info('Generating commit message via CommitManager...\n')
 
     const commitManager = new CommitManager()
@@ -32,9 +17,7 @@ export class TestCommitMsgCommand {
     const result = await commitManager.generateClaudeCommitMessage(
       worktreePath,
       undefined,
-      '#',
-      undefined,
-      true, // bare:true — this diagnostic exists to exercise the opt-in bare-mode launch path
+      '#'
     )
     const duration = Date.now() - startTime
 

--- a/src/commands/test-commit-msg.ts
+++ b/src/commands/test-commit-msg.ts
@@ -32,7 +32,9 @@ export class TestCommitMsgCommand {
     const result = await commitManager.generateClaudeCommitMessage(
       worktreePath,
       undefined,
-      '#'
+      '#',
+      undefined,
+      true, // bare:true — this diagnostic exists to exercise the opt-in bare-mode launch path
     )
     const duration = Date.now() - startTime
 

--- a/src/lib/BranchNamingService.test.ts
+++ b/src/lib/BranchNamingService.test.ts
@@ -170,7 +170,7 @@ describe('BranchNamingService', () => {
 
 			// Verify the mock was called with correct arguments
 			const { generateBranchName } = await import('../utils/claude.js')
-			expect(generateBranchName).toHaveBeenCalledWith('Test Issue', 123, 'haiku', undefined)
+			expect(generateBranchName).toHaveBeenCalledWith('Test Issue', 123, 'haiku')
 			// The mock should return the mocked value
 			expect(branchName).toBe('feat/issue-123__ai-generated-branch')
 		})
@@ -180,7 +180,7 @@ describe('BranchNamingService', () => {
 			await strategy.generate(456, 'Another Issue')
 
 			const { generateBranchName } = await import('../utils/claude.js')
-			expect(generateBranchName).toHaveBeenCalledWith('Another Issue', 456, 'sonnet', undefined)
+			expect(generateBranchName).toHaveBeenCalledWith('Another Issue', 456, 'sonnet')
 		})
 
 		it('should use haiku model by default', async () => {
@@ -188,7 +188,7 @@ describe('BranchNamingService', () => {
 			await strategy.generate(789, 'Default Model Test')
 
 			const { generateBranchName } = await import('../utils/claude.js')
-			expect(generateBranchName).toHaveBeenCalledWith('Default Model Test', 789, 'haiku', undefined)
+			expect(generateBranchName).toHaveBeenCalledWith('Default Model Test', 789, 'haiku')
 		})
 	})
 })

--- a/src/lib/BranchNamingService.ts
+++ b/src/lib/BranchNamingService.ts
@@ -27,12 +27,12 @@ export class SimpleBranchNameStrategy implements BranchNameStrategy {
  * Uses Claude CLI to generate semantic branch names
  */
 export class ClaudeBranchNameStrategy implements BranchNameStrategy {
-	constructor(private claudeModel = 'haiku', private skipBareMode?: boolean) {}
+	constructor(private claudeModel = 'haiku') {}
 
 	async generate(issueNumber: string | number, title: string): Promise<string> {
 		// Dynamic import to allow mocking in tests
 		const { generateBranchName } = await import('../utils/claude.js')
-		return generateBranchName(title, issueNumber, this.claudeModel, this.skipBareMode)
+		return generateBranchName(title, issueNumber, this.claudeModel)
 	}
 }
 
@@ -61,13 +61,12 @@ export class DefaultBranchNamingService implements BranchNamingService {
 		strategy?: BranchNameStrategy
 		useClaude?: boolean
 		claudeModel?: string
-		skipBareMode?: boolean
 	}) {
 		// Set up default strategy based on options
 		if (options?.strategy) {
 			this.defaultStrategy = options.strategy
 		} else if (options?.useClaude !== false) {
-			this.defaultStrategy = new ClaudeBranchNameStrategy(options?.claudeModel, options?.skipBareMode)
+			this.defaultStrategy = new ClaudeBranchNameStrategy(options?.claudeModel)
 		} else {
 			this.defaultStrategy = new SimpleBranchNameStrategy()
 		}

--- a/src/lib/CommitManager.ts
+++ b/src/lib/CommitManager.ts
@@ -301,7 +301,6 @@ export class CommitManager {
     issueNumber: string | number | undefined,
     issuePrefix: string,
     trailerType?: 'Refs' | 'Fixes',
-    bare?: boolean,
   ): Promise<string | null> {
     const startTime = Date.now()
 
@@ -364,7 +363,6 @@ export class CommitManager {
         systemPrompt: 'You are a git commit message generator. Generate a concise commit message in imperative mood with subject line under 72 characters. Your entire response is used verbatim as the commit message — output ONLY the raw commit message, no explanatory text.',
         noSessionPersistence: true, // Utility operation - don't persist session
         effort: 'low', // Minimize turns for fast commit message generation
-        ...(bare != null && { bare }),
       }
       getLogger().debug('Claude CLI call parameters:', {
         options: claudeOptions,

--- a/src/lib/CommitManager.ts
+++ b/src/lib/CommitManager.ts
@@ -73,7 +73,7 @@ export class CommitManager {
     // Skip Claude if custom message provided
     if (!options.message) {
       try {
-        message = await this.generateClaudeCommitMessage(worktreePath, options.issueNumber, options.issuePrefix, options.trailerType, options.skipBareMode)
+        message = await this.generateClaudeCommitMessage(worktreePath, options.issueNumber, options.issuePrefix, options.trailerType)
       } catch (error) {
         getLogger().debug('Claude commit message generation failed, using fallback', { error })
       }
@@ -301,7 +301,7 @@ export class CommitManager {
     issueNumber: string | number | undefined,
     issuePrefix: string,
     trailerType?: 'Refs' | 'Fixes',
-    skipBareMode?: boolean,
+    bare?: boolean,
   ): Promise<string | null> {
     const startTime = Date.now()
 
@@ -362,9 +362,9 @@ export class CommitManager {
         model: 'claude-haiku-4-5-20251001', // Fast, cost-effective model
         timeout: 120000, // 120 second timeout
         systemPrompt: 'You are a git commit message generator. Generate a concise commit message in imperative mood with subject line under 72 characters. Your entire response is used verbatim as the commit message — output ONLY the raw commit message, no explanatory text.',
-        noSessionPersistence: true, // Utility operation - bare mode auto-applied by launchClaude
+        noSessionPersistence: true, // Utility operation - don't persist session
         effort: 'low', // Minimize turns for fast commit message generation
-        ...(skipBareMode != null && { skipBareMode }),
+        ...(bare != null && { bare }),
       }
       getLogger().debug('Claude CLI call parameters:', {
         options: claudeOptions,

--- a/src/lib/IssueEnhancementService.ts
+++ b/src/lib/IssueEnhancementService.ts
@@ -116,7 +116,6 @@ Your response should be the raw markdown that will become the issue body.`
 				model: 'sonnet',
 				agents,
 				noSessionPersistence: true, // Utility operation - don't persist session
-				skipBareMode: settings.skipBareMode,
 			})
 
 			if (enhanced && typeof enhanced === 'string') {
@@ -257,7 +256,6 @@ Press any key to open issue for editing...`
 			model: 'sonnet',
 			agents,
 			noSessionPersistence: true, // Headless operation - no session persistence needed
-			skipBareMode: settings.skipBareMode,
 			...(mcpConfig && { mcpConfig }),
 			...(allowedTools && { allowedTools }),
 			...(disallowedTools && { disallowedTools }),

--- a/src/lib/MergeManager.ts
+++ b/src/lib/MergeManager.ts
@@ -44,7 +44,7 @@ export class MergeManager {
 	 * @throws Error if main branch doesn't exist, uncommitted changes exist, or conflicts occur
 	 */
 	async rebaseOnMain(worktreePath: string, options: MergeOptions = {}): Promise<RebaseOutcome> {
-		const { dryRun = false, force = false, jsonStream = false, skipBareMode } = options
+		const { dryRun = false, force = false, jsonStream = false } = options
 
 		// Pre-check: abort any in-progress rebase before starting a new one
 		await this.abortInProgressRebase(worktreePath)
@@ -231,7 +231,7 @@ export class MergeManager {
 					const resolved = await this.attemptClaudeConflictResolution(
 						worktreePath,
 						conflictedFiles,
-						{ jsonStream, conflictType: 'merge', ...(skipBareMode != null && { skipBareMode }) }
+						{ jsonStream, conflictType: 'merge' }
 					)
 
 					if (resolved) {
@@ -284,7 +284,7 @@ export class MergeManager {
 				const resolved = await this.attemptClaudeConflictResolution(
 					worktreePath,
 					conflictedFiles,
-					{ jsonStream, ...(skipBareMode != null && { skipBareMode }) }
+					{ jsonStream }
 				)
 
 				if (resolved) {
@@ -568,7 +568,7 @@ export class MergeManager {
 	private async attemptClaudeConflictResolution(
 		worktreePath: string,
 		conflictedFiles: string[],
-		options: { jsonStream?: boolean; conflictType?: 'rebase' | 'merge'; skipBareMode?: boolean } = {}
+		options: { jsonStream?: boolean; conflictType?: 'rebase' | 'merge' } = {}
 	): Promise<boolean> {
 		const conflictType = options.conflictType ?? 'rebase'
 
@@ -642,7 +642,6 @@ export class MergeManager {
 				}),
 				allowedTools,
 				noSessionPersistence: true, // Utility operation - no session persistence needed
-				...(options.skipBareMode != null && { skipBareMode: options.skipBareMode }),
 			})
 
 			// After Claude interaction completes, check if conflicts resolved

--- a/src/lib/PRManager.ts
+++ b/src/lib/PRManager.ts
@@ -74,7 +74,6 @@ export class PRManager {
 					addDir: worktreePath,
 					timeout: 30000,
 					noSessionPersistence: true, // Utility operation - don't persist session
-					...(this.settings.skipBareMode && { skipBareMode: this.settings.skipBareMode }),
 				})
 
 				if (body && typeof body === 'string' && body.trim()) {

--- a/src/lib/SessionSummaryService.ts
+++ b/src/lib/SessionSummaryService.ts
@@ -84,13 +84,12 @@ export class SessionSummaryService {
 	 * causing a "Prompt is too long" error. This helper detects that condition (either as a
 	 * thrown error or as a returned result string) and retries with opus[1m] (1M context).
 	 */
-	private async launchSessionSummary(prompt: string, model: string, sessionId: string, skipBareMode?: boolean): Promise<string | void> {
+	private async launchSessionSummary(prompt: string, model: string, sessionId: string): Promise<string | void> {
 		const launchOptions = {
 			headless: true,
 			model,
 			sessionId,
 			noSessionPersistence: true,
-			...(skipBareMode ? { skipBareMode } : {}),
 		}
 
 		try {
@@ -172,7 +171,7 @@ export class SessionSummaryService {
 			// 7. Invoke Claude headless to generate summary
 			// Use --resume with session ID so Claude knows which conversation to summarize
 			const summaryModel = this.settingsManager.getSummaryModel(settings)
-			const summaryResult = await this.launchSessionSummary(prompt, summaryModel, sessionId, settings.skipBareMode)
+			const summaryResult = await this.launchSessionSummary(prompt, summaryModel, sessionId)
 
 			if (!summaryResult || typeof summaryResult !== 'string' || summaryResult.trim() === '') {
 				logger.warn('Session summary generation returned empty result')
@@ -280,7 +279,6 @@ export class SessionSummaryService {
 				headless: true,
 				model: summaryModel,
 				noSessionPersistence: true,
-				...(settings.skipBareMode ? { skipBareMode: settings.skipBareMode } : {}),
 			})
 
 			if (!reportResult || typeof reportResult !== 'string' || reportResult.trim() === '') {
@@ -373,7 +371,7 @@ export class SessionSummaryService {
 
 		// 6. Invoke Claude headless to generate summary
 		const summaryModel = this.settingsManager.getSummaryModel(settings)
-		const summaryResult = await this.launchSessionSummary(prompt, summaryModel, sessionId, settings.skipBareMode)
+		const summaryResult = await this.launchSessionSummary(prompt, summaryModel, sessionId)
 
 		if (!summaryResult || typeof summaryResult !== 'string' || summaryResult.trim() === '') {
 			throw new Error('Session summary generation returned empty result')

--- a/src/lib/SettingsManager.test.ts
+++ b/src/lib/SettingsManager.test.ts
@@ -15,7 +15,6 @@ vi.mock('../utils/logger.js', () => ({
 const defaultSettings = {
 	git: { commitTimeout: 60000 },
 	rebase: { maxCommitsForRebase: 20 },
-	skipBareMode: true,
 }
 
 describe('SettingsManager', () => {

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -497,16 +497,6 @@ export const IloomSettingsSchema = z.object({
 				'(e.g., database URLs with ?, &, or other shell metacharacters). ' +
 				'Shell compatibility issues may cause processes to fail or behave unexpectedly.',
 		),
-	skipBareMode: z
-		.boolean()
-		.default(true)
-		.describe(
-			'Skip bare mode for headless Claude CLI utility operations (branch-name generation, ' +
-				'commit messages, conflict resolution, and session summaries). Bare mode launches the Claude ' +
-				'CLI with --bare — a minimal mode that skips hooks, LSP, plugins, and CLAUDE.md auto-discovery ' +
-				'and requires ANTHROPIC_API_KEY (disabling OAuth/keychain). Defaults to true (bare mode off); ' +
-				'set to false to opt into bare mode on accounts where it is supported. Unrelated to database/Neon branching.',
-		),
 	worktreePrefix: z
 		.string()
 		.optional()
@@ -813,16 +803,6 @@ export const IloomSettingsSchemaNoDefaults = z.object({
 				'Before enabling, verify ALL your .env.* files do not contain unquoted special characters ' +
 				'(e.g., database URLs with ?, &, or other shell metacharacters). ' +
 				'Shell compatibility issues may cause processes to fail or behave unexpectedly.',
-		),
-	skipBareMode: z
-		.boolean()
-		.optional()
-		.describe(
-			'Skip bare mode for headless Claude CLI utility operations (branch-name generation, ' +
-				'commit messages, conflict resolution, and session summaries). Bare mode launches the Claude ' +
-				'CLI with --bare — a minimal mode that skips hooks, LSP, plugins, and CLAUDE.md auto-discovery ' +
-				'and requires ANTHROPIC_API_KEY (disabling OAuth/keychain). Defaults to true (bare mode off); ' +
-				'set to false to opt into bare mode on accounts where it is supported. Unrelated to database/Neon branching.',
 		),
 	worktreePrefix: z
 		.string()

--- a/src/lib/ValidationRunner.ts
+++ b/src/lib/ValidationRunner.ts
@@ -30,7 +30,6 @@ export class ValidationRunner {
 
 		const claudeOpts = {
 			...(options.jsonStream != null && { jsonStream: options.jsonStream }),
-			...(options.skipBareMode != null && { skipBareMode: options.skipBareMode }),
 		}
 
 		// Run typecheck
@@ -85,7 +84,7 @@ export class ValidationRunner {
 	private async runTypecheck(
 		worktreePath: string,
 		dryRun: boolean,
-		options: { jsonStream?: boolean | undefined; skipBareMode?: boolean | undefined } = {}
+		options: { jsonStream?: boolean | undefined } = {}
 	): Promise<ValidationStepResult> {
 		const stepStartTime = Date.now()
 
@@ -161,7 +160,7 @@ export class ValidationRunner {
 				scriptToRun,
 				worktreePath,
 				packageManager,
-				{ jsonStream: options.jsonStream, skipBareMode: options.skipBareMode }
+				{ jsonStream: options.jsonStream }
 			)
 
 			if (fixed) {
@@ -194,7 +193,7 @@ export class ValidationRunner {
 	private async runLint(
 		worktreePath: string,
 		dryRun: boolean,
-		options: { jsonStream?: boolean | undefined; skipBareMode?: boolean | undefined } = {}
+		options: { jsonStream?: boolean | undefined } = {}
 	): Promise<ValidationStepResult> {
 		const stepStartTime = Date.now()
 
@@ -259,7 +258,7 @@ export class ValidationRunner {
 				'lint',
 				worktreePath,
 				packageManager,
-				{ jsonStream: options.jsonStream, skipBareMode: options.skipBareMode }
+				{ jsonStream: options.jsonStream }
 			)
 
 			if (fixed) {
@@ -290,7 +289,7 @@ export class ValidationRunner {
 	private async runTests(
 		worktreePath: string,
 		dryRun: boolean,
-		options: { jsonStream?: boolean | undefined; skipBareMode?: boolean | undefined } = {}
+		options: { jsonStream?: boolean | undefined } = {}
 	): Promise<ValidationStepResult> {
 		const stepStartTime = Date.now()
 
@@ -355,7 +354,7 @@ export class ValidationRunner {
 				'test',
 				worktreePath,
 				packageManager,
-				{ jsonStream: options.jsonStream, skipBareMode: options.skipBareMode }
+				{ jsonStream: options.jsonStream }
 			)
 
 			if (fixed) {
@@ -393,7 +392,7 @@ export class ValidationRunner {
 		validationType: 'compile' | 'typecheck' | 'lint' | 'test',
 		worktreePath: string,
 		packageManager: string,
-		options: { jsonStream?: boolean | undefined; skipBareMode?: boolean | undefined } = {}
+		options: { jsonStream?: boolean | undefined } = {}
 	): Promise<boolean> {
 		// Check if Claude CLI is available
 		const isClaudeAvailable = await detectClaudeCli()
@@ -420,7 +419,6 @@ export class ValidationRunner {
 				permissionMode: options.jsonStream ? 'bypassPermissions' : 'acceptEdits',
 				model: 'sonnet',
 				noSessionPersistence: true,
-				...(options.skipBareMode != null && { skipBareMode: options.skipBareMode }),
 				...(options.jsonStream && { passthroughStdout: true }),
 			})
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -356,7 +356,6 @@ export interface ValidationOptions {
 	skipLint?: boolean
 	skipTests?: boolean
 	jsonStream?: boolean
-	skipBareMode?: boolean
 }
 
 export interface ValidationStepResult {
@@ -385,7 +384,6 @@ export interface CommitOptions {
 	skipVerifySilent?: boolean  // Skip without warning (for --wip-commit)
 	trailerType?: 'Refs' | 'Fixes'  // Trailer type: "Refs" references issue, "Fixes" closes it (default: 'Fixes' for backward compat)
 	timeout?: number      // Timeout in milliseconds for commit operation
-	skipBareMode?: boolean // Skip bare mode attempt for Claude CLI calls
 }
 
 /**
@@ -406,7 +404,6 @@ export interface MergeOptions {
 	repoRoot?: string     // Repository root path (optional, auto-detected if not provided)
 	jsonStream?: boolean  // When true, run Claude headless and stream JSONL for conflict resolution
 	noFf?: boolean        // Use --no-ff instead of --ff-only for local merge (set when rebase fell back to merge strategy)
-	skipBareMode?: boolean // Skip bare mode attempt for Claude CLI calls
 }
 
 export interface MergeResult {

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -29,7 +29,6 @@ export interface LoomCreatedProperties {
   one_shot_mode: 'default' | 'skip-reviews' | 'yolo'
   complexity_override: boolean
   create_only: boolean
-  skip_bare_mode: boolean
 }
 
 export interface LoomFinishedProperties {

--- a/src/utils/claude.test.ts
+++ b/src/utils/claude.test.ts
@@ -2113,13 +2113,6 @@ describe('claude utils', () => {
 			it('should add --no-session-persistence flag when noSessionPersistence is true', async () => {
 				const prompt = 'Test prompt'
 
-				// resolveBareModeConfig will try OAuth extraction - make it fail
-				if (process.platform === 'darwin') {
-					mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
-				} else {
-					vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
-				}
-
 				mockExeca().mockResolvedValueOnce({
 					stdout: 'output',
 					exitCode: 0,
@@ -2194,13 +2187,6 @@ describe('claude utils', () => {
 			it('should combine noSessionPersistence with other options in correct order', async () => {
 				const prompt = 'Test prompt'
 				const sessionId = '12345678-1234-5678-1234-567812345678'
-
-				// resolveBareModeConfig will try OAuth extraction - make it fail
-				if (process.platform === 'darwin') {
-					mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
-				} else {
-					vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
-				}
 
 				mockExeca().mockResolvedValueOnce({
 					stdout: 'output',
@@ -2309,7 +2295,7 @@ describe('claude utils', () => {
 				expect(execaCall[1]).not.toContain('--bare')
 			})
 
-			it('should auto-apply --bare when headless + noSessionPersistence and ANTHROPIC_API_KEY is set', async () => {
+			it('should NOT auto-apply --bare for headless + noSessionPersistence (bare is strictly opt-in), even with ANTHROPIC_API_KEY set', async () => {
 				const originalApiKey = process.env.ANTHROPIC_API_KEY
 				try {
 					process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
@@ -2325,11 +2311,10 @@ describe('claude utils', () => {
 						noSessionPersistence: true,
 					})
 
-					expect(execa).toHaveBeenCalledWith(
-						'claude',
-						expect.arrayContaining(['--bare']),
-						expect.any(Object)
+					const execaCall = mockExeca().mock.calls.find(
+						(call: unknown[]) => call[0] === 'claude'
 					)
+					expect(execaCall?.[1]).not.toContain('--bare')
 				} finally {
 					if (originalApiKey !== undefined) {
 						process.env.ANTHROPIC_API_KEY = originalApiKey
@@ -2346,13 +2331,6 @@ describe('claude utils', () => {
 					delete process.env.ANTHROPIC_API_KEY
 					delete process.env.CLAUDE_CODE_OAUTH_TOKEN
 					const prompt = 'Test prompt'
-
-					// On macOS, extractOAuthToken will call security command - make it fail
-					if (process.platform === 'darwin') {
-						mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
-					} else {
-						vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
-					}
 
 					mockExeca().mockResolvedValueOnce({
 						stdout: 'output',
@@ -2444,66 +2422,7 @@ describe('claude utils', () => {
 				)
 			})
 
-			it('should skip auto-apply bare mode when skipBareMode is true', async () => {
-				const originalApiKey = process.env.ANTHROPIC_API_KEY
-				try {
-					process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
-					const prompt = 'Test prompt'
-
-					mockExeca().mockResolvedValueOnce({
-						stdout: 'output',
-						exitCode: 0,
-					})
-
-					await launchClaude(prompt, {
-						headless: true,
-						noSessionPersistence: true,
-						skipBareMode: true,
-					})
-
-					const execaCall = mockExeca().mock.calls[0]
-					expect(execaCall[1]).not.toContain('--bare')
-				} finally {
-					if (originalApiKey !== undefined) {
-						process.env.ANTHROPIC_API_KEY = originalApiKey
-					} else {
-						delete process.env.ANTHROPIC_API_KEY
-					}
-				}
-			})
-
-			it('should still auto-apply bare mode when skipBareMode is false', async () => {
-				const originalApiKey = process.env.ANTHROPIC_API_KEY
-				try {
-					process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
-					const prompt = 'Test prompt'
-
-					mockExeca().mockResolvedValueOnce({
-						stdout: 'output',
-						exitCode: 0,
-					})
-
-					await launchClaude(prompt, {
-						headless: true,
-						noSessionPersistence: true,
-						skipBareMode: false,
-					})
-
-					expect(execa).toHaveBeenCalledWith(
-						'claude',
-						expect.arrayContaining(['--bare']),
-						expect.any(Object)
-					)
-				} finally {
-					if (originalApiKey !== undefined) {
-						process.env.ANTHROPIC_API_KEY = originalApiKey
-					} else {
-						delete process.env.ANTHROPIC_API_KEY
-					}
-				}
-			})
-
-			it('should honor explicit bare:true even when skipBareMode is true', async () => {
+			it('should honor explicit bare:true', async () => {
 				const prompt = 'Test prompt'
 
 				mockExeca().mockResolvedValueOnce({
@@ -2514,7 +2433,6 @@ describe('claude utils', () => {
 				await launchClaude(prompt, {
 					headless: true,
 					bare: true,
-					skipBareMode: true,
 				})
 
 				expect(execa).toHaveBeenCalledWith(
@@ -2904,68 +2822,6 @@ describe('claude utils', () => {
 			}
 		})
 
-		it('should retry without --bare when auto-applied bare mode fails with auth error', async () => {
-			// Set up OAuth token so bare mode will be auto-applied
-			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
-
-			const fakeSubprocess1 = {
-				stdout: null,
-				on: vi.fn(),
-				kill: vi.fn(),
-			}
-
-			const fakeSubprocess2 = {
-				stdout: null,
-				on: vi.fn(),
-				kill: vi.fn(),
-			}
-
-			// First call: fails with auth error (bare mode auto-applied)
-			const authError = Object.assign(new Error('Invalid API Key'), {
-				stderr: 'Invalid API Key',
-				exitCode: 1,
-			})
-			mockExeca().mockReturnValueOnce(
-				Object.assign(Promise.reject(authError), fakeSubprocess1)
-			)
-
-			// Second call: succeeds (retry without bare)
-			mockExeca().mockReturnValueOnce(
-				Object.assign(Promise.resolve({ stdout: 'retry output', exitCode: 0 }), fakeSubprocess2)
-			)
-
-			const result = await launchClaude('test prompt', {
-				headless: true,
-				noSessionPersistence: true,
-			})
-
-			expect(result).toBe('retry output')
-
-			// Verify first call had --bare and --settings
-			const firstCallArgs = mockExeca().mock.calls[0][1] as string[]
-			expect(firstCallArgs).toContain('--bare')
-			expect(firstCallArgs).toContain('--settings')
-
-			// Verify first call passes OAuth token via env var, not in args
-			const firstCallOpts = mockExeca().mock.calls[0][2] as Record<string, unknown>
-			const firstCallEnv = firstCallOpts.env as Record<string, string>
-			expect(firstCallEnv.__ILOOM_OAUTH_TOKEN).toBe('sk-ant-oat01-test-token')
-
-			// Verify settings JSON does NOT contain the actual token
-			const settingsIdx = firstCallArgs.indexOf('--settings')
-			const settingsJson = firstCallArgs[settingsIdx + 1]
-			expect(settingsJson).not.toContain('sk-ant-oat01-test-token')
-			expect(settingsJson).toContain('__ILOOM_OAUTH_TOKEN')
-
-			// Verify second call does NOT have --bare or --settings
-			const secondCallArgs = mockExeca().mock.calls[1][1] as string[]
-			expect(secondCallArgs).not.toContain('--bare')
-			expect(secondCallArgs).not.toContain('--settings')
-
-			// Verify warning was logged
-			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Bare mode failed'))
-		})
-
 		it('should NOT retry when bare was explicitly set by caller', async () => {
 			// Mock OAuth extraction failure so resolveBareModeConfig can complete
 			// (bare:true without settings triggers resolveBareModeConfig for OAuth)
@@ -3031,58 +2887,6 @@ describe('claude utils', () => {
 
 			// Should only have been called once (no retry)
 			expect(execa).toHaveBeenCalledTimes(1)
-		})
-
-		it('should retry without --bare when session-in-use --resume retry fails with auth error', async () => {
-			// Set up OAuth token so bare mode will be auto-applied
-			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-test-token'
-
-			const sessionId = '01af28fe-8630-4778-ae85-39398ab84f54'
-
-			// First call: fails with session-in-use error (bare mode auto-applied)
-			mockExeca().mockRejectedValueOnce({
-				stderr: `Error: Session ID ${sessionId} is already in use.`,
-				exitCode: 1,
-			})
-
-			// Second call (--resume retry): fails with auth error
-			const authError = Object.assign(new Error('authentication_failed'), {
-				stderr: 'Invalid API key',
-				exitCode: 1,
-			})
-			mockExeca().mockRejectedValueOnce(authError)
-
-			// Third call: succeeds (retry without bare)
-			mockExeca().mockResolvedValueOnce({
-				stdout: 'success without bare',
-				exitCode: 0,
-			})
-
-			const result = await launchClaude('test prompt', {
-				headless: true,
-				noSessionPersistence: true,
-				sessionId,
-			})
-
-			expect(result).toBe('success without bare')
-			expect(execa).toHaveBeenCalledTimes(3)
-
-			// First call should have --bare and --session-id
-			const firstCallArgs = mockExeca().mock.calls[0][1] as string[]
-			expect(firstCallArgs).toContain('--bare')
-			expect(firstCallArgs).toContain('--session-id')
-
-			// Second call (--resume) should have --bare and --resume
-			const secondCallArgs = mockExeca().mock.calls[1][1] as string[]
-			expect(secondCallArgs).toContain('--bare')
-			expect(secondCallArgs).toContain('--resume')
-
-			// Third call should NOT have --bare (fallback)
-			const thirdCallArgs = mockExeca().mock.calls[2][1] as string[]
-			expect(thirdCallArgs).not.toContain('--bare')
-
-			// Verify warning was logged
-			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Bare mode failed during --resume retry'))
 		})
 
 		it('should throw when session-in-use --resume retry fails with non-auth error', async () => {
@@ -3323,15 +3127,6 @@ describe('claude utils', () => {
 			}
 		})
 
-		// Helper: mock OAuth extraction failure for macOS (security command) or Linux (readFile)
-		function mockOAuthExtractionFailure(): void {
-			if (process.platform === 'darwin') {
-				mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
-			} else {
-				vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
-			}
-		}
-
 		it('should generate branch name using Claude when available', async () => {
 			const issueTitle = 'Add user authentication'
 			const issueNumber = 123
@@ -3341,9 +3136,6 @@ describe('claude utils', () => {
 				stdout: '/usr/local/bin/claude',
 				exitCode: 0,
 			})
-
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
 
 			// Mock Claude response with full branch name
 			mockExeca().mockResolvedValueOnce({
@@ -3388,9 +3180,6 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
-
 			// Mock Claude returning error message
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'API error: rate limit exceeded',
@@ -3411,9 +3200,6 @@ describe('claude utils', () => {
 				stdout: '/usr/local/bin/claude',
 				exitCode: 0,
 			})
-
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
 
 			// Mock Claude returning empty string
 			mockExeca().mockResolvedValueOnce({
@@ -3436,9 +3222,6 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
-
 			// Mock Claude returning properly formatted branch
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'fix/issue-123__authentication-bug',
@@ -3460,9 +3243,6 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
-
 			// Mock Claude returning invalid format (no prefix)
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'add-user-auth',
@@ -3483,9 +3263,6 @@ describe('claude utils', () => {
 				stdout: '/usr/local/bin/claude',
 				exitCode: 0,
 			})
-
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
 
 			// Mock Claude execution fails
 			mockExeca().mockRejectedValueOnce({
@@ -3509,9 +3286,6 @@ describe('claude utils', () => {
 				exitCode: 0,
 			})
 
-			// OAuth extraction will fail (no credentials)
-			mockOAuthExtractionFailure()
-
 			// Mock Claude returning lowercase branch name (correct behavior)
 			mockExeca().mockResolvedValueOnce({
 				stdout: 'feat/issue-mark-1__nextjs-vercel',
@@ -3524,88 +3298,6 @@ describe('claude utils', () => {
 			expect(result).toBe('feat/issue-mark-1__nextjs-vercel')
 		})
 
-		describe('bare mode (auto-applied by launchClaude)', () => {
-			let originalApiKey: string | undefined
-			let originalOAuthToken: string | undefined
-
-			beforeEach(() => {
-				originalApiKey = process.env.ANTHROPIC_API_KEY
-				originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
-			})
-
-			afterEach(() => {
-				if (originalApiKey !== undefined) {
-					process.env.ANTHROPIC_API_KEY = originalApiKey
-				} else {
-					delete process.env.ANTHROPIC_API_KEY
-				}
-				if (originalOAuthToken !== undefined) {
-					process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
-				} else {
-					delete process.env.CLAUDE_CODE_OAUTH_TOKEN
-				}
-			})
-
-			it('should auto-apply --bare when ANTHROPIC_API_KEY is set (headless + noSessionPersistence)', async () => {
-				process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
-				const issueTitle = 'Add user authentication'
-				const issueNumber = 123
-
-				// Mock Claude CLI detection
-				mockExeca().mockResolvedValueOnce({
-					stdout: '/usr/local/bin/claude',
-					exitCode: 0,
-				})
-
-				// Mock Claude response
-				mockExeca().mockResolvedValueOnce({
-					stdout: 'feat/issue-123__user-authentication',
-					exitCode: 0,
-				})
-
-				await generateBranchName(issueTitle, issueNumber)
-
-				expect(execa).toHaveBeenCalledWith(
-					'claude',
-					expect.arrayContaining(['--bare']),
-					expect.any(Object)
-				)
-			})
-
-			it('should not auto-apply --bare when no API key or OAuth token available', async () => {
-				delete process.env.ANTHROPIC_API_KEY
-				delete process.env.CLAUDE_CODE_OAUTH_TOKEN
-				const issueTitle = 'Add user authentication'
-				const issueNumber = 123
-
-				// Mock Claude CLI detection
-				mockExeca().mockResolvedValueOnce({
-					stdout: '/usr/local/bin/claude',
-					exitCode: 0,
-				})
-
-				// On macOS, extractOAuthToken calls security command - make it fail
-				if (process.platform === 'darwin') {
-					mockExeca().mockRejectedValueOnce(new Error('security: item not found'))
-				} else {
-					vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT'))
-				}
-
-				// Mock Claude response
-				mockExeca().mockResolvedValueOnce({
-					stdout: 'feat/issue-123__user-authentication',
-					exitCode: 0,
-				})
-
-				await generateBranchName(issueTitle, issueNumber)
-
-				// Find the launchClaude call (the claude command, not security)
-				const claudeCall = mockExeca().mock.calls.find(
-					(call: unknown[]) => call[0] === 'claude' && (call[1] as string[])?.includes('-p')
-				)
-				expect(claudeCall?.[1]).not.toContain('--bare')
-			})
-		})
 	})
 
 	describe('AbortSignal support', () => {

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -83,8 +83,7 @@ export interface ClaudeCliOptions {
 	effort?: string // Effort level to pass via --effort flag (e.g., 'low', 'high', 'max')
 	env?: Record<string, string> // Additional environment variables to pass to the Claude process
 	signal?: AbortSignal // Optional AbortSignal for graceful termination of the Claude process
-	bare?: boolean // Minimal mode: skip hooks, LSP, plugins, CLAUDE.md auto-discovery. Requires ANTHROPIC_API_KEY (disables OAuth/keychain).
-	skipBareMode?: boolean // When true, never auto-apply bare mode (skip the try-then-fallback overhead)
+	bare?: boolean // Minimal mode: skip hooks, LSP, plugins, CLAUDE.md auto-discovery. Requires ANTHROPIC_API_KEY (disables OAuth/keychain). Strictly opt-in — only applied when explicitly set to true.
 	settings?: string // JSON settings string for --settings flag (e.g., '{"apiKeyHelper": "echo TOKEN"}')
 }
 
@@ -158,30 +157,21 @@ export async function launchClaude(
 	prompt: string,
 	options: ClaudeCliOptions = {}
 ): Promise<string | void> {
-	const { model, permissionMode, addDir, headless = false, systemPrompt, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, effort, env: extraEnv, signal, bare, skipBareMode, settings } = options
+	const { model, permissionMode, addDir, headless = false, systemPrompt, appendSystemPrompt, appendSystemPromptFile, mcpConfig, allowedTools, disallowedTools, agents, pluginDir, sessionId, noSessionPersistence, outputFormat, verbose, jsonMode, passthroughStdout, effort, env: extraEnv, signal, bare, settings } = options
 	const log = getLogger()
 
-	// Resolve bare mode configuration
+	// Resolve bare mode configuration. Bare mode is strictly opt-in: it is applied
+	// only when the caller explicitly passes bare:true. All other launches (including
+	// headless utility operations) use the standard, non-bare code path.
 	let effectiveBare = bare ?? false
 	let effectiveSettings = settings
-	let bareModeAutoApplied = false
 	let oauthToken: string | undefined
-
-	// Auto-apply bare mode for headless utility operations when not explicitly set
-	if (bare === undefined && headless && noSessionPersistence && !skipBareMode) {
-		const config = await resolveBareModeConfig()
-		effectiveBare = config.bare
-		effectiveSettings ??= config.settings
-		oauthToken = config.oauthToken
-		bareModeAutoApplied = config.bare // track that WE decided to use bare
-	}
 
 	// When caller explicitly sets bare:true without settings, resolve OAuth settings too
 	if (bare === true && !effectiveSettings) {
 		const config = await resolveBareModeConfig()
 		effectiveSettings ??= config.settings
 		oauthToken = config.oauthToken
-		// bareModeAutoApplied stays false - caller explicitly requested bare
 	}
 
 	const isDebugMode = logger.isDebugEnabled()
@@ -403,70 +393,47 @@ export async function launchClaude(
 		return
 	}
 
-	// Handle headless mode with retry loop (max 2 attempts)
+	// Handle headless mode (bare mode, when requested, is applied via buildBaseArgs)
 	if (headless) {
-		const maxAttempts = bareModeAutoApplied ? 2 : 1
-		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-			const useBare = attempt === 1
-			const args = buildBaseArgs(useBare)
-			const env = buildEnv(useBare)
+		const args = buildBaseArgs(true)
+		const env = buildEnv(true)
 
-			try {
-				return await runHeadlessSubprocess(args, env)
-			} catch (error) {
-				if (signal?.aborted) return
+		try {
+			return await runHeadlessSubprocess(args, env)
+		} catch (error) {
+			if (signal?.aborted) return
 
-				const execaError = error as { stderr?: string; message?: string; exitCode?: number }
-				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
-				const rawErrorMessage = execaError.stderr || execaError.message || 'Unknown Claude CLI error'
-				const errorMessage = redactSettings(rawErrorMessage)
+			const execaError = error as { stderr?: string; message?: string; exitCode?: number }
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
+			const rawErrorMessage = execaError.stderr || execaError.message || 'Unknown Claude CLI error'
+			const errorMessage = redactSettings(rawErrorMessage)
 
-				// On first attempt with auto-applied bare mode, check for auth failure and retry
-				if (attempt === 1 && bareModeAutoApplied) {
-					const isAuthError = /not logged in|unauthorized|authentication|invalid api key|Could not resolve credentials/i.test(rawErrorMessage)
-					if (isAuthError) {
-						logger.warn('Bare mode failed (likely expired OAuth token), retrying without --bare')
-						continue // Retry without bare on next iteration
-					}
+			// Check for "Session ID ... is already in use" error and retry with --resume
+			const sessionInUseMatch = errorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
+			const extractedSessionId = sessionInUseMatch?.[1]
+			if (sessionInUseMatch && sessionId && extractedSessionId) {
+				log.debug(`Session ID ${extractedSessionId} already in use, retrying with --resume`)
+
+				// Build clean args with --resume instead of --session-id
+				const resumeArgs = args.filter((arg, idx) => {
+					if (arg === '--session-id') return false
+					if (idx > 0 && args[idx - 1] === '--session-id') return false
+					return true
+				})
+				resumeArgs.push('--resume', extractedSessionId)
+
+				try {
+					return await runHeadlessSubprocess(resumeArgs, env)
+				} catch (retryError) {
+					const retryExecaError = retryError as { stderr?: string; message?: string }
+					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
+					const retryErrorMessage = retryExecaError.stderr || retryExecaError.message || 'Unknown Claude CLI error'
+					throw new Error(`Claude CLI error: ${redactSettings(retryErrorMessage)}`)
 				}
-
-				// Check for "Session ID ... is already in use" error and retry with --resume
-				const sessionInUseMatch = errorMessage.match(/Session ID ([0-9a-f-]+) is already in use/i)
-				const extractedSessionId = sessionInUseMatch?.[1]
-				if (sessionInUseMatch && sessionId && extractedSessionId) {
-					log.debug(`Session ID ${extractedSessionId} already in use, retrying with --resume`)
-
-					// Build clean args with --resume instead of --session-id
-					const resumeArgs = args.filter((arg, idx) => {
-						if (arg === '--session-id') return false
-						if (idx > 0 && args[idx - 1] === '--session-id') return false
-						return true
-					})
-					resumeArgs.push('--resume', extractedSessionId)
-
-					try {
-						return await runHeadlessSubprocess(resumeArgs, env)
-					} catch (retryError) {
-						const retryExecaError = retryError as { stderr?: string; message?: string }
-						// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string stderr should fall through to message
-						const retryErrorMessage = retryExecaError.stderr || retryExecaError.message || 'Unknown Claude CLI error'
-
-						if (attempt === 1 && bareModeAutoApplied) {
-							const isAuthError = /not logged in|unauthorized|authentication|invalid api key|Could not resolve credentials/i.test(retryErrorMessage)
-							if (isAuthError) {
-								logger.warn('Bare mode failed during --resume retry (likely expired OAuth token), retrying without --bare')
-								continue
-							}
-						}
-
-						throw new Error(`Claude CLI error: ${redactSettings(retryErrorMessage)}`)
-					}
-				}
-
-				throw new Error(`Claude CLI error: ${errorMessage}`)
 			}
+
+			throw new Error(`Claude CLI error: ${errorMessage}`)
 		}
-		return
 	}
 
 	// Interactive mode: run Claude in current terminal with stdio inherit
@@ -710,7 +677,7 @@ export async function generateBranchName(
 	issueTitle: string,
 	issueNumber: string | number,
 	model: string = 'haiku',
-	skipBareMode?: boolean
+	bare?: boolean
 ): Promise<string> {
 	try {
 		// Check if Claude CLI is available
@@ -748,7 +715,7 @@ Generate a git branch name for the following issue:
 			noSessionPersistence: true, // Utility operation - don't persist session
 			systemPrompt: 'You are a git branch name generator. Given an issue title and number, generate a branch name following the exact format and constraints provided. Output only the branch name, nothing else. No preamble, analysis, or meta-commentary.',
 			effort: 'low', // Simple text generation, minimize turns
-			...(skipBareMode ? { skipBareMode } : {}),
+			...(bare ? { bare } : {}),
 		})) as string
 
 		// Normalize to lowercase for consistency (Linear IDs are uppercase but branches should be lowercase)

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -676,8 +676,7 @@ export function hasApiKeyForBareMode(): boolean {
 export async function generateBranchName(
 	issueTitle: string,
 	issueNumber: string | number,
-	model: string = 'haiku',
-	bare?: boolean
+	model: string = 'haiku'
 ): Promise<string> {
 	try {
 		// Check if Claude CLI is available
@@ -715,7 +714,6 @@ Generate a git branch name for the following issue:
 			noSessionPersistence: true, // Utility operation - don't persist session
 			systemPrompt: 'You are a git branch name generator. Given an issue title and number, generate a branch name following the exact format and constraints provided. Output only the branch name, nothing else. No preamble, analysis, or meta-commentary.',
 			effort: 'low', // Simple text generation, minimize turns
-			...(bare ? { bare } : {}),
 		})) as string
 
 		// Normalize to lowercase for consistency (Linear IDs are uppercase but branches should be lowercase)


### PR DESCRIPTION
## Summary

Follow-up to #1029. That PR was merged after only its first commit (docs fix + defaulting bare mode off via `skipBareMode: true`). This PR lands the remaining cleanup that finishes the job: **bare mode is now strictly opt-in** and the `skipBareMode` setting is gone entirely.

### What changed
- `launchClaude` applies `--bare` **only** when a caller explicitly passes `bare: true`. No more auto-apply for headless utility ops, so bare mode is off by default everywhere with no footgun where an un-threaded caller silently gets it.
- Removed the `skipBareMode` setting and all its plumbing (settings schema, `ValidationOptions`/`CommitOptions`/`MergeOptions`, `BranchNamingService`, `CommitManager`, `MergeManager`, `PRManager`, `ValidationRunner`, `SessionSummaryService`, `IssueEnhancementService`, and the `loom.created` `skip_bare_mode` telemetry property). It only existed to opt out of the auto-apply, which no longer happens.
- Removed the auth-error retry-without-bare loop (only applied to auto-applied bare); the session-in-use `--resume` retry is retained.
- The hidden `test-branch-name` / `test-commit-msg` diagnostics now exercise the **default non-bare path** that most users hit, instead of opting into bare.

### Verification
`pnpm build`, `pnpm compile`, `pnpm lint`, and the full test suite (148 files, 5236 passed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)